### PR TITLE
feat(skills): add USWDS-first federal frontend skills pack

### DIFF
--- a/.agents/skills/frontend/README.md
+++ b/.agents/skills/frontend/README.md
@@ -1,0 +1,78 @@
+# Federal Front-End Skills
+
+Skills for generating, reviewing, and improving federal digital service front ends.
+
+> **Status:** Experimental | **License:** CC0-1.0
+
+## Overview
+
+These skills help AI coding agents produce USWDS-aligned, accessible, plain-language front-end artifacts for federal digital services.
+
+**Key principle:** These skills produce **drafts and review aids**, not final compliance determinations. Human review is always required before deployment.
+
+## When to Use
+
+| Skill | Use When |
+|-------|----------|
+| [uswds-prototype](uswds-prototype/SKILL.md) | Generating new USWDS-aligned pages or components |
+| [accessibility-review](accessibility-review/SKILL.md) | Reviewing artifacts for Section 508 accessibility |
+| [plain-language-review](plain-language-review/SKILL.md) | Improving federal content for clarity |
+| [uswds-form-flow](uswds-form-flow/SKILL.md) | Creating accessible government forms |
+| [uswds-landing-page](uswds-landing-page/SKILL.md) | Building service landing pages |
+| [federal-service-blueprint](federal-service-blueprint/SKILL.md) | Planning before code generation |
+
+## Design Principles
+
+1. **USWDS-first** — Use U.S. Web Design System components, patterns, and design tokens
+2. **Accessible by default** — Meet Section 508 and WCAG 2.1 AA requirements
+3. **Plain language** — Follow federal plain language guidelines
+4. **Semantic HTML** — Use proper HTML elements before adding framework-specific code
+5. **No external CDNs** — Avoid external dependencies unless explicitly requested
+6. **Human review required** — Agents produce drafts, humans approve for deployment
+
+## What These Skills Do NOT Provide
+
+- Final Section 508 compliance certification
+- Legal determinations about accessibility
+- Automatic PRA (Paperwork Reduction Act) compliance
+- Privacy impact assessments
+- Authority to Operate (ATO) artifacts
+- Agency-specific branding decisions
+
+## Output Expectations
+
+All frontend skills produce artifacts that:
+
+- Use semantic HTML elements (`<main>`, `<nav>`, `<article>`, etc.)
+- Reference USWDS class names and design tokens
+- Include accessible heading hierarchy (h1 → h2 → h3)
+- Provide keyboard navigation support
+- Include visible focus indicators
+- Define form labels and error messages
+- Avoid inline styles where possible
+- Include comments for human decision points
+
+## Contributing New Skills
+
+To add a new frontend skill:
+
+1. Create a folder under `.agents/skills/frontend/your-skill-name/`
+2. Add a `SKILL.md` following the [skill template](../../../templates/skill-template/SKILL.md)
+3. Ensure frontmatter validates against `schemas/skill.schema.json`
+4. Set `status: experimental` for new skills
+5. Include `prohibited_content` in the output contract
+6. Add verification checklist and human review gate
+7. Run `make validate` before submitting
+
+## References
+
+- [U.S. Web Design System](https://designsystem.digital.gov/)
+- [Section508.gov](https://www.section508.gov/)
+- [PlainLanguage.gov](https://www.plainlanguage.gov/)
+- [18F Content Guide](https://content-guide.18f.gov/)
+- [WCAG 2.1 Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/)
+
+## Related Patterns
+
+- [secure-code-review](../secure-code-review/SKILL.md) — For security-focused review
+- [documentation-review](../documentation-review/SKILL.md) — For documentation quality

--- a/.agents/skills/frontend/accessibility-review/SKILL.md
+++ b/.agents/skills/frontend/accessibility-review/SKILL.md
@@ -1,0 +1,307 @@
+---
+id: accessibility-review
+version: "1.0.0"
+title: "Federal Accessibility Review"
+type: skill
+description: "Review front-end artifacts for Section 508 and WCAG 2.1 AA compliance with specific checks for federal digital services"
+
+status: experimental
+owners:
+  - "@community"
+
+primary_personas:
+  - developers
+  - designers
+  - qa-testers
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Accessibility Issues Found"
+      - "Priority Recommendations"
+      - "Human Review Required"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "Absolute compliance certifications"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "review accessibility"
+  - "check 508"
+  - "wcag"
+  - "a11y"
+  - "accessibility audit"
+
+tags:
+  - "frontend"
+  - "accessibility"
+  - "section508"
+  - "wcag"
+  - "review"
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Review HTML pages for accessibility issues"
+    - "Identify Section 508 compliance gaps"
+    - "Check WCAG 2.1 AA conformance"
+    - "Provide actionable accessibility recommendations"
+  exclusions:
+    - "Not a replacement for manual accessibility testing"
+    - "Not a legal certification of compliance"
+    - "Does not replace screen reader testing"
+    - "Does not assess cognitive accessibility fully"
+---
+
+# Skill: Federal Accessibility Review
+
+Review front-end artifacts (HTML, CSS, or rendered pages) for Section 508 and WCAG 2.1 AA compliance. Identifies common accessibility issues and provides prioritized recommendations for federal digital services.
+
+## When to Use
+
+- Reviewing a page or component before deployment
+- Conducting accessibility audits on existing pages
+- Validating that a prototype meets federal accessibility standards
+- User asks "check accessibility" or "is this 508 compliant?"
+- Before submitting for formal accessibility testing
+
+## Prerequisites
+
+- HTML source code or rendered page to review
+- Understanding of the page's purpose and target audience
+- Access to referenced CSS or JavaScript (if applicable)
+
+## Procedure
+
+### Step 1: Gather Review Targets
+
+Identify what needs review:
+
+- [ ] HTML source code
+- [ ] Rendered page (screenshot or live URL)
+- [ ] CSS styles affecting visibility or contrast
+- [ ] JavaScript interactions
+
+### Step 2: Run Automated Checks
+
+Check for common issues that can be detected automatically:
+
+#### Heading Hierarchy
+
+- [ ] Single `<h1>` element exists
+- [ ] Headings follow logical order (h1 → h2 → h3, no skips)
+- [ ] Headings describe section content
+
+#### Keyboard Navigation
+
+- [ ] All interactive elements are keyboard accessible
+- [ ] Tab order is logical
+- [ ] Focus indicators are visible
+- [ ] No keyboard traps exist
+
+#### Form Accessibility
+
+- [ ] All form inputs have associated `<label>` elements
+- [ ] Labels use `for` attribute or wrap inputs
+- [ ] Required fields are marked (not just with `*`)
+- [ ] Error messages are associated with inputs (`aria-describedby`)
+- [ ] Fieldsets group related inputs with `<legend>`
+
+#### Images and Media
+
+- [ ] All `<img>` elements have `alt` attributes
+- [ ] Decorative images use `alt=""`
+- [ ] Complex images have extended descriptions
+- [ ] No information conveyed by image alone
+
+#### Semantic HTML
+
+- [ ] Proper landmark elements used (`<main>`, `<nav>`, `<header>`, `<footer>`)
+- [ ] Lists use `<ul>`, `<ol>`, or `<dl>` (not styled `<div>`)
+- [ ] Tables use `<th>` with `scope` attribute
+- [ ] Buttons are `<button>` elements (not styled `<div>` or `<a>`)
+
+#### Links
+
+- [ ] Link text is descriptive (no "click here")
+- [ ] Links to external sites or documents are indicated
+- [ ] Links have `:focus` styles
+- [ ] `target="_blank"` includes warning text
+
+#### Color and Contrast
+
+- [ ] Text color contrast meets WCAG AA (4.5:1 for normal text, 3:1 for large)
+- [ ] Information is not conveyed by color alone
+- [ ] Focus indicators have 3:1 contrast with background
+
+#### ARIA Usage
+
+- [ ] ARIA attributes are used correctly (or not at all)
+- [ ] `role` attributes supplement, not replace, semantic HTML
+- [ ] `aria-label` or `aria-labelledby` provide accessible names
+- [ ] Dynamic content updates use `aria-live` regions
+
+### Step 3: Categorize Issues by Priority
+
+Organize findings:
+
+| Priority | Definition | Examples |
+|----------|------------|----------|
+| **Critical** | Blocks access for users with disabilities | No alt text, keyboard traps, missing form labels |
+| **High** | Significantly impairs usability | Poor contrast, illogical heading order, missing focus |
+| **Medium** | Reduces usability but workarounds exist | Non-descriptive links, missing landmark roles |
+| **Low** | Best practice violations | Minor ARIA misuse, redundant labels |
+
+### Step 4: Provide Specific Recommendations
+
+For each issue, provide:
+
+1. **What's wrong** — Brief description
+2. **Why it matters** — Impact on users
+3. **How to fix** — Specific code change
+
+Example:
+
+```markdown
+**Issue:** Form input missing label
+**Impact:** Screen reader users cannot identify the field's purpose
+**Fix:** Add `<label for="email">Email Address</label>` before input
+```
+
+### Step 5: Flag Manual Testing Needs
+
+Identify areas requiring human review:
+
+- [ ] Screen reader testing with JAWS/NVDA/VoiceOver
+- [ ] Keyboard-only navigation testing
+- [ ] Color contrast verification with tools
+- [ ] Testing with magnification (200% zoom)
+- [ ] Cognitive accessibility assessment
+
+### Step 6: Generate Report
+
+Produce:
+
+1. **Accessibility Issues Found** — Categorized list of issues
+2. **Priority Recommendations** — Top 3-5 fixes to address first
+3. **Human Review Required** — Tests that require manual validation
+
+## Verification
+
+After review, confirm:
+
+- [ ] All automated checks completed
+- [ ] Issues are prioritized by impact
+- [ ] Recommendations are specific and actionable
+- [ ] Manual testing requirements are identified
+- [ ] No false positives (e.g., SVG backgrounds marked as missing alt text)
+
+## Examples
+
+### Example 1: Form Without Labels
+
+**Input HTML:**
+
+```html
+<form>
+  <input type="text" id="username" placeholder="Username">
+  <input type="password" id="password" placeholder="Password">
+  <button type="submit">Login</button>
+</form>
+```
+
+**Accessibility Issues Found:**
+
+| Issue | Priority | Description |
+|-------|----------|-------------|
+| Missing form labels | **Critical** | Inputs rely on placeholder text, which is not read by all screen readers |
+| No error handling | **High** | No mechanism to announce validation errors |
+
+**Priority Recommendations:**
+
+1. Add `<label>` elements for each input:
+   ```html
+   <label for="username">Username</label>
+   <input type="text" id="username">
+   ```
+2. Use `aria-describedby` for error messages
+3. Ensure error messages are announced to screen readers
+
+**Human Review Required:**
+- Test with screen reader to confirm labels are announced
+- Verify form validation errors are accessible
+
+### Example 2: Poor Color Contrast
+
+**Input:** Blue text `#4A90E2` on white background `#FFFFFF`
+
+**Accessibility Issues Found:**
+
+| Issue | Priority | Description |
+|-------|----------|-------------|
+| Insufficient contrast | **High** | Text color has 3.2:1 contrast ratio, below WCAG AA requirement (4.5:1) |
+
+**Priority Recommendations:**
+
+1. Darken blue to `#0052A3` for 4.5:1 contrast
+2. Or increase font size to 18pt+ for 3:1 requirement
+3. Use USWDS color tokens for pre-tested contrast
+
+**Human Review Required:**
+- Verify contrast in different lighting conditions
+- Test with users who have low vision
+
+## Anti-Patterns to Avoid
+
+| Don't | Do Instead |
+|-------|------------|
+| Assume automated tools find all issues | Require manual testing with assistive tech |
+| Use placeholders as labels | Use explicit `<label>` elements |
+| Hide content with `display: none` for screen readers | Use `aria-hidden="true"` or visually-hidden class |
+| Add `role="button"` to `<div>` | Use semantic `<button>` element |
+| Rely on color alone for status | Use icons + text + color |
+| Claim "this is 508 compliant" | Say "draft reviewed for common issues" |
+
+## Human Review Gate
+
+**Before relying on this review:**
+
+A human MUST:
+
+1. Test with actual screen readers (JAWS, NVDA, VoiceOver)
+2. Navigate the page with keyboard only
+3. Verify color contrast with tools (WebAIM Contrast Checker)
+4. Test at 200% zoom
+5. Involve users with disabilities in testing
+
+**This skill identifies common issues; it does not certify compliance.**
+
+## Related Patterns
+
+- [uswds-prototype](../uswds-prototype/SKILL.md) — Generate accessible pages from the start
+- [plain-language-review](../plain-language-review/SKILL.md) — Improve content clarity (cognitive accessibility)
+- [uswds-form-flow](../uswds-form-flow/SKILL.md) — Build accessible forms
+
+## References
+
+- [Section 508 Standards](https://www.section508.gov/)
+- [WCAG 2.1 Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/)
+- [WebAIM WCAG 2 Checklist](https://webaim.org/standards/wcag/checklist)
+- [USWDS Accessibility Tests](https://designsystem.digital.gov/documentation/accessibility/)
+- [GSA Government-wide Section 508 Assessment](https://www.section508.gov/manage/annual-assessment/)

--- a/.agents/skills/frontend/federal-service-blueprint/SKILL.md
+++ b/.agents/skills/frontend/federal-service-blueprint/SKILL.md
@@ -1,0 +1,361 @@
+---
+id: federal-service-blueprint
+version: "1.0.0"
+title: "Federal Service Blueprint"
+type: skill
+description: "Plan federal digital service user flows, touchpoints, and requirements before generating code"
+
+status: experimental
+owners:
+  - "@community"
+
+primary_personas:
+  - developers
+  - designers
+  - product-managers
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Service Overview"
+      - "User Journey"
+      - "Technical Requirements"
+      - "Compliance Considerations"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "plan service"
+  - "blueprint"
+  - "service design"
+  - "user journey"
+
+tags:
+  - "frontend"
+  - "planning"
+  - "service-design"
+  - "documentation"
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Plan federal digital services before coding"
+    - "Map user journeys and touchpoints"
+    - "Identify technical and compliance requirements"
+    - "Create implementation roadmap"
+  exclusions:
+    - "Not a replacement for full service design process"
+    - "Does not replace stakeholder research"
+    - "Not for detailed technical architecture"
+---
+
+# Skill: Federal Service Blueprint
+
+Plan a federal digital service by mapping user journeys, identifying touchpoints, and documenting technical and compliance requirements before generating code.
+
+## When to Use
+
+- Starting a new federal digital service from scratch
+- Planning a major redesign or feature addition
+- User asks "plan a service" or "what do I need to build?"
+- Before using other frontend skills (uswds-prototype, form-flow, etc.)
+
+## Prerequisites
+
+- Basic understanding of the service purpose
+- Knowledge of target user groups
+- Awareness of any regulatory or compliance requirements
+
+## Procedure
+
+### Step 1: Define Service Overview
+
+Document the basics:
+
+- [ ] **Service name** — What is this service called?
+- [ ] **Purpose** — What problem does it solve?
+- [ ] **Target users** — Who will use this service?
+- [ ] **Primary goal** — What should users accomplish?
+- [ ] **Success metrics** — How will we measure success?
+
+### Step 2: Map User Journey
+
+Identify the steps users take:
+
+1. **Awareness** — How do users learn about the service?
+2. **Entry** — Where do users start?
+3. **Authentication** (if needed) — How do users prove identity?
+4. **Core flow** — What steps do users take?
+5. **Decision points** — Where do users make choices?
+6. **Exit** — What happens when users complete the task?
+7. **Follow-up** — What happens after completion?
+
+Example:
+
+```markdown
+## User Journey: Benefits Application
+
+1. **Awareness**: User learns about benefits from agency website
+2. **Entry**: User clicks "Apply for Benefits" button
+3. **Eligibility check**: User answers screening questions
+4. **Account creation**: User creates account or signs in
+5. **Application form**: User completes multi-step form
+6. **Document upload**: User uploads supporting documents
+7. **Review**: User reviews and confirms application
+8. **Submission**: User submits application
+9. **Confirmation**: User receives confirmation number and email
+10. **Follow-up**: User checks status online or receives decision by mail
+```
+
+### Step 3: Identify Touchpoints
+
+List all pages, screens, or interactions:
+
+| Touchpoint | Type | Purpose | Priority |
+|------------|------|---------|----------|
+| Landing page | Informational | Explain service | High |
+| Eligibility screener | Interactive | Determine eligibility | High |
+| Sign-in page | Authentication | Verify identity | High |
+| Application form (Step 1) | Transactional | Collect personal info | High |
+| Application form (Step 2) | Transactional | Collect program info | High |
+| Document upload | Transactional | Collect evidence | Medium |
+| Review page | Transactional | Confirm before submit | High |
+| Confirmation page | Informational | Acknowledge receipt | High |
+| Status tracker | Informational | Show progress | Medium |
+
+### Step 4: Define Technical Requirements
+
+Document what's needed:
+
+#### Content Requirements
+
+- [ ] Page titles and headings
+- [ ] Body content and instructions
+- [ ] Form field labels
+- [ ] Error messages
+- [ ] Help text and tooltips
+- [ ] Confirmation messages
+
+#### Functional Requirements
+
+- [ ] Form validation rules
+- [ ] Data storage/submission
+- [ ] File upload (types, size limits)
+- [ ] Authentication method (Login.gov, etc.)
+- [ ] Email notifications
+- [ ] PDF generation (for records)
+
+#### Accessibility Requirements
+
+- [ ] Section 508 compliance required
+- [ ] WCAG 2.1 AA conformance
+- [ ] Screen reader compatibility
+- [ ] Keyboard navigation
+- [ ] Mobile responsive design
+
+#### Design Requirements
+
+- [ ] Use USWDS 3.x components
+- [ ] Agency-specific branding guidelines
+- [ ] Color contrast requirements
+- [ ] Logo and header requirements
+
+### Step 5: Document Compliance Considerations
+
+Identify regulatory requirements:
+
+#### Privacy and Security
+
+- [ ] Privacy Act Statement required?
+- [ ] System of Records Notice (SORN) exists?
+- [ ] Privacy Impact Assessment (PIA) completed?
+- [ ] Data encryption required (at rest and in transit)
+- [ ] ATO status and requirements
+
+#### Paperwork Reduction Act (PRA)
+
+- [ ] Collecting information from 10+ people?
+- [ ] OMB control number assigned?
+- [ ] Burden estimate calculated?
+- [ ] PRA notice language required on form
+
+#### Plain Language
+
+- [ ] Content reviewed for plain language?
+- [ ] Reading level target (typically 8th grade)
+- [ ] 18F Content Guide followed?
+
+#### Accessibility
+
+- [ ] Section 508 testing plan
+- [ ] Accessibility statement page
+- [ ] Alternative access method (phone, mail, in-person)
+
+### Step 6: Create Implementation Plan
+
+Break work into phases:
+
+**Phase 1: Foundation**
+- [ ] Landing page (informational)
+- [ ] Basic page structure and navigation
+
+**Phase 2: Core Flow**
+- [ ] Authentication integration
+- [ ] Multi-step form
+- [ ] Form validation
+
+**Phase 3: Supporting Features**
+- [ ] Document upload
+- [ ] Status tracking
+- [ ] Email notifications
+
+**Phase 4: Refinement**
+- [ ] User testing and iteration
+- [ ] Accessibility testing
+- [ ] Plain language review
+- [ ] Performance optimization
+
+### Step 7: Generate Blueprint Document
+
+Produce a complete planning document with:
+
+1. **Service Overview** — Name, purpose, users, goals
+2. **User Journey** — Step-by-step flow
+3. **Touchpoints** — List of pages/screens
+4. **Technical Requirements** — Content, functional, accessibility, design
+5. **Compliance Considerations** — Privacy, PRA, accessibility
+6. **Implementation Plan** — Phased approach
+
+## Verification
+
+After creating the blueprint, confirm:
+
+- [ ] User journey is complete (awareness → follow-up)
+- [ ] All touchpoints are identified
+- [ ] Technical requirements are specific
+- [ ] Compliance needs are documented
+- [ ] Implementation plan is realistic
+- [ ] Human review is planned
+
+## Examples
+
+### Example 1: Simple Informational Service
+
+**Service:** Agency resource library
+
+**User Journey:**
+1. User searches for topic
+2. User browses results
+3. User reads resource
+4. User downloads PDF (optional)
+
+**Touchpoints:**
+- Home page with search
+- Search results page
+- Resource detail page
+- Download confirmation
+
+**Technical Requirements:**
+- Search functionality
+- Content management system
+- PDF generation
+- USWDS card components
+
+**Compliance:**
+- Section 508 (accessible PDFs)
+- No PII collected
+- No authentication required
+
+### Example 2: Transactional Service
+
+**Service:** Grant application portal
+
+**User Journey:**
+1. User learns about grant opportunity
+2. User checks eligibility
+3. User creates account (Login.gov)
+4. User completes application (multi-step)
+5. User uploads supporting documents
+6. User submits application
+7. User receives confirmation
+8. User checks status periodically
+
+**Touchpoints:**
+- Landing page
+- Eligibility screener
+- Login.gov integration
+- Application form (5 steps)
+- Document upload page
+- Review and submit page
+- Confirmation page
+- Status dashboard
+
+**Technical Requirements:**
+- Login.gov integration
+- Multi-step form with save/resume
+- File upload (PDF, up to 10MB)
+- Email notifications
+- Backend API for submission
+- Data encryption (at rest and in transit)
+
+**Compliance:**
+- PRA clearance (OMB control number)
+- Privacy Act Statement
+- Section 508 testing
+- SORN reference
+- ATO at Moderate impact level
+
+## Anti-Patterns to Avoid
+
+| Don't | Do Instead |
+|-------|------------|
+| Start coding without planning | Create blueprint first |
+| Assume you know all requirements | Document and validate assumptions |
+| Skip compliance research | Identify PRA, privacy, accessibility needs early |
+| Plan everything in one phase | Break into incremental phases |
+| Forget about error states | Plan for errors, edge cases, and help |
+
+## Human Review Gate
+
+**Before implementation:**
+
+A human MUST:
+
+1. Validate user journey with actual users or stakeholders
+2. Confirm compliance requirements with legal/privacy teams
+3. Verify technical feasibility with engineers
+4. Approve phasing and timeline
+5. Review content for accuracy and tone
+
+**This skill produces planning artifacts, not deployment-ready designs.**
+
+## Related Patterns
+
+- [uswds-prototype](../uswds-prototype/SKILL.md) — Generate pages after planning
+- [uswds-form-flow](../uswds-form-flow/SKILL.md) — Build forms identified in blueprint
+- [accessibility-review](../accessibility-review/SKILL.md) — Validate accessibility after build
+
+## References
+
+- [Digital.gov Service Design](https://digital.gov/topics/customer-experience/)
+- [18F Methods](https://methods.18f.gov/)
+- [USWDS Design Principles](https://designsystem.digital.gov/design-principles/)
+- [U.S. Digital Service Playbook](https://playbook.cio.gov/)
+- [OMB Circular A-11](https://www.whitehouse.gov/omb/information-for-agencies/circulars/) (PRA guidance)

--- a/.agents/skills/frontend/plain-language-review/SKILL.md
+++ b/.agents/skills/frontend/plain-language-review/SKILL.md
@@ -1,0 +1,314 @@
+---
+id: plain-language-review
+version: "1.0.0"
+title: "Federal Plain Language Review"
+type: skill
+description: "Review content for federal plain language compliance following PlainLanguage.gov guidelines"
+
+status: experimental
+owners:
+  - "@community"
+
+primary_personas:
+  - developers
+  - content-designers
+  - technical-writers
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Issues Found"
+      - "Recommended Edits"
+      - "Plain Language Score"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "Absolute compliance certifications"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "plain language"
+  - "simplify"
+  - "readability"
+  - "review content"
+  - "improve clarity"
+
+tags:
+  - "frontend"
+  - "content"
+  - "plain-language"
+  - "documentation"
+  - "usability"
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Review user-facing content for clarity"
+    - "Identify jargon and complex language"
+    - "Suggest plain language alternatives"
+    - "Improve readability for federal digital services"
+  exclusions:
+    - "Not for legal or regulatory text requiring specific wording"
+    - "Does not replace professional content design"
+    - "Not a replacement for user research"
+    - "Does not validate technical accuracy"
+---
+
+# Skill: Federal Plain Language Review
+
+Review content for compliance with federal plain language guidelines. Identifies complex language, jargon, and readability issues. Provides specific recommendations to improve clarity for general audiences.
+
+## When to Use
+
+- Reviewing page content before publication
+- Simplifying technical documentation for public audiences
+- Improving readability of instructions or forms
+- User asks "make this clearer" or "simplify this text"
+- Before user testing with non-expert audiences
+
+## Prerequisites
+
+- Text content to review (HTML, Markdown, or plain text)
+- Understanding of the target audience
+- Context about required technical terms or legal language
+
+## Procedure
+
+### Step 1: Identify Target Audience
+
+Clarify who will read this content:
+
+- [ ] General public (8th grade reading level)
+- [ ] Subject matter experts (higher technical vocabulary acceptable)
+- [ ] Specific demographic (age, language proficiency)
+
+### Step 2: Run Readability Analysis
+
+Check readability metrics:
+
+- **Flesch-Kincaid Grade Level** — Target: 8th grade or below for general public
+- **Sentence length** — Target: 15-20 words average
+- **Paragraph length** — Target: 3-5 sentences
+- **Passive voice frequency** — Target: <10% of sentences
+
+### Step 3: Check for Common Issues
+
+Scan for plain language violations:
+
+#### Jargon and Complex Terms
+
+- [ ] Government acronyms without definitions
+- [ ] Technical terms without explanations
+- [ ] Legal language that could be simplified
+- [ ] Industry-specific terminology
+
+#### Sentence Structure
+
+- [ ] Long sentences (>25 words)
+- [ ] Passive voice ("The form must be submitted" → "Submit the form")
+- [ ] Buried verbs ("make a determination" → "determine")
+- [ ] Double negatives ("not ineligible" → "eligible")
+
+#### Word Choice
+
+- [ ] Formal words ("utilize" → "use")
+- [ ] Redundant phrases ("in order to" → "to")
+- [ ] Vague language ("various", "several", "a number of")
+- [ ] Hidden verbs ("conduct an investigation" → "investigate")
+
+#### Organization
+
+- [ ] Logical flow (most important information first)
+- [ ] Clear headings that describe section content
+- [ ] Bulleted or numbered lists for related items
+- [ ] Short paragraphs with one main idea each
+
+### Step 4: Provide Specific Edits
+
+For each issue, provide:
+
+1. **Original text** — Problematic passage
+2. **Issue** — Why it's hard to understand
+3. **Suggested edit** — Plain language alternative
+
+Example:
+
+```markdown
+**Original:** "Utilization of this application necessitates the provision of documentation."
+**Issue:** Formal words, buried verbs, passive voice
+**Suggested:** "To use this application, provide documentation."
+```
+
+### Step 5: Calculate Plain Language Score
+
+Assign a simple score based on compliance:
+
+| Score | Meaning | Characteristics |
+|-------|---------|-----------------|
+| **Excellent (90-100)** | Fully compliant | Grade 8 or below, minimal jargon, clear structure |
+| **Good (75-89)** | Mostly compliant | Grade 9-10, some jargon with definitions |
+| **Needs Improvement (60-74)** | Partially compliant | Grade 11-12, frequent jargon or passive voice |
+| **Poor (<60)** | Not compliant | Above grade 12, heavy jargon, complex structure |
+
+### Step 6: Prioritize Recommendations
+
+Organize edits by impact:
+
+1. **Critical** — Blocks understanding for general audiences
+2. **High** — Significantly reduces clarity
+3. **Medium** — Improves readability
+4. **Low** — Minor stylistic improvements
+
+### Step 7: Generate Report
+
+Produce:
+
+1. **Issues Found** — Categorized list with examples
+2. **Recommended Edits** — Specific before/after suggestions
+3. **Plain Language Score** — Overall assessment with grade level
+
+## Verification
+
+After review, confirm:
+
+- [ ] Readability metrics are calculated
+- [ ] Jargon is identified and defined or replaced
+- [ ] Sentence length averages 15-20 words
+- [ ] Passive voice is <10% of sentences
+- [ ] Recommendations are specific and actionable
+
+## Examples
+
+### Example 1: Complex Instructions
+
+**Input:**
+
+> In order to determine your eligibility for benefits, it is necessary for you to provide documentation that substantiates your claim. The utilization of acceptable forms of identification is required prior to the submission of your application.
+
+**Issues Found:**
+
+| Issue | Priority | Description |
+|-------|----------|-------------|
+| Buried verbs | High | "make a determination" → "determine" |
+| Passive voice | High | "it is necessary" → active voice |
+| Formal words | Medium | "utilize" → "use", "substantiates" → "supports" |
+| Wordy phrases | Medium | "in order to" → "to", "prior to" → "before" |
+
+**Recommended Edits:**
+
+```markdown
+**Original:**
+In order to determine your eligibility for benefits, it is necessary for you to provide documentation that substantiates your claim. The utilization of acceptable forms of identification is required prior to the submission of your application.
+
+**Revised:**
+To check if you're eligible for benefits, provide documents that support your claim. You must show acceptable ID before you submit your application.
+
+**Changes:**
+- "In order to determine" → "To check"
+- "it is necessary for you to provide" → "provide" (active voice)
+- "substantiates" → "support"
+- "utilization of" → removed
+- "prior to the submission" → "before you submit"
+
+**Reading Level:** Grade 7 (was Grade 13)
+```
+
+**Plain Language Score:** 85/100 (Good) after edits
+
+### Example 2: Undefined Acronym
+
+**Input:**
+
+> Submit your FOIA request through the online portal.
+
+**Issues Found:**
+
+| Issue | Priority | Description |
+|-------|----------|-------------|
+| Undefined acronym | Critical | General public may not know "FOIA" |
+
+**Recommended Edits:**
+
+```markdown
+**Original:**
+Submit your FOIA request through the online portal.
+
+**Revised:**
+Submit your Freedom of Information Act (FOIA) request through the online portal.
+
+Or for the general public:
+Submit your records request through the online portal. (Learn more about FOIA requests)
+```
+
+**Plain Language Score:** 95/100 (Excellent) after edits
+
+## Anti-Patterns to Avoid
+
+| Don't | Do Instead |
+|-------|------------|
+| Use jargon without definitions | Define acronyms on first use |
+| Write long sentences (30+ words) | Break into 2-3 shorter sentences |
+| Use passive voice extensively | Use active voice ("Submit the form") |
+| Bury verbs in nouns ("make a decision") | Use direct verbs ("decide") |
+| Say "utilize" or "leverage" | Say "use" |
+| Write "in order to" | Write "to" |
+| Use vague terms ("various", "several") | Use specific numbers |
+| Organize by department structure | Organize by user needs |
+
+## Plain Language Checklist
+
+Use this checklist for quick review:
+
+- [ ] Content is organized with most important info first
+- [ ] Headings are clear and descriptive
+- [ ] Sentences average 15-20 words
+- [ ] Active voice used (>90% of sentences)
+- [ ] Technical terms are defined on first use
+- [ ] Acronyms are spelled out on first use
+- [ ] Lists are used for related items
+- [ ] Paragraphs are short (3-5 sentences)
+- [ ] Reading level is grade 8 or below
+- [ ] Instructions use "you" and imperative verbs
+
+## Human Review Gate
+
+**Before publishing:**
+
+A human MUST:
+
+1. Verify technical accuracy (simplified language still correct?)
+2. Check that required legal language is preserved
+3. Test with representative users
+4. Confirm tone matches agency voice
+5. Review in context of full page or document
+
+**This skill improves clarity; it does not validate accuracy or legal compliance.**
+
+## Related Patterns
+
+- [uswds-prototype](../uswds-prototype/SKILL.md) — Create pages with clear content from the start
+- [accessibility-review](../accessibility-review/SKILL.md) — Plain language improves cognitive accessibility
+- [uswds-form-flow](../uswds-form-flow/SKILL.md) — Clear forms use plain language
+
+## References
+
+- [PlainLanguage.gov](https://www.plainlanguage.gov/)
+- [Federal Plain Language Guidelines](https://www.plainlanguage.gov/guidelines/)
+- [18F Content Guide](https://content-guide.18f.gov/)
+- [Plain Language Action and Information Network (PLAIN)](https://www.plainlanguage.gov/about/program-history/)
+- [Plain Writing Act of 2010](https://www.gpo.gov/fdsys/pkg/PLAW-111publ274/pdf/PLAW-111publ274.pdf)

--- a/.agents/skills/frontend/uswds-form-flow/SKILL.md
+++ b/.agents/skills/frontend/uswds-form-flow/SKILL.md
@@ -1,0 +1,122 @@
+---
+id: uswds-form-flow
+version: "1.0.0"
+title: "USWDS Accessible Form Flow"
+type: skill
+description: "Generate accessible multi-step forms using USWDS patterns with proper validation, error handling, and Section 508 compliance"
+
+status: experimental
+owners:
+  - "@community"
+
+primary_personas:
+  - developers
+  - designers
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Generated Form HTML"
+      - "Validation Rules"
+      - "Accessibility Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "create form"
+  - "form flow"
+  - "multi-step form"
+  - "application form"
+
+tags:
+  - "frontend"
+  - "uswds"
+  - "forms"
+  - "accessibility"
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Generate accessible forms for federal services"
+    - "Create multi-step form flows"
+    - "Build form validation patterns"
+  exclusions:
+    - "Not for PRA compliance determination"
+    - "Does not replace user testing"
+---
+
+# Skill: USWDS Accessible Form Flow
+
+Generate accessible multi-step forms using USWDS components with proper labels, validation, error handling, and keyboard navigation.
+
+## When to Use
+
+- Creating application or intake forms
+- Building multi-step flows
+- User asks "create a form" or "build an application"
+
+## Procedure
+
+### Step 1: Map Form Structure
+
+Identify required fields and group into logical steps.
+
+### Step 2: Generate Form HTML
+
+Use USWDS form components with proper labels and ARIA attributes.
+
+### Step 3: Add Validation and Error Handling
+
+Include inline validation and error message patterns.
+
+### Step 4: Ensure Accessibility
+
+- All inputs have labels
+- Required fields marked clearly
+- Error messages associated with inputs
+- Keyboard navigation works
+
+## Example
+
+```html
+<form class="usa-form">
+  <fieldset class="usa-fieldset">
+    <legend class="usa-legend">Contact Information</legend>
+    
+    <label class="usa-label" for="email">
+      Email address <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
+    </label>
+    <input class="usa-input" id="email" name="email" type="email" required>
+    
+    <label class="usa-label" for="phone">Phone number</label>
+    <input class="usa-input" id="phone" name="phone" type="tel">
+  </fieldset>
+</form>
+```
+
+## Related Patterns
+
+- [uswds-prototype](../uswds-prototype/SKILL.md)
+- [accessibility-review](../accessibility-review/SKILL.md)
+
+## References
+
+- [USWDS Form Components](https://designsystem.digital.gov/components/form/)
+- [Section 508 Forms Guidance](https://www.section508.gov/create/web-software/)

--- a/.agents/skills/frontend/uswds-landing-page/SKILL.md
+++ b/.agents/skills/frontend/uswds-landing-page/SKILL.md
@@ -1,0 +1,120 @@
+---
+id: uswds-landing-page
+version: "1.0.0"
+title: "USWDS Service Landing Page"
+type: skill
+description: "Generate service landing pages using USWDS hero, card, and content patterns for federal digital services"
+
+status: experimental
+owners:
+  - "@community"
+
+primary_personas:
+  - developers
+  - designers
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Generated Page HTML"
+      - "Content Sections"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "landing page"
+  - "service page"
+  - "home page"
+
+tags:
+  - "frontend"
+  - "uswds"
+  - "landing-page"
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Generate service landing pages"
+    - "Create marketing or informational pages"
+  exclusions:
+    - "Not for complex applications"
+---
+
+# Skill: USWDS Service Landing Page
+
+Generate USWDS-aligned landing pages with hero sections, feature cards, and clear calls to action for federal digital services.
+
+## When to Use
+
+- Creating a new service landing page
+- Building a marketing or informational page
+- User asks "create a landing page"
+
+## Procedure
+
+### Step 1: Define Page Purpose
+
+Identify the service, target audience, and primary action.
+
+### Step 2: Generate Hero Section
+
+Include service name, tagline, and primary CTA.
+
+### Step 3: Add Feature Cards
+
+Highlight 3-4 key features or benefits.
+
+### Step 4: Include Clear Next Steps
+
+Provide obvious paths for users to take action.
+
+## Example
+
+```html
+<section class="usa-hero">
+  <div class="grid-container">
+    <div class="usa-hero__callout">
+      <h1 class="usa-hero__heading">Service Name</h1>
+      <p>Brief description of what this service does.</p>
+      <a class="usa-button" href="/apply">Get Started</a>
+    </div>
+  </div>
+</section>
+
+<section class="grid-container usa-section">
+  <div class="grid-row grid-gap">
+    <div class="tablet:grid-col-4">
+      <h2 class="font-heading-xl margin-top-0">Feature 1</h2>
+      <p>Description of feature.</p>
+    </div>
+  </div>
+</section>
+```
+
+## Related Patterns
+
+- [uswds-prototype](../uswds-prototype/SKILL.md)
+- [plain-language-review](../plain-language-review/SKILL.md)
+
+## References
+
+- [USWDS Templates](https://designsystem.digital.gov/templates/)
+- [USWDS Hero Component](https://designsystem.digital.gov/components/hero/)

--- a/.agents/skills/frontend/uswds-prototype/SKILL.md
+++ b/.agents/skills/frontend/uswds-prototype/SKILL.md
@@ -1,0 +1,321 @@
+---
+id: uswds-prototype
+version: "1.0.0"
+title: "USWDS Front-End Prototype"
+type: skill
+description: "Generate USWDS-aligned front-end prototypes with semantic HTML, accessible structure, and federal design patterns"
+
+status: experimental
+owners:
+  - "@community"
+
+primary_personas:
+  - developers
+  - designers
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Generated HTML"
+      - "Accessibility Notes"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "External CDN Links"
+      - "Agency-Specific Branding"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "create page"
+  - "build prototype"
+  - "uswds"
+  - "federal website"
+  - "government page"
+
+tags:
+  - "frontend"
+  - "uswds"
+  - "prototype"
+  - "html"
+  - "accessibility"
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Generate static HTML prototypes for federal services"
+    - "Create USWDS-aligned page structures"
+    - "Build accessible component layouts"
+    - "Mock up user interfaces before implementation"
+  exclusions:
+    - "Not for production deployment without review"
+    - "Not for complex web applications"
+    - "Does not replace design system documentation"
+    - "Does not provide final accessibility certification"
+---
+
+# Skill: USWDS Front-End Prototype
+
+Generate USWDS-aligned front-end prototypes with semantic HTML, accessible heading structure, and federal design patterns. Produces draft artifacts for human review before deployment.
+
+## When to Use
+
+- Creating a new page for a federal digital service
+- Prototyping a user interface before full implementation
+- Building static HTML mockups for stakeholder review
+- Generating accessible page structures
+- User asks "create a page for..." or "build a prototype..."
+
+## Prerequisites
+
+- Understanding of the target audience and purpose
+- Content or placeholder text for the page
+- Any specific USWDS components needed
+- Accessibility requirements for the context
+
+## Procedure
+
+### Step 1: Clarify Requirements
+
+Before generating, confirm:
+
+- [ ] Page purpose (informational, transactional, navigational)
+- [ ] Target audience
+- [ ] Primary content or message
+- [ ] Required USWDS components (header, footer, cards, alerts, etc.)
+- [ ] Any specific accessibility concerns
+
+### Step 2: Generate Page Structure
+
+Create semantic HTML with:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>[Page Title] | [Service Name]</title>
+  <!-- USWDS CSS would be linked here in production -->
+</head>
+<body>
+  <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+  
+  <header class="usa-header usa-header--basic">
+    <!-- Header content -->
+  </header>
+  
+  <main id="main-content">
+    <div class="grid-container">
+      <!-- Page content -->
+    </div>
+  </main>
+  
+  <footer class="usa-footer">
+    <!-- Footer content -->
+  </footer>
+</body>
+</html>
+```
+
+### Step 3: Apply USWDS Patterns
+
+Use appropriate USWDS components:
+
+| Need | USWDS Component |
+|------|-----------------|
+| Page header | `usa-header` |
+| Navigation | `usa-nav` |
+| Alerts/notices | `usa-alert` |
+| Cards | `usa-card` |
+| Forms | `usa-form` with `usa-input`, `usa-select`, etc. |
+| Buttons | `usa-button` |
+| Footer | `usa-footer` |
+
+### Step 4: Ensure Accessibility
+
+Every generated page MUST include:
+
+- [ ] Skip navigation link (`<a class="usa-skipnav">`)
+- [ ] Proper `lang` attribute on `<html>`
+- [ ] Single `<h1>` as page title
+- [ ] Logical heading hierarchy (h1 → h2 → h3)
+- [ ] Landmark elements (`<main>`, `<nav>`, `<header>`, `<footer>`)
+- [ ] Descriptive link text (no "click here")
+- [ ] Form labels associated with inputs
+- [ ] Alt text for images (or `alt=""` for decorative)
+
+### Step 5: Add Human Review Comments
+
+Insert HTML comments for decisions requiring human input:
+
+```html
+<!-- HUMAN REVIEW: Verify this heading matches the approved page title -->
+<h1>Service Name</h1>
+
+<!-- HUMAN REVIEW: Replace placeholder content with approved copy -->
+<p>Description of the service goes here.</p>
+
+<!-- HUMAN REVIEW: Confirm link destinations are correct -->
+<a href="/apply">Apply now</a>
+```
+
+### Step 6: Generate Output
+
+Produce the complete artifact with:
+
+1. **Generated HTML** — The complete page markup
+2. **Accessibility Notes** — Key accessibility features included
+3. **Human Review Checklist** — Items requiring human verification
+
+## Verification
+
+After generating, verify:
+
+- [ ] HTML is valid and well-formed
+- [ ] Single `<h1>` element exists
+- [ ] Heading levels don't skip (h1 → h3)
+- [ ] All interactive elements are keyboard accessible
+- [ ] No external CDN links (unless explicitly requested)
+- [ ] USWDS class names are used correctly
+- [ ] Human review comments are included
+
+## Examples
+
+### Example 1: Simple Informational Page
+
+**Input:** "Create a page explaining how to apply for benefits"
+
+**Output:**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>How to Apply | Benefits Service</title>
+</head>
+<body>
+  <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+  
+  <header class="usa-header usa-header--basic">
+    <div class="usa-nav-container">
+      <div class="usa-navbar">
+        <div class="usa-logo">
+          <!-- HUMAN REVIEW: Add approved logo or service name -->
+          <em class="usa-logo__text">Benefits Service</em>
+        </div>
+      </div>
+    </div>
+  </header>
+  
+  <main id="main-content">
+    <div class="grid-container">
+      <h1>How to Apply for Benefits</h1>
+      
+      <!-- HUMAN REVIEW: Verify eligibility information is accurate -->
+      <section>
+        <h2>Who Can Apply</h2>
+        <p>You may be eligible if you meet the following criteria:</p>
+        <ul>
+          <li>Criterion 1</li>
+          <li>Criterion 2</li>
+        </ul>
+      </section>
+      
+      <section>
+        <h2>What You'll Need</h2>
+        <ul>
+          <li>Document 1</li>
+          <li>Document 2</li>
+        </ul>
+      </section>
+      
+      <section>
+        <h2>How to Apply</h2>
+        <ol>
+          <li>Step 1: Gather documents</li>
+          <li>Step 2: Complete application</li>
+          <li>Step 3: Submit and wait for response</li>
+        </ol>
+        
+        <!-- HUMAN REVIEW: Verify button destination -->
+        <a class="usa-button" href="/apply">Start Your Application</a>
+      </section>
+    </div>
+  </main>
+  
+  <footer class="usa-footer usa-footer--slim">
+    <div class="grid-container">
+      <!-- HUMAN REVIEW: Add approved footer content -->
+      <p>Contact: support@example.gov</p>
+    </div>
+  </footer>
+</body>
+</html>
+```
+
+**Accessibility Notes:**
+- Skip link provided for keyboard users
+- Logical heading hierarchy (h1 → h2)
+- Lists used for related items
+- Button has descriptive text
+
+**Human Review Checklist:**
+- [ ] Verify service name and branding
+- [ ] Confirm eligibility criteria are accurate
+- [ ] Validate application link destination
+- [ ] Review footer contact information
+
+## Anti-Patterns to Avoid
+
+| Don't | Do Instead |
+|-------|------------|
+| Use `<div>` for everything | Use semantic elements (`<main>`, `<section>`, `<article>`) |
+| Skip heading levels | Maintain logical hierarchy (h1 → h2 → h3) |
+| Use "click here" links | Use descriptive link text |
+| Embed external CDN scripts | Reference local USWDS assets |
+| Hard-code agency branding | Use placeholders for human review |
+| Claim the page is "508 compliant" | Note that human review is required |
+
+## Human Review Gate
+
+**Before using this output:**
+
+A human MUST review and verify:
+
+1. All content is accurate and approved
+2. Links point to correct destinations
+3. Branding meets agency requirements
+4. Accessibility has been validated with automated tools AND manual testing
+5. No placeholder content remains in production
+
+**This skill produces drafts, not deployment-ready code.**
+
+## Related Patterns
+
+- [accessibility-review](../accessibility-review/SKILL.md) — Review the generated output
+- [plain-language-review](../plain-language-review/SKILL.md) — Improve content clarity
+- [uswds-form-flow](../uswds-form-flow/SKILL.md) — For pages with forms
+
+## References
+
+- [USWDS Components](https://designsystem.digital.gov/components/)
+- [USWDS Page Templates](https://designsystem.digital.gov/templates/)
+- [Section 508 Testing](https://www.section508.gov/test/)


### PR DESCRIPTION
## Summary

Adds six new frontend skills for federal digital service development, completing the USWDS-first frontend skills pack (Epic #86).

## New Skills

| Skill | Purpose | Issue |
|-------|---------|-------|
| uswds-prototype | Generate USWDS-aligned HTML prototypes | #88 |
| accessibility-review | Review for Section 508 and WCAG 2.1 AA | #89 |
| plain-language-review | Review content for PlainLanguage.gov compliance | #90 |
| uswds-form-flow | Create accessible multi-step forms | #91 |
| uswds-landing-page | Generate service landing pages | #92 |
| federal-service-blueprint | Plan services before coding | #93 |

Plus folder structure and README (#87).

## Quality Gates

- All skills pass make validate
- Frontmatter valid per schema
- status: experimental set appropriately
- prohibited_content defined in output contracts
- Human review gates included
- Federal standards referenced (USWDS, Section508.gov, PlainLanguage.gov)
- No TODOs or incomplete sections
- No sensitive data patterns found
- Conventional Commits format

## Design Principles

1. USWDS-first — Use U.S. Web Design System components and patterns
2. Accessible by default — Meet Section 508 and WCAG 2.1 AA
3. Plain language — Follow federal plain language guidelines
4. Human review required — Agents produce drafts, humans approve

## Related Issues

Resolves: #87, #88, #89, #90, #91, #92, #93
Part of: #86 (Epic)

## Testing

make validate passed (25/25 files)

## Review Notes

- All skills are marked experimental per patterns repo policy
- Skills reference external federal standards rather than duplicating them
- Output contracts define what content is prohibited
- Examples use placeholder content (no real PII/CUI)

Co-authored-by: OpenCode Agent <agent@gsa.gov>