### PR TITLE
feat(outreach): Add explainer-video and explainer-gif skills

### DIFF
--- a/.agents/skills/outreach/README.md
+++ b/.agents/skills/outreach/README.md
@@ -1,0 +1,48 @@
+# Outreach Skills
+
+Skills for producing developer-relations and outreach media — explainer videos,
+terminal screencasts, and similar artifacts that show what a tool or service
+does.
+
+> **Status:** Experimental | **License:** CC0-1.0
+
+## Overview
+
+These skills help AI coding agents produce **outreach media drafts** — animated
+explainers, demo GIFs, and the like — for slide decks, READMEs, and landing
+pages. They produce drafts and review aids, not publish-ready artifacts. Human
+review is always required before publishing.
+
+## The `explainer-*` Family
+
+Outreach explainer skills share a naming convention so the namespace stays
+predictable as it grows:
+
+| Skill | Use When |
+|-------|----------|
+| [explainer-video](explainer-video/SKILL.md) | Producing an animated MP4 explainer from a hand-authored HTML composition (slide decks, landing pages) |
+| [explainer-gif](explainer-gif/SKILL.md) | Recording a CLI tool as a deterministic, accessible terminal-screencast GIF (README heroes, quick previews) |
+| explainer-html *(planned)* | An interactive or embeddable HTML explainer (not yet authored) |
+
+Pick by where the artifact will live: a GIF embeds inline anywhere (including a
+committed repo path), while an MP4 is smaller and higher fidelity but needs
+hosting to play inline. The two skills cross-reference each other.
+
+## Design Principles
+
+1. **Accessible by default** — Pair every motion/color artifact with a text
+   summary and a poster or alt text; meet WCAG contrast and use-of-color
+   guidance so meaning survives without playback.
+2. **Deterministic and reproducible** — Script the artifact (a composition or a
+   tape) and pin tool versions so renders are repeatable in CI.
+3. **Offline and supply-chain safe** — Vendor assets locally; pin and review
+   any rendering tool; never send content to a hosted renderer.
+4. **Source of truth** — Draw any real numbers from a documented source so the
+   artifact can be refreshed when they change.
+5. **Drafts, not final media** — A human reviews and approves before publishing.
+
+## Contributing
+
+Add a new outreach skill under `skills/outreach/<id>/SKILL.md` following the
+[skill schema](../../schemas/skill.schema.json), keep the `explainer-*` naming
+for explainer artifacts, and register it in `INDEX.yaml` (run `make validate`).

--- a/.agents/skills/outreach/explainer-gif/SKILL.md
+++ b/.agents/skills/outreach/explainer-gif/SKILL.md
@@ -1,0 +1,306 @@
+---
+id: explainer-gif
+version: "1.0.0"
+title: "Explainer GIF (Terminal Screencast)"
+type: skill
+description: "Script a terminal session as a deterministic tape and render it to an accessible, readable GIF or short video for documentation and outreach"
+
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Tape Script"
+      - "Recording Command"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "terminal demo"
+  - "screencast"
+  - "demo gif"
+  - "cli recording"
+  - "asciinema"
+  - "vhs"
+
+tags:
+  - "outreach"
+  - "gif"
+  - "screencast"
+  - "terminal"
+  - "vhs"
+  - "demo"
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Record a CLI tool walkthrough as a GIF for a README hero"
+    - "Produce a deterministic, re-renderable terminal demo for docs or CI"
+    - "Create an accessible, paced screencast that reads well at a glance"
+  exclusions:
+    - "Not for live, unscripted screen captures (use a screen recorder)"
+    - "Not for GUI or browser demos (use a video tool; see explainer-video)"
+    - "Does not replace prose documentation — pair the GIF with a text summary"
+---
+
+# Skill: Explainer GIF (Terminal Screencast)
+
+Script a terminal session as a tape file, then render it deterministically to a
+GIF (or short MP4/WebM) of a command-line tool in action. The recording is
+reproducible: there is no live typing to fumble, the same inputs always produce
+the same frames, and the artifact can be re-rendered in CI. This skill produces
+draft tape scripts and recording commands for human review before publishing.
+
+## When to Use
+
+- Showing what a CLI tool does at the top of a README
+- Producing a paced, readable terminal walkthrough for documentation
+- Re-rendering a demo automatically when the tool changes
+- User asks to "record a terminal demo", "make a demo GIF", or "screencast the CLI"
+
+## Prerequisites
+
+- The CLI tool to demonstrate, runnable from a shell
+- A recording tool installed. The reference tool is
+  [VHS](https://github.com/charmbracelet/vhs) (MIT), which renders a `.tape`
+  script to GIF/MP4/WebM via a headless terminal plus `ffmpeg`. Alternatives:
+  [asciinema](https://asciinema.org/) to capture a cast, and
+  [agg](https://github.com/asciinema/agg) (asciinema-agg) to convert a cast to
+  a GIF.
+- A target screen size, theme, and font decided in advance
+- A short list of commands and the order to show them
+
+## Procedure
+
+### Step 1: Write the Tape
+
+Script the session declaratively so the render is reproducible. A tape is a
+list of directives the recorder replays: set the environment, type a command,
+press Enter, sleep, repeat. Do not capture live typing — a script removes
+timing jitter and typos, and lets you re-render after the tool changes.
+
+Keep the demo short. Pick three to six commands that tell one story. Trim
+anything that does not earn its screen time.
+
+### Step 2: Make It Deterministic
+
+Pin every variable that affects the output:
+
+- [ ] Pin the recorder version (record it in a comment or a `Require` line)
+- [ ] Set the terminal width and height in the tape, not the host terminal
+- [ ] Set the theme, font, and font size in the tape
+- [ ] Set any tool environment variables in the tape so output is stable
+- [ ] Avoid commands whose output changes run to run (timestamps, random IDs);
+      if unavoidable, pin a seed or a fixed clock
+
+Deterministic input plus a fixed terminal equals a render that looks identical
+on every machine and in CI.
+
+### Step 3: Set Pacing for Readability
+
+A GIF that scrolls too fast is unreadable. Two validated techniques:
+
+1. **Slide / paginated mode (recommended for GIFs).** Clear the screen, show
+   ONE screenful, hold it for about five to seven seconds, then clear and
+   advance. Each frame is a full, readable screen rather than a racing scroll.
+   This is the pattern large CLI projects use for tool GIFs.
+2. **Narrated pacing.** Before each command, print what it does and what to
+   look for, then pause for reading time (about 200 words per minute plus a few
+   seconds of buffer), then run the command and pause again so the output can
+   sink in.
+
+Prefer slide mode for a GIF: a viewer cannot pause a GIF, so every frame must
+stand on its own. Use narrated pacing for a live screen-share or a longer
+video.
+
+- [ ] Each slide holds long enough to read (about five to seven seconds)
+- [ ] Reading pauses scale with the amount of text on screen
+- [ ] The final slide is held before recording stops (give the recorder a
+      window slightly longer than the total hold time)
+
+### Step 4: Set an Accessible Palette
+
+Build for WCAG 2.1. The terminal palette is the demo's only visual channel, so
+it must carry meaning without relying on color alone.
+
+- **Contrast (WCAG 1.4.6, AAA).** Use foregrounds that meet at least a 7:1
+  contrast ratio against the background. No single chromatic color is AAA on
+  both a dark and a light terminal, so select a theme per render (a dark theme
+  for a dark background, a light theme for a light one) and pair each
+  foreground with an explicit background so the ratio is guaranteed.
+- **Use of color (WCAG 1.4.1).** Never let color be the only signal. Pair every
+  status with a text label and a glyph — for example `PASS`, `FAIL`, `WARN`
+  with `[+]`, `[x]`, `[!]` — so meaning survives no-color, colorblind, and
+  grayscale viewing.
+- **Honor `NO_COLOR`.** Respect the [no-color.org](https://no-color.org/)
+  convention so the demo degrades cleanly to plain text.
+- **Self-check contrast.** Provide a check that computes the WCAG
+  relative-luminance and contrast-ratio formulas for every palette pair and
+  fails if any drops below 7:1, so CI can gate it.
+- **No audio, motion-only info.** A GIF has no sound and conveys information
+  through motion. Pair it with a text summary or alt text so the same
+  information is available without playback.
+
+### Step 5: Keep Tool Output Compact
+
+Long tool output overflows a terminal frame and pushes content off screen.
+Render a compact or trimmed view — one fixed-width row per result, errors only,
+or a summarized table — so each result fits a single screen. Keep the full,
+detailed output in the normal (non-recorded) command.
+
+### Step 6: Render and Commit
+
+Render the tape to an artifact and commit it so documentation can reference it
+without a toolchain:
+
+```bash
+vhs demo.tape          # renders the Output path declared in the tape
+```
+
+- [ ] Render to a GIF for README heroes (universal inline playback)
+- [ ] Commit the artifact to the repository
+- [ ] Reference it from the README or docs
+- [ ] Commit the tape alongside the artifact so it can be re-rendered
+
+GitHub renders a committed GIF inline in Markdown. A committed MP4 does **not**
+play inline from a repo path — it needs a hosted `user-attachments` asset URL to
+embed. For an MP4 walkthrough, see the related `explainer-video` skill.
+
+## Tape Script
+
+A small VHS tape that records two commands in slide-friendly, accessible style.
+Replace the commands and theme to match your tool. Comments explain each choice.
+
+```tape
+# demo.tape — render with:  vhs demo.tape
+# Requires the recorder and ffmpeg on PATH.
+Require bash
+
+# Output artifact. A GIF embeds inline in Markdown everywhere.
+Output demo.gif
+
+# Deterministic terminal: size, font, and theme live HERE, not on the host.
+Set Shell bash
+Set FontSize 22
+Set Width 1280
+Set Height 800
+Set Padding 24
+
+# A dark theme whose foregrounds meet AAA contrast (>= 7:1) on this background.
+# Pick a light theme instead when recording on a light background.
+Set Theme { "name": "Demo", "background": "#1e1e1e", "foreground": "#e6e6e6", "green": "#73d393", "red": "#ff8a80", "yellow": "#f0c674", "blue": "#4dc9d6" }
+
+# Tool environment, pinned so output is stable across machines and CI.
+Env NO_COLOR ""
+
+Sleep 800ms
+
+# Slide 1: type a command, run it, hold long enough to read the screen.
+Type "your-cli --help"
+Sleep 600ms
+Enter
+Sleep 6s
+
+# Clear before the next slide so each frame is one full, readable screen.
+Type "clear"
+Enter
+Sleep 300ms
+
+# Slide 2: show a result. Status carries a text label, not just color.
+Type "your-cli check ./example   # prints PASS / FAIL, not color alone"
+Sleep 600ms
+Enter
+Sleep 6s
+```
+
+## Recording Command
+
+Render the tape with the reference tool:
+
+```bash
+vhs demo.tape          # renders the Output path declared in the tape
+```
+
+The render is deterministic because the terminal size, theme, font, and tool
+environment are all declared in the tape rather than inherited from the host.
+Commit both the rendered artifact and the tape so the demo can be re-rendered
+when the tool changes.
+
+## Accessibility
+
+A terminal GIF must remain useful with no color, no motion, and no sound.
+
+- [ ] Foreground colors meet at least 7:1 contrast against the background (WCAG
+      1.4.6 AAA); the theme is chosen to match the background
+- [ ] Status is conveyed by a text label and a glyph, never color alone (WCAG
+      1.4.1)
+- [ ] `NO_COLOR` is honored; the demo reads cleanly as plain text
+- [ ] A contrast self-check verifies every palette pair and can gate in CI
+- [ ] The GIF is paired with a text summary or alt text describing what it shows
+- [ ] Pacing gives a viewer time to read each screen without pausing
+
+## Tradeoffs
+
+| Format | Inline playback | Size | Fidelity | Best for |
+|--------|-----------------|------|----------|----------|
+| GIF | Plays inline anywhere, including a committed repo path | Larger | Lower (256 colors, no audio) | README heroes, quick previews |
+| MP4 / WebM | Smaller and higher fidelity, but needs hosting to embed inline | Smaller | Higher | Slide decks, longer walkthroughs |
+
+Recommend a GIF for a README hero and an MP4 for a slide deck or a longer
+narrated demo. For the MP4 path and inline-embedding details, cross-link the
+`explainer-video` skill.
+
+## Human Review Checklist
+
+Before publishing this output, a human MUST verify:
+
+- [ ] The tape contains no secrets, real PII, real CUI, or internal URLs in any
+      typed command or output
+- [ ] The demo tells one clear story in three to six commands
+- [ ] Every slide holds long enough to read at a glance
+- [ ] The palette matches the background and meets AAA contrast
+- [ ] Status meaning survives with color disabled (labels and glyphs present)
+- [ ] The GIF is paired with a text summary or alt text
+- [ ] Tool output is trimmed so each result fits one screen
+- [ ] The artifact and the tape are both committed so the demo can be re-rendered
+
+**This skill produces draft tapes and recording commands, not published media.**
+
+## Related Patterns
+
+- `explainer-video` — Produce an MP4 walkthrough and embed it inline
+
+## References
+
+- [VHS](https://github.com/charmbracelet/vhs) — Scriptable terminal recorder (MIT); renders `.tape` to GIF/MP4/WebM
+- [asciinema](https://asciinema.org/) — Record a terminal session to a cast
+- [agg](https://github.com/asciinema/agg) — Convert an asciinema cast to a GIF
+- [ffmpeg](https://ffmpeg.org/) — Encodes the rendered frames
+- [WCAG 2.1: Contrast (Enhanced) 1.4.6](https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced.html)
+- [WCAG 2.1: Use of Color 1.4.1](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html)
+- [NO_COLOR convention](https://no-color.org/)

--- a/.agents/skills/outreach/explainer-video/SKILL.md
+++ b/.agents/skills/outreach/explainer-video/SKILL.md
@@ -1,0 +1,403 @@
+---
+id: explainer-video
+version: "1.0.0"
+title: "Explainer Video (HTML to MP4)"
+type: skill
+description: "Hand-author an HTML composition and render it to a deterministic MP4 explainer video by seeking a paused GSAP timeline frame-by-frame with headless Chromium and FFmpeg, fully offline with locally vendored assets"
+
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Composition HTML"
+      - "Render Command"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "External CDN Links"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "explainer video"
+  - "promo video"
+  - "animated overview"
+  - "html to video"
+  - "launch video"
+
+tags:
+  - "outreach"
+  - "video"
+  - "explainer"
+  - "hyperframes"
+  - "gsap"
+  - "animation"
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Produce a short animated explainer or launch video from a hand-authored HTML file"
+    - "Render an HTML composition to MP4 locally, offline, and deterministically"
+    - "Create promo or overview motion graphics for a slide deck, README, or landing page"
+  exclusions:
+    - "Not for hosted-cloud rendering of sensitive content"
+    - "Not a replacement for accessible text — pair every video with a text summary"
+    - "Not for crawling or capturing arbitrary web pages"
+---
+
+# Skill: Explainer Video (HTML to MP4)
+
+Render a short animated explainer video from a single hand-authored HTML file.
+The capability: a renderer drives a paused GSAP timeline frame-by-frame in
+headless Chromium and pipes each frame to FFmpeg, producing an MP4. There is no
+build step and no proprietary timeline format — the HTML plays as-is. This skill
+uses [HyperFrames](https://github.com/heygen-com/hyperframes) (Apache-2.0) as
+the reference renderer, but the technique generalizes to any tool that seeks a
+deterministic timeline.
+
+The render runs entirely offline with locally vendored scripts and fonts. This
+skill produces a draft video for human review, never a publish-ready artifact.
+
+## When to Use
+
+- Building a short animated explainer (title cards, timed reveals, simple charts)
+- Producing a launch or promo video for a release
+- Turning a static one-pager into a 30-45 second animated overview
+- User asks "make an explainer video", "html to video", or "animated overview"
+
+## When Not to Use
+
+- The content contains secrets, real PII, or real CUI (never send to a renderer
+  you do not fully control; never use hosted rendering)
+- The audience needs the information without video playback (provide text instead)
+- You need to capture or crawl an existing live web page
+
+## Prerequisites
+
+- Node.js and `npx` available locally
+- Docker available (strongly preferred for deterministic renders); otherwise a
+  system Chrome/Chromium plus FFmpeg on `PATH`
+- A pinned renderer version recorded in your project (treat any bump as a
+  re-review trigger)
+- GSAP downloaded once and vendored locally (see Step 3)
+- A short script or storyboard: what each scene says, in order
+
+## Procedure
+
+### Step 1: Plan the Storyboard
+
+Aim for 30-45 seconds at 1920x1080. Use a 6-scene pattern (generic, adapt the
+copy to your subject):
+
+1. Title — name the thing, one-line tagline
+2. The problem — the pain you solve, stated plainly
+3. The tool in action — a focused demonstration or key capability
+4. A comparison or metric — an animated chart (before/after, bar growth)
+5. A result or gauge — an animated number or progress dial
+6. Call to action — where to go next (a repo path, a doc title; no live URLs)
+
+Keep each scene 4-8 seconds. Source any real numbers from a single source of
+truth and note in the composition where they came from so they can be refreshed.
+
+### Step 2: Write the Composition HTML
+
+A composition is one HTML file with a root element carrying composition metadata:
+
+```html
+<div id="root" data-composition-id="explainer"
+     data-start="0" data-width="1920" data-height="1080">
+  <section id="scene1"> ... </section>
+  <section id="scene2"> ... </section>
+  <!-- one plain <section> per scene -->
+</div>
+```
+
+Authoring contract:
+
+- **Scene layers are plain `<section>` elements** — full-frame layers whose
+  visibility you drive with GSAP. Start them `opacity: 0` in CSS.
+- **KEY VALIDATED LESSON: do NOT put `class="clip"` on a scene layer you animate
+  with GSAP.** The renderer manages clip visibility itself and rejects GSAP
+  tweens on the `visibility`/`display` of a `clip` element. A GSAP-driven scene
+  layer must be a plain `<section>` with no `class="clip"` and no `data-start`.
+- Use `class="clip"` ONLY for discrete media you are NOT animating on the master
+  timeline (for example a static `<img>`). A clip needs `data-start` and, for
+  images, `data-duration`; `data-track-index` controls z-order (one track cannot
+  overlap itself in time).
+
+### Step 3: Vendor GSAP and Fonts Locally
+
+Download GSAP once at author time (a CDN fetch here is fine — the rule is only
+that the *composition* must not reference a CDN at render time):
+
+```bash
+curl -fsSL -o assets/gsap.min.js \
+  https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js
+```
+
+Reference it by relative path inside the composition:
+
+```html
+<script src="./assets/gsap.min.js"></script>
+```
+
+License note: GSAP is under the GreenSock Standard License — this is **not** an
+OSI or MIT license. Record GSAP and its version in your SBOM; revisit if the
+terms change.
+
+Fonts: the renderer substitutes common families to bundled fonts. Use the
+**target** names directly to avoid a `font_family_without_font_face` error:
+
+```css
+font-family: Inter, sans-serif;
+font-family: "JetBrains Mono", monospace;
+```
+
+Do not use `-apple-system` or `BlinkMacSystemFont` — they alias to a generic
+fallback.
+
+### Step 4: Build the Single Paused Timeline
+
+Animation is a **single paused GSAP timeline** registered as
+`window.__timelines["<data-composition-id>"]`. The key MUST match the
+composition id exactly. The composition duration equals `tl.duration()`; pad the
+end with `tl.set`.
+
+```html
+<script>
+  const tl = gsap.timeline({ paused: true });
+
+  // Scene 1: fade in, reveal children, fade out
+  tl.to("#scene1", { opacity: 1, duration: 0.5 }, 0);
+  tl.from("#scene1 .title", { y: 40, opacity: 0, duration: 0.6 }, 0.2);
+  tl.to("#scene1", { opacity: 0, duration: 0.5 }, 4);
+  // HARD KILL: settle non-linear seeking — kill BOTH opacity and visibility
+  tl.set("#scene1", { opacity: 0, visibility: "hidden" }, 4.5);
+
+  // Scene 2 ...
+  tl.to("#scene2", { opacity: 1, duration: 0.5 }, 4.5);
+  // ... repeat the pattern per scene ...
+
+  // Pad total duration (co-locate the final hard kill at the boundary)
+  tl.set("#scene6", { opacity: 0, visibility: "hidden" }, 40);
+  tl.set({}, {}, 42);
+
+  // Required for hand-authored compositions:
+  window.__timelines = window.__timelines || {};
+  window.__timelines["explainer"] = tl;
+</script>
+```
+
+### Step 5: The Hard-Kill Rule (Validated Fix)
+
+After each scene's fade-OUT, add a hard-kill `tl.set(...)` at the fade-end time
+on the non-clip scene layer, killing **BOTH** opacity and visibility:
+
+```js
+tl.set("#sceneN", { opacity: 0, visibility: "hidden" }, <endSeconds>);
+```
+
+Omitting it triggers `gsap_exit_missing_hard_kill` /
+`scene_layer_missing_visibility_kill` and fails lint. The `visibility` kill is
+correct and required here because plain `<section>` scene layers are NOT clips —
+the prohibition on animating `visibility` applies only to actual `class="clip"`
+elements. Apply the same hard-kill to the FINAL scene at the composition-end
+second, co-located with the `tl.set({}, {}, <total>)` duration pad; the linter
+accepts a hard-kill at the duration boundary.
+
+### Step 6: Lint, Then Render
+
+Run the lint step first, then render. Both use the locked-down environment.
+
+See **Render Command** below for the exact, blessed invocation.
+
+### Step 7: Inspect the Output
+
+The render writes the MP4 relative to the composition directory. A docker render
+prints an internal `/output/...` container path first, then the real host path —
+use the host path. Watch the result end to end before review.
+
+## Composition HTML
+
+A minimal, complete skeleton (combine with the timeline from Step 4):
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    html, body { margin: 0; background: #0b0b0f; }
+    #root { position: relative; width: 1920px; height: 1080px; }
+    section {
+      position: absolute; inset: 0;
+      display: flex; align-items: center; justify-content: center;
+      opacity: 0; /* scenes start hidden; GSAP reveals them */
+      font-family: Inter, sans-serif; color: #fff;
+    }
+    .title { font-size: 96px; font-weight: 700; }
+    .mono { font-family: "JetBrains Mono", monospace; }
+  </style>
+</head>
+<body>
+  <div id="root" data-composition-id="explainer"
+       data-start="0" data-width="1920" data-height="1080">
+    <section id="scene1"><h1 class="title">Title Card</h1></section>
+    <section id="scene2"><p class="title">The problem, stated plainly.</p></section>
+    <section id="scene3"><p class="title">The tool in action.</p></section>
+    <section id="scene4"><div class="chart"><!-- animated bars --></div></section>
+    <section id="scene5"><p class="title mono">98%</p></section>
+    <section id="scene6"><p class="title">See: docs/overview</p></section>
+  </div>
+
+  <script src="./assets/gsap.min.js"></script>
+  <script>
+    /* single paused timeline registered at window.__timelines["explainer"] */
+    /* see Step 4 + Step 5 hard-kill rule */
+  </script>
+</body>
+</html>
+```
+
+## Render Command
+
+This is the only blessed, locked-down envelope. Always set the three privacy
+env vars and pin the exact version. Run lint, then render, from the composition
+directory.
+
+```bash
+# Pin the version; treat any bump as a re-review trigger.
+VERSION=0.6.112
+
+# 1) Lint (auto-discovers index.html in the current dir; no single-file flag)
+HYPERFRAMES_NO_TELEMETRY=1 DO_NOT_TRACK=1 HYPERFRAMES_NO_UPDATE_CHECK=1 \
+  npx --yes hyperframes@${VERSION} lint
+
+# 2) Render (deterministic): builds a LOCAL renderer image, no hosted pull
+HYPERFRAMES_NO_TELEMETRY=1 DO_NOT_TRACK=1 HYPERFRAMES_NO_UPDATE_CHECK=1 \
+  npx --yes hyperframes@${VERSION} render --docker \
+    --output out.mp4 --fps 30 --quality high
+```
+
+Notes:
+
+- Prefer `--docker`: the first docker render builds a LOCAL renderer image from
+  a bundled Dockerfile (pinned Chrome, fonts, FFmpeg). It does not pull a
+  vendor-hosted image and gives deterministic output.
+- `--output out.mp4` is written **relative to the composition dir**.
+- **Local fallback** (only if Docker is unavailable): drop `--docker`. Local
+  renders need a system Chrome/Chromium and FFmpeg on `PATH` and are NOT
+  guaranteed bit-deterministic across machines — prefer `--docker`.
+- The benign `gsap_studio_edit_blocked` warning is **expected** for
+  hand-authored compositions: you registered `window.__timelines` by hand. It is
+  safe and does not block the render. **Ignore that warning's own `Fix:` text
+  telling you to remove the manual `window.__timelines` registration** — for a
+  hand-authored composition the registration is required; removing it breaks the
+  render.
+
+## Security and Supply Chain
+
+The renderer ships opt-in subcommands that fetch unpinned code or send content
+to a hosted service. The blessed envelope avoids all of them.
+
+**Hard guardrails:**
+
+- Set `HYPERFRAMES_NO_TELEMETRY=1 DO_NOT_TRACK=1 HYPERFRAMES_NO_UPDATE_CHECK=1`
+  on **every** invocation. (`CI=true` alone does NOT disable telemetry.)
+- Pin the exact renderer version. **Any version bump is a re-review trigger.**
+- Vendor all scripts and fonts locally; the composition must make **zero network
+  requests at render time**.
+- Verify the package tarball integrity against the registry before adopting a
+  new version. Record vendored asset licenses (GSAP, fonts) in the SBOM.
+
+**NEVER run these subcommands:**
+
+| Command | Why it is forbidden |
+|---------|---------------------|
+| `hyperframes skills` | Runs `npx skills` -> `git clone` with `GIT_CLONE_PROTECTION_ACTIVE=0`; unpinned third-party CLI |
+| `hyperframes init` without `--skip-skills` | Interactive path offers to install skills |
+| `hyperframes add` / `catalog` | Fetch+write from an unpinned `main`-branch registry |
+| `hyperframes capture` | Headless crawl of arbitrary URLs |
+| `hyperframes publish` / `lambda` / `cloud` / `login` | Hosted rendering — never send sensitive content to a hosted renderer |
+| `--tailwind` | Pulls a CDN runtime at render time; use plain CSS |
+
+If you must initialize a project, use `hyperframes init --skip-skills`. Skills in
+this ecosystem are Markdown instructions, not executable code — the risk is in
+the *delivery* (`npx skills` + `git clone`), which the envelope sidesteps.
+
+## Determinism Rules (Hard)
+
+- No `Date.now()`.
+- No `Math.random()` (or seed it deterministically).
+- No network fetches at render time — all assets load before frame 0.
+- Vendor scripts and fonts locally; reference them by relative path.
+
+## Human Review Checklist
+
+Before using this output, a human MUST verify:
+
+- [ ] Video plays end to end with no flicker, ghost frames, or stuck scenes
+- [ ] Each scene fades fully out (hard-kill present on every non-clip scene)
+- [ ] No scene layer carries `class="clip"`
+- [ ] Single paused timeline registered at `window.__timelines["<id>"]`, key
+      matches `data-composition-id`
+- [ ] Composition makes zero network requests at render time
+- [ ] GSAP and fonts are vendored locally and recorded in the SBOM
+- [ ] Renderer version is pinned; the three privacy env vars were set
+- [ ] No forbidden subcommands were run (no `skills`/`add`/`catalog`/`capture`/
+      hosted commands)
+- [ ] No secrets, real PII, real CUI, internal URLs, or CDN links in the output
+- [ ] All numbers trace to a single source of truth and are current
+- [ ] Accessibility: a poster image + text summary exists (see below)
+
+**This skill produces drafts, not publish-ready artifacts.**
+
+## Accessibility
+
+Video conveys information through motion and color, which excludes some users
+and breaks down without playback. Always pair the video with:
+
+- A **poster image** (a representative still frame)
+- A **text summary** that contains the same information as the video, so the
+  message survives with no playback at all
+
+Treat the text summary as the source of record; the video is an enhancement.
+
+## Related Patterns
+
+- `explainer-gif` — Record a CLI tool as a deterministic, accessible
+  terminal-screencast GIF. Prefer a GIF for a README hero (plays inline from a
+  committed repo path); prefer this MP4 explainer for slide decks and
+  higher-fidelity walkthroughs.
+
+## References
+
+- [HyperFrames](https://github.com/heygen-com/hyperframes) — reference renderer
+  (Apache-2.0). HTML-to-MP4 via headless Chromium + FFmpeg.
+- [GSAP](https://gsap.com/) — animation library (GreenSock Standard License; not
+  OSI/MIT — record in SBOM).
+- [GreenSock Standard License](https://gsap.com/standard-license)
+- [FFmpeg](https://ffmpeg.org/) — frame encoding.

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -23,6 +23,16 @@ patterns:
     title: Secure Code Review
     type: skill
     status: experimental
+  - path: skills/outreach/explainer-video/SKILL.md
+    id: explainer-video
+    title: Explainer Video (HTML to MP4)
+    type: skill
+    status: experimental
+  - path: skills/outreach/explainer-gif/SKILL.md
+    id: explainer-gif
+    title: Explainer GIF (Terminal Screencast)
+    type: skill
+    status: experimental
   - path: skills/frontend/uswds-prototype/SKILL.md
     id: uswds-prototype
     title: USWDS Front-End Prototype
@@ -103,8 +113,8 @@ patterns:
     type: lesson
     status: experimental
 stats:
-  total_patterns: 19
-  skills: 10
+  total_patterns: 21
+  skills: 12
   prompts: 3
   agents: 3
   workflows: 2


### PR DESCRIPTION
Adds a new `skills/outreach/` category for developer-relations / outreach media patterns, seeded with two skills generalized from validated real-world work.

## New skills

- **`explainer-video`** — hand-author an HTML composition and render a deterministic MP4 (HyperFrames + GSAP → headless Chromium + FFmpeg). Captures the hard-won authoring contract (scene layers must be plain `<section>`, not `class="clip"`; the dual `opacity` + `visibility` hard-kill), the locked-down render envelope (telemetry off, pinned version, `--docker`), and a full supply-chain **"NEVER run"** table (no `skills`/`init`/`add`/`catalog`/`capture`/hosted commands).
- **`explainer-gif`** — script a CLI tool as a deterministic VHS tape and render an accessible, paced terminal-screencast GIF: slide mode with timed holds, WCAG 2.1 AAA palette, color-plus-glyph status (survives `NO_COLOR`/grayscale), contrast self-check. Notes `agg`/`asciinema` as alternatives.

## Category

`skills/outreach/README.md` documents the `explainer-*` family and names `explainer-html` as a planned sibling. The two skills cross-reference each other (GIF for README heroes that embed inline; MP4 for slide decks).

## Provenance & generalization

Distilled from a real, cold-validated implementation; **generalized for CC0** — no agency/product coupling, internal URLs, or sensitive data. Owned by `@GSA-TTS/agentic-coding-team`.

## Verification

- `make validate` → all validators passed
- `scripts/generate_index.py --check` → INDEX.yaml up to date (stats 19→21, skills 10→12)
- markdownlint → 0 errors
- Reviewed (QA + security + cleanup): schema-valid, required_sections match real headings, security guardrails accurate, fully generic.