### PR TITLE
chore: disable subject-case rule to allow acronyms

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -38,8 +38,10 @@ export default {
     // Subject must not end with period
     'subject-full-stop': [2, 'never', '.'],
 
-    // Subject must be lowercase
-    'subject-case': [2, 'always', 'lower-case'],
+    // Subject case: disabled to allow acronyms (CLI, API, SQL, GSA, NIST) in subjects
+    // The Conventional Commits spec only mandates lowercase for types, not subjects
+    // Strict enforcement causes false positives like "sbx CLI" being flagged
+    'subject-case': [0],
 
     // Type must be lowercase
     'type-case': [2, 'always', 'lower-case'],


### PR DESCRIPTION
## Summary

Syncs commitlint configuration across all agentic repos to allow acronyms in commit subjects.

## Change

Changed `subject-case` rule from `[2, 'always', 'lower-case']` to `[0]` (disabled).

## Rationale

The [Conventional Commits spec](https://www.conventionalcommits.org/) only requires lowercase for the **type prefix** (feat, fix, etc.), not the subject text itself.

Strict lowercase enforcement causes false positives for valid federal/tech commits like:
- `feat: add CLI support for sbx`
- `docs: implement NIST SP 800-53 mapping`
- `chore: update GSA branding assets`

## Cross-Repo Sync

| Repo | subject-case | Status |
|------|--------------|--------|
| **quickstart** | `[0]` (disabled) | ✅ Already updated |
| **playbook** | `[0]` (disabled) | ✅ Updated (PR #66) |
| **patterns** | `[0]` (disabled) | ← This PR |

Refs: GSA-TTS/agentic-coding-playbook#55

Co-authored-by: OpenCode Agent <agent@gsa.gov>