### PR TITLE
chore(owners): Assign pattern ownership to @GSA-TTS/agentic-coding-team

### DIFF
--- a/.agents/skills/dependency-analysis/SKILL.md
+++ b/.agents/skills/dependency-analysis/SKILL.md
@@ -7,7 +7,7 @@ description: "Analyze project dependencies for security vulnerabilities, license
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers

--- a/.agents/skills/documentation-review/SKILL.md
+++ b/.agents/skills/documentation-review/SKILL.md
@@ -7,7 +7,7 @@ description: "Review documentation for quality, accuracy, completeness, and acce
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers

--- a/.agents/skills/frontend/accessibility-review/SKILL.md
+++ b/.agents/skills/frontend/accessibility-review/SKILL.md
@@ -7,7 +7,7 @@ description: "Review front-end artifacts for Section 508 and WCAG 2.1 AA complia
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers
@@ -155,7 +155,7 @@ vale --config profiles/federal.vale.ini content.md
 
 Vale checks for:
 - Color-alone meaning (WCAG 1.4.1)
-- Flashing content warnings (WCAG 2.3.1)  
+- Flashing content warnings (WCAG 2.3.1)
 - Link text quality (WCAG 2.4.4)
 - Image descriptions (WCAG 1.4.5)
 - Mouse-only interaction warnings (WCAG 2.1.1)

--- a/.agents/skills/frontend/federal-service-blueprint/SKILL.md
+++ b/.agents/skills/frontend/federal-service-blueprint/SKILL.md
@@ -7,7 +7,7 @@ description: "Plan federal digital service user flows, touchpoints, and requirem
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers

--- a/.agents/skills/frontend/plain-language-review/SKILL.md
+++ b/.agents/skills/frontend/plain-language-review/SKILL.md
@@ -7,7 +7,7 @@ description: "Review content for federal plain language compliance following Pla
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers

--- a/.agents/skills/frontend/uswds-form-flow/SKILL.md
+++ b/.agents/skills/frontend/uswds-form-flow/SKILL.md
@@ -7,7 +7,7 @@ description: "Generate accessible multi-step forms using USWDS patterns with pro
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers
@@ -112,19 +112,19 @@ Use USWDS form components with proper structure:
 <form class="usa-form usa-form--large" action="/submit" method="post">
   <fieldset class="usa-fieldset">
     <legend class="usa-legend usa-legend--large">Section Title</legend>
-    
+
     <!-- Text input with label -->
     <label class="usa-label" for="first-name">
       First name <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
     </label>
     <input class="usa-input" id="first-name" name="first-name" type="text" required>
-    
+
     <!-- Input with help text -->
     <label class="usa-label" for="ssn">
       Social Security Number (last 4 digits)
     </label>
     <span class="usa-hint" id="ssn-hint">For example: 1234</span>
-    <input class="usa-input usa-input--medium" id="ssn" name="ssn" 
+    <input class="usa-input usa-input--medium" id="ssn" name="ssn"
            type="text" pattern="[0-9]{4}" aria-describedby="ssn-hint">
   </fieldset>
 </form>
@@ -172,7 +172,7 @@ Include error message patterns:
 <span class="usa-error-message" id="email-error" role="alert">
   Enter a valid email address
 </span>
-<input class="usa-input usa-input--error" id="email" name="email" 
+<input class="usa-input usa-input--error" id="email" name="email"
        type="email" aria-describedby="email-error" required>
 
 <!-- Error summary at top of form -->
@@ -232,22 +232,22 @@ Produce the complete artifact with:
 <form class="usa-form" action="/contact" method="post">
   <fieldset class="usa-fieldset">
     <legend class="usa-legend">Contact Us</legend>
-    
+
     <label class="usa-label" for="name">
       Your name <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
     </label>
     <input class="usa-input" id="name" name="name" type="text" required>
-    
+
     <label class="usa-label" for="email">
       Email address <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
     </label>
     <input class="usa-input" id="email" name="email" type="email" required>
-    
+
     <label class="usa-label" for="message">
       Message <abbr title="required" class="usa-hint usa-hint--required">*</abbr>
     </label>
     <textarea class="usa-textarea" id="message" name="message" required></textarea>
-    
+
     <button type="submit" class="usa-button">Send Message</button>
   </fieldset>
 </form>

--- a/.agents/skills/frontend/uswds-landing-page/SKILL.md
+++ b/.agents/skills/frontend/uswds-landing-page/SKILL.md
@@ -7,7 +7,7 @@ description: "Generate service landing pages using USWDS hero, card, and content
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers
@@ -121,7 +121,7 @@ Highlight key features with card components:
 <section class="usa-section">
   <div class="grid-container">
     <h2 class="font-heading-xl margin-y-0">Why Use This Service</h2>
-    
+
     <ul class="usa-card-group">
       <li class="usa-card tablet:grid-col-4">
         <div class="usa-card__container">
@@ -133,7 +133,7 @@ Highlight key features with card components:
           </div>
         </div>
       </li>
-      
+
       <li class="usa-card tablet:grid-col-4">
         <div class="usa-card__container">
           <div class="usa-card__header">
@@ -144,7 +144,7 @@ Highlight key features with card components:
           </div>
         </div>
       </li>
-      
+
       <li class="usa-card tablet:grid-col-4">
         <div class="usa-card__container">
           <div class="usa-card__header">
@@ -168,7 +168,7 @@ Show users how to get started:
 <section class="usa-section usa-section--light">
   <div class="grid-container">
     <h2 class="font-heading-xl margin-top-0">How It Works</h2>
-    
+
     <ol class="usa-process-list">
       <li class="usa-process-list__item">
         <h3 class="usa-process-list__heading">Step One</h3>
@@ -195,7 +195,7 @@ Address common questions:
 <section class="usa-section">
   <div class="grid-container">
     <h2 class="font-heading-xl margin-top-0">Frequently Asked Questions</h2>
-    
+
     <div class="usa-accordion usa-accordion--bordered">
       <h3 class="usa-accordion__heading">
         <button type="button" class="usa-accordion__button" aria-expanded="false" aria-controls="faq-1">
@@ -205,7 +205,7 @@ Address common questions:
       <div id="faq-1" class="usa-accordion__content usa-prose" hidden>
         <p>Answer to the question.</p>
       </div>
-      
+
       <h3 class="usa-accordion__heading">
         <button type="button" class="usa-accordion__button" aria-expanded="false" aria-controls="faq-2">
           Question two goes here?
@@ -234,24 +234,24 @@ Combine all sections:
 </head>
 <body>
   <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-  
+
   <!-- Banner -->
   <section class="usa-banner" aria-label="Official website of the United States government">
     <!-- Official government banner content -->
   </section>
-  
+
   <!-- Header -->
   <header class="usa-header usa-header--basic">
     <!-- Navigation -->
   </header>
-  
+
   <main id="main-content">
     <!-- Hero Section -->
     <!-- Feature Cards -->
     <!-- Process Steps -->
     <!-- FAQ Section -->
   </main>
-  
+
   <!-- Footer -->
   <footer class="usa-footer usa-footer--slim">
     <!-- Footer content -->
@@ -289,7 +289,7 @@ Combine all sections:
 </head>
 <body>
   <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-  
+
   <header class="usa-header usa-header--basic">
     <div class="usa-nav-container">
       <div class="usa-navbar">
@@ -300,7 +300,7 @@ Combine all sections:
       </div>
     </div>
   </header>
-  
+
   <main id="main-content">
     <!-- Hero -->
     <section class="usa-hero" aria-label="Introduction">
@@ -315,12 +315,12 @@ Combine all sections:
         </div>
       </div>
     </section>
-    
+
     <!-- Features -->
     <section class="usa-section">
       <div class="grid-container">
         <h2 class="font-heading-xl margin-y-0">Why Use This Service</h2>
-        
+
         <ul class="usa-card-group">
           <li class="usa-card tablet:grid-col-4">
             <div class="usa-card__container">
@@ -332,7 +332,7 @@ Combine all sections:
               </div>
             </div>
           </li>
-          
+
           <li class="usa-card tablet:grid-col-4">
             <div class="usa-card__container">
               <div class="usa-card__header">
@@ -343,7 +343,7 @@ Combine all sections:
               </div>
             </div>
           </li>
-          
+
           <li class="usa-card tablet:grid-col-4">
             <div class="usa-card__container">
               <div class="usa-card__header">
@@ -357,12 +357,12 @@ Combine all sections:
         </ul>
       </div>
     </section>
-    
+
     <!-- Process -->
     <section class="usa-section usa-section--light">
       <div class="grid-container">
         <h2 class="font-heading-xl margin-top-0">How to Apply</h2>
-        
+
         <ol class="usa-process-list">
           <li class="usa-process-list__item">
             <h3 class="usa-process-list__heading">Check your eligibility</h3>
@@ -377,12 +377,12 @@ Combine all sections:
             <p class="margin-top-05">Complete the online form and upload your documents.</p>
           </li>
         </ol>
-        
+
         <a class="usa-button usa-button--big" href="/apply">Start Your Application</a>
       </div>
     </section>
   </main>
-  
+
   <footer class="usa-footer usa-footer--slim">
     <div class="grid-container">
       <!-- HUMAN REVIEW: Add approved footer content -->

--- a/.agents/skills/frontend/uswds-prototype/SKILL.md
+++ b/.agents/skills/frontend/uswds-prototype/SKILL.md
@@ -7,7 +7,7 @@ description: "Generate USWDS-aligned front-end prototypes with semantic HTML, ac
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers
@@ -115,17 +115,17 @@ Create semantic HTML with:
 </head>
 <body>
   <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-  
+
   <header class="usa-header usa-header--basic">
     <!-- Header content -->
   </header>
-  
+
   <main id="main-content">
     <div class="grid-container">
       <!-- Page content -->
     </div>
   </main>
-  
+
   <footer class="usa-footer">
     <!-- Footer content -->
   </footer>
@@ -228,7 +228,7 @@ vale --config profiles/uswds.vale.ini output.html
 </head>
 <body>
   <a class="usa-skipnav" href="#main-content">Skip to main content</a>
-  
+
   <header class="usa-header usa-header--basic">
     <div class="usa-nav-container">
       <div class="usa-navbar">
@@ -239,11 +239,11 @@ vale --config profiles/uswds.vale.ini output.html
       </div>
     </div>
   </header>
-  
+
   <main id="main-content">
     <div class="grid-container">
       <h1>How to Apply for Benefits</h1>
-      
+
       <!-- HUMAN REVIEW: Verify eligibility information is accurate -->
       <section>
         <h2>Who Can Apply</h2>
@@ -253,7 +253,7 @@ vale --config profiles/uswds.vale.ini output.html
           <li>Criterion 2</li>
         </ul>
       </section>
-      
+
       <section>
         <h2>What You'll Need</h2>
         <ul>
@@ -261,7 +261,7 @@ vale --config profiles/uswds.vale.ini output.html
           <li>Document 2</li>
         </ul>
       </section>
-      
+
       <section>
         <h2>How to Apply</h2>
         <ol>
@@ -269,13 +269,13 @@ vale --config profiles/uswds.vale.ini output.html
           <li>Step 2: Complete application</li>
           <li>Step 3: Submit and wait for response</li>
         </ol>
-        
+
         <!-- HUMAN REVIEW: Verify button destination -->
         <a class="usa-button" href="/apply">Start Your Application</a>
       </section>
     </div>
   </main>
-  
+
   <footer class="usa-footer usa-footer--slim">
     <div class="grid-container">
       <!-- HUMAN REVIEW: Add approved footer content -->

--- a/.agents/skills/secure-code-review/SKILL.md
+++ b/.agents/skills/secure-code-review/SKILL.md
@@ -7,7 +7,7 @@ description: "Security-focused code review pattern covering OWASP Top 10 vulnera
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers

--- a/.agents/skills/test-generation/SKILL.md
+++ b/.agents/skills/test-generation/SKILL.md
@@ -7,7 +7,7 @@ description: "Generate unit tests, identify edge cases, and analyze test coverag
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ version: "1.0.0"                      # semver
 title: "Pattern Title"
 type: skill                           # skill|prompt|workflow|agent|lesson
 status: experimental
-owners: ["@community"]
+owners: ["@GSA-TTS/agentic-coding-team"]
 primary_personas: ["developers"]
 requires:
   anchors: []

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,15 @@
 # CODEOWNERS for agentic-coding-patterns
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Last matching pattern wins. The team owns the repo by default; the
+# admin-only overrides below take precedence for security-sensitive paths.
 
-# Security-sensitive files require admin review
+# Default: the team is responsible for all pattern content and docs
+*                           @GSA-TTS/agentic-coding-team
+
+# Security-sensitive files require admin review (override the default above)
 /.github/workflows/         @GSA-TTS/agentic-coding-admins
 /SECURITY.md                @GSA-TTS/agentic-coding-admins
 
 # Scripts contain validation logic
 /scripts/                   @GSA-TTS/agentic-coding-admins
-
-# Pattern definitions
-/patterns/                  @GSA-TTS/agentic-coding-team

--- a/agents/documentation/AGENTS.md
+++ b/agents/documentation/AGENTS.md
@@ -7,7 +7,7 @@ description: "Documentation-focused agent instructions for clear, accurate, and 
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - documentation

--- a/agents/general/AGENTS.md
+++ b/agents/general/AGENTS.md
@@ -7,7 +7,7 @@ description: "General-purpose agent instructions for incremental, safe developme
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers

--- a/agents/security-review/AGENTS.md
+++ b/agents/security-review/AGENTS.md
@@ -7,7 +7,7 @@ description: "Security-focused agent instructions for vulnerability identificati
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - security

--- a/lessons-learned/example-agentic-session/SKILL.md
+++ b/lessons-learned/example-agentic-session/SKILL.md
@@ -9,7 +9,7 @@ description: "Lessons from using agentic coding patterns for a security document
 # Status and ownership
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 # Audience
 primary_personas:

--- a/prompts/planning/implementation-plan/SKILL.md
+++ b/prompts/planning/implementation-plan/SKILL.md
@@ -7,7 +7,7 @@ description: "Generate structured implementation plans by breaking features into
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers

--- a/prompts/review/qa-round/SKILL.md
+++ b/prompts/review/qa-round/SKILL.md
@@ -7,7 +7,7 @@ description: "Guide QA verification including test coverage, bug reproduction, a
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - testers

--- a/prompts/security/safe-code-review/SKILL.md
+++ b/prompts/security/safe-code-review/SKILL.md
@@ -7,7 +7,7 @@ description: "Prompt for identifying OWASP risks, injection vulnerabilities, and
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - security

--- a/workflows/issue-to-merge-request/SKILL.md
+++ b/workflows/issue-to-merge-request/SKILL.md
@@ -7,7 +7,7 @@ description: "Complete development workflow from issue analysis to merged PR"
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - developers

--- a/workflows/qa-round/SKILL.md
+++ b/workflows/qa-round/SKILL.md
@@ -7,7 +7,7 @@ description: "Structured QA verification workflow from pre-check through sign-of
 
 status: experimental
 owners:
-  - "@community"
+  - "@GSA-TTS/agentic-coding-team"
 
 primary_personas:
   - testers


### PR DESCRIPTION
Reassigns every pattern currently owned by `@community` to the `@GSA-TTS/agentic-coding-team` team, and makes CODEOWNERS reflect that the team owns the repo by default.

## Changes

- **owners:** `@community` → `@GSA-TTS/agentic-coding-team` in all **19 patterns** (10 skills, 3 prompts, 3 agents, 2 workflows, 1 lesson) plus the example frontmatter block in the root `AGENTS.md`.
- **CODEOWNERS:** add a `*` default owned by `@GSA-TTS/agentic-coding-team`; keep the `@GSA-TTS/agentic-coding-admins` overrides for `/.github/workflows/`, `/SECURITY.md`, and `/scripts/` ordered **after** the default so last-match-wins still routes those security-sensitive paths to admins. Removes the stale `/patterns/` rule (no such directory exists).
- Pre-commit hooks also normalized trailing-whitespace / end-of-file in four USWDS frontend skills (incidental, unrelated to ownership).

## Left for follow-up (orphaned dead files)

`scripts/tests/fixtures/{valid_skill,invalid_schema}.md` still say `@community`. They are **not referenced by any test** — `test_validate_frontmatter.py` uses inline Python string fixtures — so they're orphaned. Tracked in a follow-up issue to either update or delete them.

## Verification

- `make validate` → all validators passed.
- pre-commit (markdownlint, frontmatter schema validation) → passed.