### PR TITLE
chore(test): add coverage target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup validate generate generate-check test security ci clean search install-hooks help
+.PHONY: setup validate generate generate-check test coverage security ci clean search install-hooks help
 
 help:  ## Show this help message
 	@echo "agentic-coding-patterns — Available targets:"
@@ -61,6 +61,12 @@ test:  ## Run pytest test suite
 		echo "⚠️  No tests found in scripts/tests/"; \
 		echo "    Create tests to enable this check (see issue #16)"; \
 	fi
+
+coverage:  ## Run tests with coverage report
+	PYTHONPATH=scripts python3 -m pytest scripts/tests/ \
+		--cov=scripts \
+		--cov-report=html \
+		--cov-report=term
 
 ci:  ## Full CI check (validate + security + test + pre-commit checks)
 	@echo "==> Running pre-commit checks (duplicates pre-commit hooks)..."

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ make validate
 
 # Generate INDEX.yaml
 make generate
+
+# Run tests with coverage report
+make coverage
 ```
 
 **Note:** Pre-commit hooks are opt-in. Use `make install-hooks` to enable automatic checks on commit. CI enforces all checks regardless of local hook installation.


### PR DESCRIPTION
## Summary

Adds a `make coverage` target to run pytest with coverage reporting.

## Changes

- Added `coverage` target to Makefile that:
  - Runs pytest with `--cov=scripts`
  - Generates HTML report to `htmlcov/`
  - Shows terminal coverage summary
  - Uses `PYTHONPATH=scripts` like other test targets
- Updated README.md to include `make coverage` in the Quick Start section
- `.gitignore` already included `htmlcov/` and `.coverage`

## Testing

```bash
make coverage
```

✅ 78 tests passed with 67% overall coverage
✅ HTML report generated in `htmlcov/`
✅ Terminal summary displayed

## Related Issues

Resolves #53

## Checklist

- [x] `make validate` passes
- [x] `make coverage` runs successfully
- [x] HTML report generated
- [x] README.md updated
- [x] Conventional commit message
- [x] Co-authored-by trailer included