### PR TITLE
fix(docs): repair broken internal links

### DIFF
--- a/docs/content-lifecycle.md
+++ b/docs/content-lifecycle.md
@@ -141,10 +141,8 @@ deprecated_date: "2026-05-15"
 
 This pattern is deprecated as of 2026-05-15.
 
-**Reason:** Superseded by [secure-code-review-v2](../secure-code-review-v2/SKILL.md)
+**Reason:** Superseded by [secure-code-review](../skills/secure-code-review/SKILL.md)
 which includes updated OWASP Top 10 2023 guidance.
-
-**Migration:** See [migration guide](./MIGRATION.md) for upgrade steps.
 ```
 
 ## Community Feedback Mechanism

--- a/examples/claude-code/README.md
+++ b/examples/claude-code/README.md
@@ -269,4 +269,4 @@ When multiple patterns apply, follow this priority order:
 - [Claude for VS Code Documentation](https://www.anthropic.com/claude-code)
 - [AI Agent Integration Guide](../../docs/AI-AGENT-GUIDE.md)
 - [Pattern Library](../../)
-- [Coding Practices](../../docs/CODING_PRACTICES.md)
+- [Coding Practices](../../../agentic-coding-playbook/docs/CODING_PRACTICES.md)

--- a/examples/opencode/README.md
+++ b/examples/opencode/README.md
@@ -36,8 +36,8 @@ OpenCode automatically discovers skills in `.opencode/skills/`. You can also ref
 ```markdown
 ## Available Skills
 
-- [Secure Code Review](skills/secure-code-review.md)
-- [Documentation Review](skills/documentation-review.md)
+- [Secure Code Review](../../skills/secure-code-review/SKILL.md)
+- [Documentation Review](../../skills/documentation-review/SKILL.md)
 ```
 
 ## Pattern Adaptation

--- a/examples/opencode/secure-code-review-example.md
+++ b/examples/opencode/secure-code-review-example.md
@@ -57,7 +57,7 @@ Reference the skill in your agent instructions:
 
 ### Available Skills
 
-When performing code reviews, use the [Secure Code Review](skills/secure-code-review.md) skill to:
+When performing code reviews, use the [Secure Code Review](../../skills/secure-code-review/SKILL.md) skill to:
 - Check for OWASP Top 10 vulnerabilities
 - Validate input sanitization
 - Review authentication/authorization
@@ -124,9 +124,9 @@ Combine multiple skills in a workflow:
 
 ## Pull Request Review Workflow
 
-1. Use [Secure Code Review](skills/secure-code-review.md) for security
-2. Use [Test Generation](skills/test-generation.md) for coverage
-3. Use [Documentation Review](skills/documentation-review.md) for docs
+1. Use [Secure Code Review](../../skills/secure-code-review/SKILL.md) for security
+2. Use [Test Generation](../../skills/test-generation/SKILL.md) for coverage
+3. Use [Documentation Review](../../skills/documentation-review/SKILL.md) for docs
 
 Aggregate findings and produce summary report.
 ```


### PR DESCRIPTION
## Summary

This PR fixes high-priority broken links identified in issue #57.

## Changes Made

1. **docs/content-lifecycle.md**
   - Fixed broken reference from `secure-code-review-v2` to correct path `../skills/secure-code-review/SKILL.md`
   - Removed reference to non-existent `MIGRATION.md` file

2. **examples/claude-code/README.md**
   - Updated CODING_PRACTICES link from broken relative path to workspace-relative path pointing to playbook repo

3. **examples/opencode/** (6 links fixed)
   - Corrected all skill references to use repository-relative paths (`../../skills/<skill-name>/SKILL.md`)
   - Fixed in: `README.md` and `secure-code-review-example.md`

## Verification

- ✅ All target paths verified to exist
- ✅ secure-code-review/SKILL.md exists
- ✅ test-generation/SKILL.md exists
- ✅ documentation-review/SKILL.md exists
- ✅ agentic-coding-playbook/docs/CODING_PRACTICES.md exists in workspace

## Testing

All links now point to correct relative paths within the repository or workspace.

Fixes #57