### PR TITLE
chore(ci): convert to direct workflows

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,6 +1,3 @@
-# PR Lint - Consumes reusable workflow from playbook
-# See: https://github.com/GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-pr-lint.yml
-
 name: PR Lint
 
 on:
@@ -8,16 +5,33 @@ on:
     types: [opened, edited, synchronize]
 
 concurrency:
-  group: pr-lint-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
-  contents: read
   pull-requests: read
 
 jobs:
-  lint:
-    uses: GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-pr-lint.yml@workflows/v1
-    with:
-      validate-commits: true
-    # Note: GITHUB_TOKEN is automatically inherited, no need to pass as secret
+  conventional-commits:
+    name: Conventional Commit Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            perf
+            ci
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            PR title must follow conventional commits format:
+            type: description (e.g., "feat: add new feature")
+            Valid types: feat, fix, docs, chore, refactor, test, perf, ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,3 @@
-# Release - Consumes reusable workflow from playbook
-# See: https://github.com/GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-release-please.yml
-# Note: GITHUB_TOKEN is automatically inherited, no need to pass as secret
-
 name: Release
 
 on:
@@ -14,10 +10,16 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-permissions: {}
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
-  release:
-    uses: GSA-TTS/agentic-coding-playbook/.github/workflows/reusable-release-please.yml@workflows/v1
-    with:
-      release-type: simple
+  release-please:
+    name: Release Please
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4.1.0
+        with:
+          release-type: simple
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Converts all workflows from reusable (playbook) to direct implementations.

## Changes

| Workflow | Before | After |
|----------|--------|-------|
| `pr-lint.yml` | Reusable from playbook | Direct semantic-pull-request |
| `release.yml` | Reusable from playbook | Direct release-please |

## Rationale

For a 3-repo ecosystem, reusable workflows add more complexity than they save:
- Silent cross-repo failures (no jobs, no logs)
- Permission issues between repos
- Extra indirection layer

Direct workflows are:
- Self-contained and easy to understand
- Failures show up with actual logs
- No cross-repo dependencies

## Related

- PR #99 (playbook) - Removed reusable workflow files
- PR #131 (quickstart) - Direct workflows conversion