### PR TITLE
chore(ci): scope release token to job + pin commitlint config dep (#115, #116)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,15 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: googleapis/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4.1.0
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,9 @@ repos:
     hooks:
       - id: commitlint
         stages: [commit-msg]
-        additional_dependencies: ["@commitlint/config-conventional"]
+        # Pinned to the latest 19.x to match the hook's @commitlint/cli@^19
+        # and the repo's exact-pinning policy (no floating ranges).
+        additional_dependencies: ["@commitlint/config-conventional@19.8.1"]
 
   # GitHub Actions security scanning (optional - skips if zizmor not installed)
   # Install: cargo install zizmor OR brew install zizmor


### PR DESCRIPTION
## Summary

Two small, contained supply-chain / least-privilege hardening fixes.

### #115 — Scope `release.yml` GITHUB_TOKEN to the release-please job
Moved `contents: write` / `pull-requests: write` from the **workflow level** to the **`release-please` job**, with workflow-level `permissions: {}`. This prevents any future job in the file from inheriting write access, and matches the pattern already used in `agentic-coding-playbook` / `agentic-coding-quickstart` release workflows.

### #116 — Pin commitlint config dependency
Pinned `@commitlint/config-conventional` → `19.8.1` (latest 19.x, matching the hook's `@commitlint/cli@^19`), removing the floating range per the repo's exact-pinning policy. Verified against npm (19.8.1 is the newest 19.x; 21.x exists but would mismatch the hook's v19 CLI).

## Verification
- `actionlint .github/workflows/release.yml` → CLEAN.
- `.pre-commit-config.yaml` parses as valid YAML.
- `release-please-action` SHA confirmed = `v4.1.0` tag commit.

## Closes
Closes #115
Closes #116

Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>