### PR TITLE
chore(lint): align ruff configuration with playbook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,26 @@ build-backend = "setuptools.build_meta"
 where = ["scripts"]
 
 [tool.ruff]
-line-length = 100
+line-length = 120
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B", "SIM"]
+select = [
+    "E",    # pycodestyle errors
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+    "S",    # flake8-bandit (security)
+]
+ignore = [
+    "S101",  # assert used in tests
+]
+
+[tool.ruff.lint.per-file-ignores]
+"scripts/tests/*" = ["S101", "S106", "S603", "S607"]
+"scripts/validate_repo.py" = ["S603", "S607"]
 
 [tool.pytest.ini_options]
 testpaths = ["scripts/tests"]


### PR DESCRIPTION
## Summary

Aligns ruff configuration in agentic-coding-patterns with agentic-coding-playbook standards per workspace STANDARDS_COMPARISON.md analysis.

## Changes

- **line-length:** 100 → 120 (better readability, matches playbook)
- **lint.select:** Added "S" (flake8-bandit security rules)
- **ignore:** Added S101 (assert used in tests) globally
- **per-file-ignores:** Added test file exceptions (S101, S106, S603, S607) and validate_repo.py (S603, S607)

## Verification

```bash
ruff check scripts/
# All checks passed!

make ci
# ✓ All checks passed
# 78/78 tests passed
```

## Benefits

1. **Consistency:** Both repos now enforce identical linting standards
2. **Readability:** 120-character lines reduce line wrapping on modern displays
3. **Security:** flake8-bandit catches common security issues:
   - Hardcoded passwords/secrets
   - Insecure function usage (exec, eval)
   - Weak cryptography
   - SQL injection patterns

## Testing

- [x] `ruff check scripts/` passes with no new violations
- [x] `make ci` passes (validators + pip-audit + 78 tests)
- [x] No breaking changes to existing workflows

## Context

- Issue: #47
- Reference: [playbook pyproject.toml](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/pyproject.toml)
- Related: STANDARDS_COMPARISON.md (workspace analysis)

---

**Conventional Commit:** `chore(lint)`
**AI Attribution:** Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>