### PR TITLE
chore(deps): pin js-yaml + markdown-it in linters; add npm dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,19 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "chore(ci)"
+
+  # CI markdown-linter npm tree
+  - package-ecosystem: "npm"
+    directory: "/.github/linters"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -395,9 +395,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -457,14 +467,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"

--- a/.github/linters/package.json
+++ b/.github/linters/package.json
@@ -8,5 +8,9 @@
   },
   "dependencies": {
     "markdownlint-cli2": "0.22.1"
+  },
+  "overrides": {
+    "js-yaml": "4.2.0",
+    "markdown-it": "14.2.0"
   }
 }


### PR DESCRIPTION
## Context

Closes the open Dependabot alert (**markdown-it GHSA-6v5v-wf23-fmfq**, quadratic DoS) and proactively bumps **js-yaml** (GHSA-h67p-54hq-rp68) in the CI markdown-linter tree (transitive deps of `markdownlint-cli2@0.22.1` in `.github/linters`). Also resolves the **failing patterns security Dependabot run** that couldn't resolve the transitive markdown-it bump without an override.

Mirrors the fix shipped in **quickstart #152** and **playbook #117** — brings all 3 repos to parity.

## Change

- `.github/linters/package.json`: `overrides` pinning `js-yaml@4.2.0` + `markdown-it@14.2.0` (keeps `markdownlint-cli2@0.22.1`).
- `.github/linters/package-lock.json`: regenerated; integrity hashes verified.
- `.github/dependabot.yml`: add `npm` ecosystem for `/.github/linters` (weekly, 7-day cooldown).

## Verification

```
npm ci    -> 0 vulnerabilities
npm audit -> 0 vulnerabilities
versions  -> js-yaml 4.2.0, markdown-it 14.2.0, markdownlint-cli2 0.22.1
```

## Rollback

Revert this commit; restores prior pins (re-opens the alert).

## Security Impact

Positive — clears the open DoS advisory; CI-only dependency scope. No runtime/app code, perms, or secrets touched.

AI-assisted (OpenCode).