### PR TITLE
chore(security): pin pre-commit hooks to commit SHAs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,14 +28,14 @@ repos:
 
   # Markdown linting
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.43.0
+    rev: 0d9fcb51a54f3b750b911c054b4bd1a590f1b592  # v0.43.0
     hooks:
       - id: markdownlint
         args: ["--fix"]
 
   # Commit message validation
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.18.0
+    rev: e5287c0c191ba3f845841baf7e5852b74ab81f8d  # v9.18.0
     hooks:
       - id: commitlint
         stages: [commit-msg]


### PR DESCRIPTION
## Summary

Converts tag-based pre-commit hook revisions to commit SHAs for supply chain security compliance.

## Security Issue

The configuration previously used tag-based revisions:
```yaml
rev: v0.43.0  # Tag - can be modified by repo owner
```

This violates **NIST SA-12 (Supply Chain Protection)** because tags can be force-pushed to point to different commits.

## Changes

| Hook | Before | After |
|------|--------|-------|
| markdownlint-cli | `v0.43.0` | `0d9fcb51a54f3b750b911c054b4bd1a590f1b592` |
| commitlint-pre-commit-hook | `v9.18.0` | `e5287c0c191ba3f845841baf7e5852b74ab81f8d` |

## Compliance

- **NIST SA-12:** Supply Chain Protection
- **NIST SR-3:** Supply Chain Controls

## Related

Contributes to playbook #61 (standardize pre-commit config across repos)