### PR TITLE
fix: gitleaks config auto-load + markdownlint depth-2 globs

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,18 @@
-# Gitleaks repository-specific configuration
+# Gitleaks Configuration for agentic-coding-patterns
 # https://github.com/gitleaks/gitleaks
+#
+# Named .gitleaks.toml so the pre-commit gitleaks hook auto-loads it
+# (gitleaks looks for .gitleaks.toml by default). Extends the default
+# ruleset and adds allowlists for intentional example/educational secrets.
+
+title = "Agentic Coding Patterns Gitleaks Config"
+
+# Minimum gitleaks version required for this config
+minVersion = "v8.25.0"
+
+[extend]
+# Use the default gitleaks rules as the base configuration
+useDefault = true
 
 [allowlist]
 description = "Allow example API keys in documentation"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -49,11 +49,11 @@ globs:
   - "CONTRIBUTING.md"
   - "README.md"
   - "docs/**/*.md"
-  - "skills/*/SKILL.md"
-  - "prompts/*/SKILL.md"
-  - "agents/*/AGENTS.md"
-  - "workflows/*/SKILL.md"
-  - "lessons-learned/*/SKILL.md"
+  - "skills/**/SKILL.md"
+  - "prompts/**/SKILL.md"
+  - "agents/**/AGENTS.md"
+  - "workflows/**/SKILL.md"
+  - "lessons-learned/**/SKILL.md"
 
 # Ignore files
 ignores:


### PR DESCRIPTION
Closes #135, #136.

## gitleaks (#135)
Rename `.gitleaks.repo.toml` → `.gitleaks.toml` so the pre-commit gitleaks hook **auto-loads** it (gitleaks looks for `.gitleaks.toml` by default; the old name meant the allowlist never applied and the hook silently used only built-in defaults). Add `[extend] useDefault = true` so the default ruleset runs alongside the repo allowlist, matching the playbook config.

## markdownlint (#136)
Widen globs from depth-1 (`skills/*/SKILL.md`) to depth-2 (`skills/**`, `prompts/**`, `agents/**`, `workflows/**`, `lessons-learned/**`) so local lint matches CI's `**/*.md`. Previously ~9 depth-2 files (frontend skills, all prompts) were silently skipped locally but linted in CI → surprise CI failures for contributors.

## Verification
```
gitleaks hook -> Passed (auto-loaded .gitleaks.toml)
markdownlint  -> Linting: 31 file(s), 0 error(s)  (was ~22)
```

## Security Impact
Positive — gitleaks allowlist now actually applies (was inert); secret scanning behaves consistently with the playbook. NIST SI-7, CM-6.

AI-assisted (OpenCode).