### PR TITLE
chore: standardize markdown linter to markdownlint-cli2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ htmlcov/
 
 # OS
 Thumbs.db
+deleteme/

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,65 @@
+# markdownlint-cli2 configuration
+# Aligned with playbook standards for cross-repo consistency
+# See: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+config:
+  # MD003 - Heading style (disabled — mixed styles OK)
+  MD003: false
+  # MD007 - Unordered list indent (allow 2-space, frontmatter false positives)
+  MD007: false
+  # MD004 - Unordered list style (disabled — mixed markers OK)
+  MD004: false
+  # MD013 - Line length (disabled — long lines OK in docs)
+  MD013: false
+  # MD022 - Headings should be surrounded by blank lines
+  MD022: false
+  # MD024 - No duplicate heading names (disabled — repeated names OK)
+  MD024: false
+  # MD025 - Single top-level heading (disabled — multiple H1 OK for SKILL.md)
+  MD025: false
+  # MD026 - No trailing punctuation in headings
+  MD026: false
+  # MD031 - Fenced code blocks surrounded by blank lines
+  MD031: false
+  # MD032 - Lists surrounded by blank lines
+  MD032: false
+  # MD033 - No inline HTML (disabled — HTML allowed)
+  MD033: false
+  # MD034 - No bare URLs
+  MD034: false
+  # MD036 - No emphasis used instead of heading (disabled — used intentionally for OWASP categories)
+  MD036: false
+  # MD040 - Fenced code blocks should have language
+  MD040: false
+  # MD041 - First line in file should be H1 (disabled — files have frontmatter)
+  MD041: false
+  # MD051 - Link fragments should be valid
+  MD051: false
+  # MD056 - Table column count
+  MD056: false
+  # MD058 - Tables should be surrounded by blank lines
+  MD058: false
+  # MD060 - Table column style spacing (disabled — manual formatting OK)
+  MD060: false
+
+# Scan these files
+globs:
+  - "AGENTS.md"
+  - "CONTEXT-GUIDE.md"
+  - "CONTRIBUTING.md"
+  - "README.md"
+  - "docs/**/*.md"
+  - "skills/*/SKILL.md"
+  - "prompts/*/SKILL.md"
+  - "agents/*/AGENTS.md"
+  - "workflows/*/SKILL.md"
+  - "lessons-learned/*/SKILL.md"
+
+# Ignore files
+ignores:
+  - "node_modules"
+  - "deleteme"
+  - "**/fixtures/**"
+
+# Support YAML frontmatter
+frontMatter: "/^---\\s*$[\\s\\S]*?^---\\s*$/m"

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,9 +1,0 @@
-# Markdownlint configuration
-# Disable rules that conflict with existing content style
-MD013: false  # Line length - existing content has long lines
-MD040: false  # Fenced code language - some examples don't specify language
-MD025: false  # Multiple top-level headings - SKILL.md files have multiple h1 (title + skill name)
-MD036: false  # Emphasis as heading - Used intentionally in some documents (e.g., OWASP categories)
-MD060: false  # Table column style - Manual table formatting variations acceptable
-MD024: false  # Duplicate headings - Used intentionally in long documents (e.g., multiple "See Also" sections)
-MD041: false  # First line heading - Fixture files may start with frontmatter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
       - id: check-toml
       - id: check-added-large-files
         args: ['--maxkb=500']
+      - id: check-merge-conflict
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: ee6b38352380ce52369d16b7873093c4b8bf829b  # v8.24.3
@@ -26,11 +27,11 @@ repos:
         args: ["--fix"]
       - id: ruff-format
 
-  # Markdown linting
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: 0d9fcb51a54f3b750b911c054b4bd1a590f1b592  # v0.43.0
+  # Markdown linting (using markdownlint-cli2 for consistency with playbook)
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: d174eb7a8f35e05d4065c82d375ad84aa0b32352  # v0.17.2
     hooks:
-      - id: markdownlint
+      - id: markdownlint-cli2
         args: ["--fix"]
 
   # Commit message validation


### PR DESCRIPTION
## Summary

Standardizes markdown linting to use `markdownlint-cli2` for consistency with playbook and quickstart repos per playbook #61.

## Changes

### Hook Changes
| Before | After |
|--------|-------|
| `markdownlint-cli` (tag: v0.43.0) | `markdownlint-cli2` (SHA: d174eb7a8f35) |

### Files
| Change | File |
|--------|------|
| Added | `.markdownlint-cli2.yaml` - config aligned with playbook |
| Removed | `.markdownlint.yaml` - superseded by cli2 config |
| Modified | `.pre-commit-config.yaml` - updated hook |

### Additional Improvements
- Add `check-merge-conflict` hook (safety feature, already in playbook)
- Pin `markdownlint-cli2` to commit SHA per NIST SA-12

## Why markdownlint-cli2?

- `markdownlint-cli2` is the successor to `markdownlint-cli`
- Playbook already uses `markdownlint-cli2`
- Same config format can be shared across repos
- Active maintenance and better YAML config support

## Cross-Repo Consistency (After)

| Hook | Playbook | Quickstart | Patterns |
|------|:--------:|:----------:|:--------:|
| markdownlint-cli2 | ✅ | ✅ | ✅ |
| check-merge-conflict | ✅ | ✅ | ✅ |

## Related

- Addresses playbook #61 (standardize pre-commit config)
- Depends on PR #74 (SHA pinning) being merged first