### PR TITLE
chore(ci): enable strict link validation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     uses: GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-markdown-quality.yml@main
     with:
       run-link-check: true
-      continue-on-link-error: true
+      continue-on-link-error: false
 
   # Validation job (pattern-specific)
   validate:

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://raw.githubusercontent.com/tcort/markdown-link-check/master/config.schema.json",
+  "ignorePatterns": [
+    {
+      "pattern": "^#"
+    },
+    {
+      "pattern": "^mailto:"
+    },
+    {
+      "pattern": "example\\.com"
+    },
+    {
+      "pattern": "localhost"
+    },
+    {
+      "pattern": "127\\.0\\.0\\.1"
+    },
+    {
+      "pattern": "your-org"
+    },
+    {
+      "pattern": "your-repo"
+    },
+    {
+      "pattern": "\\{\\{.*\\}\\}"
+    },
+    {
+      "pattern": "<[^>]+>"
+    }
+  ],
+  "replacementPatterns": [],
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [200, 206, 301, 302, 307, 308]
+}


### PR DESCRIPTION
## Summary

Enables strict link validation in CI to catch broken documentation links before merge.

## Changes

1. **Added `.markdown-link-check.json`** - Configuration for markdown-link-check with ignore patterns:
   - Anchor links (`#`)
   - Mailto links
   - Example/localhost URLs
   - Template placeholders (`{{...}}`, `<...>`)

2. **Updated CI workflow** - Changed `continue-on-link-error` from `true` to `false`

## Benefits

- Catches broken links before merge
- Prevents documentation drift
- Reduces maintenance burden
- Improves contributor experience

## Testing

CI will run link check on this PR to verify configuration works correctly.

## Closes

Closes #58