### PR TITLE
fix(docs): remove broken conversion-guide.md links

### DIFF
--- a/examples/claude-projects/README.md
+++ b/examples/claude-projects/README.md
@@ -16,7 +16,6 @@ Claude Projects allow custom instructions that guide Claude's behavior. Patterns
 ## Example Adaptations
 
 - [QA Round Review Instructions](./qa-round-instructions.txt)
-- [Conversion Guide](./conversion-guide.md)
 
 ## Format Differences
 

--- a/examples/cursor/README.md
+++ b/examples/cursor/README.md
@@ -16,7 +16,6 @@ python convert_to_cursorrules.py skills/secure-code-review/SKILL.md
 ## Example Conversions
 
 - [Documentation Review → .cursorrules](./documentation-review.cursorrules)
-- [Conversion Guide](./conversion-guide.md)
 
 ## Key Differences
 


### PR DESCRIPTION
## Summary

Removes broken links to `conversion-guide.md` files that don't exist.

## Changes

| File | Fix |
|------|-----|
| `examples/cursor/README.md` | Remove link to non-existent `conversion-guide.md` |
| `examples/claude-projects/README.md` | Remove link to non-existent `conversion-guide.md` |

## Context

Found during QA review. These conversion guides were planned but not yet created. Removing the broken links improves documentation quality.

## Future Work

Consider creating the conversion guides as a separate enhancement if there's demand.