### PR TITLE
chore(ci): migrate vale-action to canonical vale-cli org (#117)

### DIFF
--- a/.github/workflows/frontend-skills-qa.yml
+++ b/.github/workflows/frontend-skills-qa.yml
@@ -153,7 +153,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Vale
-        uses: errata-ai/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2
+        # The action moved from errata-ai/ to the canonical vale-cli/ org
+        # (same Vale maintainer, jdkato). Pinned to the 2.1.2 release commit,
+        # which is GPG-verified and Node 24 compatible. (Issue #117)
+        uses: vale-cli/vale-action@85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a # 2.1.2
         continue-on-error: true  # Advisory only
         with:
           files: .agents/skills/frontend


### PR DESCRIPTION
## Summary

Migrates the Vale prose-lint step in `frontend-skills-qa.yml` from `errata-ai/vale-action` to the canonical **`vale-cli/vale-action`** org, pinned to the GPG-verified `2.1.2` release commit.

Resolves the situation in #117, where dependabot #108 tried to bump to a SHA that didn't exist under `errata-ai`.

## Supply-chain verification

**Ownership / official successor**
- `errata-ai/vale-action` now **redirects** to `vale-cli/vale-action` (the GitHub API returns `full_name: vale-cli/vale-action` for the old path).
- The `vale-cli` org ("Vale", blog `https://vale.sh`) also owns **`vale-cli/vale`** (the 5.4k-star Vale CLI itself), confirming it's the project's canonical home — same maintainer, **jdkato**.
- The `2.1.2` release was published **only** under `vale-cli` (latest release; not a prerelease/draft).

**Pinned commit `85f9f7f2c5f449ac0ae5b66662961bae3f77ca6a`**
- Is the exact commit the `2.1.2` release tag dereferences to. ✅
- Is **GPG-verified** (`verified: true`, `reason: valid`) authored + committed by `jdkato`. ✅
- `action.yml` runs `node24` → `lib/main.js`; runtime deps limited to `@actions/{core,exec,tool-cache}` + `node-fetch`. `install.ts` downloads the vale + reviewdog release tarballs over HTTPS. No surprising network/exec behavior. ✅

**Policy**
- Pinned to the **full 40-char commit SHA** (not a tag), per repo supply-chain policy. Version comment `# 2.1.2` matches the SHA's actual release tag.

## Verification
- `actionlint` → CLEAN.
- No other `errata-ai` references remain in any of the three repos.

## Closes
Closes #117

Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>