### PR TITLE
fix(ci): Make Readability Check advisory-only so it can't block PRs

### DIFF
--- a/.github/workflows/frontend-skills-qa.yml
+++ b/.github/workflows/frontend-skills-qa.yml
@@ -60,6 +60,9 @@ jobs:
     name: Readability Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Readability is advisory for these technical SKILL docs (code/YAML/HTML
+    # score poorly on Flesch-Kincaid). Never block a PR on it. (Issue #131)
+    continue-on-error: true
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -111,10 +114,12 @@ jobs:
 
             if [[ "$passed_check" == "true" ]]; then
               status="PASS"
-              ((passed++))
+              # Avoid `((passed++))`: it returns exit 1 when the result is 0,
+              # which aborts the step under set -e. (Issue #131)
+              passed=$((passed + 1))
             else
               status="WARN"
-              ((failed++))
+              failed=$((failed + 1))
             fi
 
             # Truncate path for display


### PR DESCRIPTION
Closes #131.

The **Readability Check** job intends to be advisory ("We don't fail the build on readability warnings") but was failing every PR with exit 1 (it blocked #129).

## Root cause
`((passed++))` / `((failed++))` return exit status **1 when the result is 0** — true on the first increment — which aborts the step under `set -e`. Since all 7 frontend docs currently warn (FK 17–32 vs grade 8/10), the first `((failed++))` tripped it.

## Fix
- `((passed++))` → `passed=$((passed+1))`, `((failed++))` → `failed=$((failed+1))` (non-failing arithmetic).
- Add `continue-on-error: true` to the `readability` job so it's advisory regardless of any future script error (same pattern the accessibility step already uses).

## Verified
- YAML parses.
- Reproduced under `set -e`: old `((failed++))` aborts on first warn; the new `$((failed+1))` form completes cleanly.

## Note (won't-fix)
The frontend SKILL/README docs scoring FK 17–32 are expected advisory warnings — dense technical docs (code/YAML/HTML) that Flesch-Kincaid scores poorly. They should warn, not fail.