### PR TITLE
chore(ci): add zizmor CI workflow, drop brittle local hook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    # Wait before opening update PRs so freshly-published (possibly
+    # compromised) releases age out before we adopt them (zizmor
+    # dependabot-cooldown).
+    cooldown:
+      default-days: 5
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -29,6 +34,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    cooldown:
+      default-days: 5
     open-pull-requests-limit: 3
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,11 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-    # Wait before opening update PRs so freshly-published (possibly
+    # Wait 7 days before opening update PRs so freshly-published (possibly
     # compromised) releases age out before we adopt them (zizmor
     # dependabot-cooldown).
     cooldown:
-      default-days: 5
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -35,7 +35,7 @@ updates:
       day: "monday"
       time: "09:00"
     cooldown:
-      default-days: 5
+      default-days: 7
     open-pull-requests-limit: 3
     labels:
       - "dependencies"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -62,6 +64,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.12
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -89,6 +93,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -114,6 +120,8 @@ jobs:
     continue-on-error: true  # External URLs can be flaky
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
         with:
@@ -128,6 +136,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/frontend-skills-qa.yml
+++ b/.github/workflows/frontend-skills-qa.yml
@@ -38,6 +38,8 @@ jobs:
       has_html_examples: ${{ steps.detect.outputs.has_html_examples }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Detect optional inputs
         id: detect
@@ -60,6 +62,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -151,6 +155,8 @@ jobs:
     if: needs.detect.outputs.has_vale_config == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run Vale
         # The action moved from errata-ai/ to the canonical vale-cli/ org
@@ -172,6 +178,8 @@ jobs:
     if: needs.detect.outputs.has_html_examples == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -202,6 +210,8 @@ jobs:
     if: needs.detect.outputs.has_html_examples == 'true'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,45 @@
+# GitHub Actions security scanning with zizmor.
+# Scoped to run only when workflow files change, so the scan executes in CI —
+# coverage no longer depends on each contributor having zizmor installed
+# locally. (Issue #103, agentic-coding-playbook#104)
+#
+# Advisory: advanced-security is disabled (works on public repos without the
+# paid GHAS feature) and the job does not block merges; it surfaces findings
+# in the run log + annotations.
+name: Actions Security (zizmor)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          advanced-security: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,18 +44,11 @@ repos:
         # and the repo's exact-pinning policy (no floating ranges).
         additional_dependencies: ["@commitlint/config-conventional@19.8.1"]
 
-  # GitHub Actions security scanning (optional - skips if zizmor not installed)
-  # Install: cargo install zizmor OR brew install zizmor
-  # Source: https://github.com/zizmorcore/zizmor
-  # Manual run: zizmor .github/workflows/
-  - repo: local
-    hooks:
-      - id: zizmor
-        name: zizmor - GitHub Actions security scanner
-        entry: bash -c 'command -v zizmor >/dev/null 2>&1 && zizmor "$@" || exit 0' --
-        language: system
-        files: ^\.github/workflows/.*\.ya?ml$
-        pass_filenames: true
+  # NOTE: GitHub Actions security scanning (zizmor) runs in CI only —
+  # see .github/workflows/zizmor.yml. It is intentionally NOT a local
+  # pre-commit hook: the zizmor CLI hard-fails when GITHUB_TOKEN is set
+  # but empty (common in sandboxed shells), which made the local hook
+  # brittle. CI provides a valid token and scans on every workflow change.
 
   # Pattern-specific validation (local hook)
   - repo: local
@@ -63,5 +56,5 @@ repos:
       - id: validate-patterns
         name: Validate pattern frontmatter
         entry: python scripts/validate_repo.py
-        language: system
+        language: unsupported
         pass_filenames: false


### PR DESCRIPTION
## Summary

Mirrors GSA-TTS/agentic-coding-playbook#104. The local zizmor pre-commit hook here had the same two problems:
1. **Failed open** — silent `exit 0` when zizmor wasn't installed (false coverage).
2. **Brittle** — the zizmor CLI hard-fails when `GITHUB_TOKEN` is set-but-empty (common in sandboxed shells).

Moves GitHub Actions security scanning to **CI only**.

## Changes
- **Add `.github/workflows/zizmor.yml`** — `zizmorcore/zizmor-action` SHA-pinned to `v0.5.6`, scoped to `.github/workflows/**`, `permissions: {}` + least-priv `contents/actions: read`, `advanced-security: false` (advisory).
- **Remove the local zizmor pre-commit hook.**
- Also switch the `validate-patterns` local hook from `language: system` (deprecated) → `language: unsupported` per workspace policy.

## Verification
- `zizmor --offline .github/workflows/` → clean.
- `actionlint` → CLEAN.

Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>