### PR TITLE
chore(ci): add commitlint configuration

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,59 @@
+// Commitlint Configuration
+// See: https://commitlint.js.org/
+
+// Extend conventional commit configuration
+export default {
+  extends: ['@commitlint/config-conventional'],
+
+  // Ignore Dependabot commits (they follow conventional commits but may have extra metadata)
+  ignores: [
+    (message) => /^chore\(deps\)|^chore\(ci\)/.test(message)
+  ],
+
+  // Custom rules
+  rules: {
+    // Type must be one of these
+    'type-enum': [
+      2,  // Level: error
+      'always',
+      [
+        'feat',      // New feature (minor version bump)
+        'fix',       // Bug fix (patch version bump)
+        'docs',      // Documentation only (no version bump)
+        'style',     // Code style/formatting (no version bump)
+        'refactor',  // Code refactoring (no version bump)
+        'perf',      // Performance improvement (patch version bump)
+        'test',      // Test changes (no version bump)
+        'chore',     // Maintenance tasks (no version bump)
+        'ci',        // CI/CD changes (no version bump)
+        'build',     // Build system changes (no version bump)
+        'revert',    // Revert previous commit
+        'security'   // Security fixes (patch version bump)
+      ]
+    ],
+
+    // Subject must not be empty
+    'subject-empty': [2, 'never'],
+
+    // Subject must not end with period
+    'subject-full-stop': [2, 'never', '.'],
+
+    // Subject must be lowercase
+    'subject-case': [2, 'always', 'lower-case'],
+
+    // Type must be lowercase
+    'type-case': [2, 'always', 'lower-case'],
+
+    // Scope must be lowercase
+    'scope-case': [2, 'always', 'lower-case'],
+
+    // Header maximum length
+    'header-max-length': [2, 'always', 100],
+
+    // Body maximum line length
+    'body-max-line-length': [2, 'always', 100],
+
+    // Footer maximum line length
+    'footer-max-line-length': [2, 'always', 100]
+  }
+};


### PR DESCRIPTION
## Summary

Adds `commitlint.config.js` for conventional commits validation with Dependabot support, aligning with quickstart and playbook repos.

## Configuration

```javascript
// Extends @commitlint/config-conventional
export default {
  extends: ['@commitlint/config-conventional'],
  
  // Ignore Dependabot commits
  ignores: [
    (message) => /^chore\(deps\)|^chore\(ci\)/.test(message)
  ],
  
  rules: {
    // Lowercase subjects, 100 char limits
    // All conventional commit types supported
  }
};
```

## Features

- ✅ Conventional Commits validation
- ✅ Dependabot commit bypass (chore(deps), chore(ci))
- ✅ Lowercase subject enforcement
- ✅ 100 character line limits (header, body, footer)
- ✅ All standard types: feat, fix, docs, style, refactor, perf, test, chore, ci, build, revert, security

## Rationale

**Ecosystem consistency:** Quickstart and playbook already use this config. Adding to patterns ensures:
- Uniform commit message standards across all 3 repos
- Dependabot PRs pass CI validation
- Better git history readability

## Testing

- Pre-commit hooks pass (gitleaks, ruff, trailing-whitespace, pattern validation)
- Config follows ES module format (Node.js 20 compatible)
- Tested in quickstart repo (PR #29)

## Related

- Quickstart: Already has this config (merged in PR #29)
- Playbook: PR being created in parallel
- Part of workspace consistency initiative (Session 10)

---

Co-authored-by: OpenCode Agent <agent@gsa.gov>