### PR TITLE
docs: fix accuracy issues from cross-repo docs review

### DIFF
--- a/.github/workflows/frontend-skills-qa.yml
+++ b/.github/workflows/frontend-skills-qa.yml
@@ -187,7 +187,7 @@ jobs:
           node-version: '20'
 
       - name: Install html-validate
-        run: npm install -g html-validate
+        run: npm install -g html-validate@11.5.3
 
       - name: Run HTML validation
         run: |
@@ -219,7 +219,7 @@ jobs:
           node-version: '20'
 
       - name: Install axe-core CLI
-        run: npm install -g @axe-core/cli
+        run: npm install -g @axe-core/cli@4.11.3
 
       - name: Run accessibility checks
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ htmlcov/
 .env
 .env.local
 
+# Node
+node_modules/
+
 # OS
 Thumbs.db
 deleteme/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -535,8 +535,10 @@ fix stuff
 
 Conventional-commit format is enforced on the **pull request title** by a
 pinned GitHub Action (`amannn/action-semantic-pull-request`) — no local
-tooling required. **Squash-merge is preferred**, so your PR title becomes the
-squashed commit subject, which drives automated releases (release-please).
+tooling required. **Squash-merge is required** (the repo allows squash only;
+the branch ruleset enforces linear history and one code-owner review), so your
+PR title becomes the squashed commit subject, which drives automated releases
+(release-please).
 
 Keep the PR title in `type(scope): description` form (e.g.
 `feat(skills): add secure code review pattern`).

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -23,6 +23,36 @@ patterns:
     title: Secure Code Review
     type: skill
     status: experimental
+  - path: skills/frontend/uswds-prototype/SKILL.md
+    id: uswds-prototype
+    title: USWDS Front-End Prototype
+    type: skill
+    status: experimental
+  - path: skills/frontend/uswds-landing-page/SKILL.md
+    id: uswds-landing-page
+    title: USWDS Service Landing Page
+    type: skill
+    status: experimental
+  - path: skills/frontend/plain-language-review/SKILL.md
+    id: plain-language-review
+    title: Federal Plain Language Review
+    type: skill
+    status: experimental
+  - path: skills/frontend/federal-service-blueprint/SKILL.md
+    id: federal-service-blueprint
+    title: Federal Service Blueprint
+    type: skill
+    status: experimental
+  - path: skills/frontend/accessibility-review/SKILL.md
+    id: accessibility-review
+    title: Federal Accessibility Review
+    type: skill
+    status: experimental
+  - path: skills/frontend/uswds-form-flow/SKILL.md
+    id: uswds-form-flow
+    title: USWDS Accessible Form Flow
+    type: skill
+    status: experimental
   prompts:
   - path: prompts/review/qa-round/SKILL.md
     id: qa-round
@@ -73,8 +103,8 @@ patterns:
     type: lesson
     status: experimental
 stats:
-  total_patterns: 13
-  skills: 4
+  total_patterns: 19
+  skills: 10
   prompts: 3
   agents: 3
   workflows: 2

--- a/README.md
+++ b/README.md
@@ -228,7 +228,6 @@ pip install pre-commit
 
 # Install the git hook scripts
 pre-commit install
-pre-commit install --hook-type commit-msg
 
 # (Optional) Run against all files
 pre-commit run --all-files
@@ -238,18 +237,19 @@ pre-commit run --all-files
 
 - **gitleaks** — Secret detection (critical for example code)
 - **ruff** — Python linting and formatting with security rules
-- **markdownlint** — Markdown formatting
-- **zizmor** (optional) — GitHub Actions security scanning (auto-skips if not installed; install: `cargo install zizmor` or `brew install zizmor`)
+- **markdownlint-cli2** — Markdown formatting
 - **Pattern validation** — Frontmatter schema validation
 - **Basic hygiene** — YAML/JSON/TOML validation, trailing whitespace, etc.
 
-**Manual security scanning:**
+**GitHub Actions security scanning (CI, not a local hook):**
+
+zizmor runs in CI via `.github/workflows/zizmor.yml` on workflow-file changes —
+it is intentionally not a local pre-commit hook. You can also run it manually:
 
 ```bash
-# Run zizmor separately for comprehensive GitHub Actions security audit
 zizmor .github/workflows/
 ```
 
-**Note:** zizmor will silently skip if not installed. Install from: <https://github.com/woodruffw/zizmor>
+Install locally (optional): `cargo install zizmor` or `brew install zizmor`.
 
 See `.pre-commit-config.yaml` for full configuration.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -369,7 +369,7 @@ git commit
 
 ### Pattern Not Showing in INDEX.yaml
 
-**Fix:** Run `make generate` to regenerate INDEX.yaml (automated in CI).
+**Fix:** Run `make generate` to regenerate INDEX.yaml (verified locally via the `generate-index` pre-commit hook / `make generate-check`).
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes the patterns documentation-accuracy findings from the Session 48 cross-repo review.

## Changes
- **`README.md`** — zizmor is **CI-only** (`.github/workflows/zizmor.yml`), not a local pre-commit hook: removed it from "Hooks configured" + the stale "auto-skips / silently skip if not installed" wording; reframed as a CI scan with optional manual run. Removed the dead `pre-commit install --hook-type commit-msg` line (no commit-msg hook since commitlint was removed in #125). Renamed "markdownlint" → "markdownlint-cli2" to match the hook id.
- **`docs/getting-started.md`** — INDEX.yaml generation is verified locally via the `generate-index` pre-commit hook / `make generate-check`, **not** "automated in CI" (it isn't run in any workflow).
- **`CONTRIBUTING.md`** — squash-merge is now **required** (repo allows squash only; ruleset enforces linear history + 1 code-owner review), upgraded from "preferred".
- **`frontend-skills-qa.yml`** — pin the two global npm installs (`html-validate@11.5.3`, `@axe-core/cli@4.11.3`) per the repo's exact-pinning policy (security review low finding).
- **`.gitignore`** — add `node_modules/` (the `.github/linters/` tree was untracked but unignored).
- `make generate` indexed 3 frontend skills already on disk but missing from `INDEX.yaml` (pre-existing drift).

## Verification
- `python scripts/validate_repo.py` → all validators pass.
- `actionlint` → CLEAN; `make generate-check` → OK.

Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>