### PR TITLE
feat(schema): adopt categories taxonomy + additive security-governance fields (#151)

### DIFF
--- a/.agents/skills/dependency-analysis/SKILL.md
+++ b/.agents/skills/dependency-analysis/SKILL.md
@@ -47,6 +47,18 @@ tags:
   - "supply-chain"
   - "vulnerabilities"
 
+categories:
+  - "security"
+  - "dependencies"
+  - "supply-chain"
+
+risk_tier: moderate
+human_review_required: true
+allowed_tools: []
+network_policy: deny
+write_policy: deny
+script_policy: deny
+
 portability:
   opencode: true
   cursor: true

--- a/.agents/skills/documentation-review/SKILL.md
+++ b/.agents/skills/documentation-review/SKILL.md
@@ -28,6 +28,10 @@ output:
       - "Real CUI"
       - "Internal URLs"
 
+categories:
+  - "documentation"
+  - "review"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/.agents/skills/frontend/accessibility-review/SKILL.md
+++ b/.agents/skills/frontend/accessibility-review/SKILL.md
@@ -31,6 +31,11 @@ output:
       - "Internal URLs"
       - "Absolute compliance certifications"
 
+categories:
+  - "frontend"
+  - "review"
+  - "compliance"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/.agents/skills/frontend/federal-service-blueprint/SKILL.md
+++ b/.agents/skills/frontend/federal-service-blueprint/SKILL.md
@@ -31,6 +31,11 @@ output:
       - "Real CUI"
       - "Internal URLs"
 
+categories:
+  - "frontend"
+  - "compliance"
+  - "documentation"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/.agents/skills/frontend/plain-language-review/SKILL.md
+++ b/.agents/skills/frontend/plain-language-review/SKILL.md
@@ -31,6 +31,11 @@ output:
       - "Internal URLs"
       - "Absolute compliance certifications"
 
+categories:
+  - "frontend"
+  - "documentation"
+  - "review"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/.agents/skills/frontend/uswds-form-flow/SKILL.md
+++ b/.agents/skills/frontend/uswds-form-flow/SKILL.md
@@ -29,6 +29,10 @@ output:
       - "Real CUI"
       - "Internal URLs"
 
+categories:
+  - "frontend"
+  - "compliance"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/.agents/skills/frontend/uswds-landing-page/SKILL.md
+++ b/.agents/skills/frontend/uswds-landing-page/SKILL.md
@@ -31,6 +31,9 @@ output:
       - "External CDN Links"
       - "Agency-Specific Branding"
 
+categories:
+  - "frontend"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/.agents/skills/frontend/uswds-prototype/SKILL.md
+++ b/.agents/skills/frontend/uswds-prototype/SKILL.md
@@ -31,6 +31,9 @@ output:
       - "External CDN Links"
       - "Agency-Specific Branding"
 
+categories:
+  - "frontend"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/.agents/skills/outreach/explainer-gif/SKILL.md
+++ b/.agents/skills/outreach/explainer-gif/SKILL.md
@@ -30,6 +30,9 @@ output:
       - "Real CUI"
       - "Internal URLs"
 
+categories:
+  - "documentation"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/.agents/skills/outreach/explainer-video/SKILL.md
+++ b/.agents/skills/outreach/explainer-video/SKILL.md
@@ -31,6 +31,10 @@ output:
       - "Internal URLs"
       - "External CDN Links"
 
+categories:
+  - "documentation"
+  - "supply-chain"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/.agents/skills/over-engineering-review/SKILL.md
+++ b/.agents/skills/over-engineering-review/SKILL.md
@@ -27,6 +27,10 @@ output:
       - "Real CUI"
       - "Internal URLs"
 
+categories:
+  - "review"
+  - "development"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/.agents/skills/secure-code-review/SKILL.md
+++ b/.agents/skills/secure-code-review/SKILL.md
@@ -45,6 +45,17 @@ tags:
   - "owasp"
   - "vulnerabilities"
 
+categories:
+  - "security"
+  - "review"
+
+risk_tier: moderate
+human_review_required: true
+allowed_tools: []
+network_policy: deny
+write_policy: deny
+script_policy: deny
+
 portability:
   opencode: true
   cursor: true

--- a/.agents/skills/test-generation/SKILL.md
+++ b/.agents/skills/test-generation/SKILL.md
@@ -28,6 +28,9 @@ output:
       - "Real CUI"
       - "Internal URLs"
 
+categories:
+  - "testing"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -8,115 +8,232 @@ patterns:
     title: Documentation Review
     type: skill
     status: experimental
+    categories:
+    - documentation
+    - review
   - path: skills/over-engineering-review/SKILL.md
     id: over-engineering-review
     title: Over-Engineering Review
     type: skill
     status: experimental
+    categories:
+    - review
+    - development
   - path: skills/dependency-analysis/SKILL.md
     id: dependency-analysis
     title: Dependency Security Analysis
     type: skill
     status: experimental
+    categories:
+    - security
+    - dependencies
+    - supply-chain
   - path: skills/test-generation/SKILL.md
     id: test-generation
     title: Test Case Generation
     type: skill
     status: experimental
+    categories:
+    - testing
   - path: skills/secure-code-review/SKILL.md
     id: secure-code-review
     title: Secure Code Review
     type: skill
     status: experimental
+    categories:
+    - security
+    - review
   - path: skills/outreach/explainer-video/SKILL.md
     id: explainer-video
     title: Explainer Video (HTML to MP4)
     type: skill
     status: experimental
+    categories:
+    - documentation
+    - supply-chain
   - path: skills/outreach/explainer-gif/SKILL.md
     id: explainer-gif
     title: Explainer GIF (Terminal Screencast)
     type: skill
     status: experimental
+    categories:
+    - documentation
   - path: skills/frontend/uswds-prototype/SKILL.md
     id: uswds-prototype
     title: USWDS Front-End Prototype
     type: skill
     status: experimental
+    categories:
+    - frontend
   - path: skills/frontend/uswds-landing-page/SKILL.md
     id: uswds-landing-page
     title: USWDS Service Landing Page
     type: skill
     status: experimental
+    categories:
+    - frontend
   - path: skills/frontend/plain-language-review/SKILL.md
     id: plain-language-review
     title: Federal Plain Language Review
     type: skill
     status: experimental
+    categories:
+    - frontend
+    - documentation
+    - review
   - path: skills/frontend/federal-service-blueprint/SKILL.md
     id: federal-service-blueprint
     title: Federal Service Blueprint
     type: skill
     status: experimental
+    categories:
+    - frontend
+    - compliance
+    - documentation
   - path: skills/frontend/accessibility-review/SKILL.md
     id: accessibility-review
     title: Federal Accessibility Review
     type: skill
     status: experimental
+    categories:
+    - frontend
+    - review
+    - compliance
   - path: skills/frontend/uswds-form-flow/SKILL.md
     id: uswds-form-flow
     title: USWDS Accessible Form Flow
     type: skill
     status: experimental
+    categories:
+    - frontend
+    - compliance
   prompts:
   - path: prompts/review/qa-round/SKILL.md
     id: qa-round
     title: QA Round Review
     type: prompt
     status: experimental
+    categories:
+    - testing
+    - review
   - path: prompts/planning/implementation-plan/SKILL.md
     id: implementation-plan
     title: Implementation Plan Generator
     type: prompt
     status: experimental
+    categories:
+    - development
   - path: prompts/security/safe-code-review/SKILL.md
     id: safe-code-review
     title: Security-Focused Code Review
     type: prompt
     status: experimental
+    categories:
+    - security
+    - review
   agents:
   - path: agents/documentation/AGENTS.md
     id: documentation-agent
     title: Documentation Agent Instructions
     type: agent
     status: experimental
+    categories:
+    - documentation
   - path: agents/general/AGENTS.md
     id: general-agent
     title: General Agent Instructions
     type: agent
     status: experimental
+    categories:
+    - development
   - path: agents/security-review/AGENTS.md
     id: security-review-agent
     title: Security Review Agent Instructions
     type: agent
     status: experimental
+    categories:
+    - security
+    - review
   workflows:
   - path: workflows/issue-to-merge-request/SKILL.md
     id: issue-to-merge-request
     title: Issue to Merge Request Workflow
     type: workflow
     status: experimental
+    categories:
+    - development
+    - review
+    - testing
   - path: workflows/qa-round/SKILL.md
     id: qa-workflow
     title: QA Round Workflow
     type: workflow
     status: experimental
+    categories:
+    - testing
+    - review
   lessons:
   - path: lessons-learned/example-agentic-session/SKILL.md
     id: example-agentic-session
     title: Example Agentic Coding Session
     type: lesson
     status: experimental
+    categories:
+    - security
+    - documentation
+categories:
+  security:
+  - dependency-analysis
+  - example-agentic-session
+  - safe-code-review
+  - secure-code-review
+  - security-review-agent
+  development:
+  - general-agent
+  - implementation-plan
+  - issue-to-merge-request
+  - over-engineering-review
+  review:
+  - accessibility-review
+  - documentation-review
+  - issue-to-merge-request
+  - over-engineering-review
+  - plain-language-review
+  - qa-round
+  - qa-workflow
+  - safe-code-review
+  - secure-code-review
+  - security-review-agent
+  testing:
+  - issue-to-merge-request
+  - qa-round
+  - qa-workflow
+  - test-generation
+  documentation:
+  - documentation-agent
+  - documentation-review
+  - example-agentic-session
+  - explainer-gif
+  - explainer-video
+  - federal-service-blueprint
+  - plain-language-review
+  dependencies:
+  - dependency-analysis
+  supply-chain:
+  - dependency-analysis
+  - explainer-video
+  compliance:
+  - accessibility-review
+  - federal-service-blueprint
+  - uswds-form-flow
+  incident-response: []
+  frontend:
+  - accessibility-review
+  - federal-service-blueprint
+  - plain-language-review
+  - uswds-form-flow
+  - uswds-landing-page
+  - uswds-prototype
 stats:
   total_patterns: 22
   skills: 13

--- a/agents/documentation/AGENTS.md
+++ b/agents/documentation/AGENTS.md
@@ -28,6 +28,9 @@ output:
       - "Real CUI"
       - "Internal URLs"
 
+categories:
+  - "documentation"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/agents/general/AGENTS.md
+++ b/agents/general/AGENTS.md
@@ -28,6 +28,9 @@ output:
       - "Real CUI"
       - "Internal URLs"
 
+categories:
+  - "development"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/agents/security-review/AGENTS.md
+++ b/agents/security-review/AGENTS.md
@@ -33,6 +33,17 @@ output:
 quality_gates:
   readability_max_grade: 10
   citations_required: false
+
+categories:
+  - "security"
+  - "review"
+
+risk_tier: moderate
+human_review_required: true
+allowed_tools: []
+network_policy: deny
+write_policy: deny
+script_policy: deny
 ---
 
 # Security Review Agent Instructions

--- a/lessons-learned/example-agentic-session/SKILL.md
+++ b/lessons-learned/example-agentic-session/SKILL.md
@@ -43,6 +43,15 @@ quality_gates:
 
 # Recommended fields
 tags: ["documentation", "security", "multi-pattern", "success"]
+categories:
+  - "security"
+  - "documentation"
+risk_tier: low
+human_review_required: true
+allowed_tools: []
+network_policy: deny
+write_policy: deny
+script_policy: deny
 scope:
   intended_use:
     - "Learn from successful use of multiple patterns"

--- a/prompts/planning/implementation-plan/SKILL.md
+++ b/prompts/planning/implementation-plan/SKILL.md
@@ -28,6 +28,9 @@ output:
       - "Real CUI"
       - "Internal URLs"
 
+categories:
+  - "development"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/prompts/review/qa-round/SKILL.md
+++ b/prompts/review/qa-round/SKILL.md
@@ -29,6 +29,10 @@ output:
       - "Real CUI"
       - "Internal URLs"
 
+categories:
+  - "testing"
+  - "review"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/prompts/security/safe-code-review/SKILL.md
+++ b/prompts/security/safe-code-review/SKILL.md
@@ -48,6 +48,17 @@ tags:
   - "owasp"
   - "vulnerabilities"
 
+categories:
+  - "security"
+  - "review"
+
+risk_tier: moderate
+human_review_required: true
+allowed_tools: []
+network_policy: deny
+write_policy: deny
+script_policy: deny
+
 portability:
   opencode: true
   cursor: true

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -22,6 +22,12 @@
       "description": "Unique pattern identifier in kebab-case",
       "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
     },
+    "description": {
+      "type": "string",
+      "description": "Short human-readable summary of the pattern (1-2 sentences)",
+      "minLength": 3,
+      "maxLength": 300
+    },
     "version": {
       "type": "string",
       "description": "Semantic version (MAJOR.MINOR.PATCH)",
@@ -141,6 +147,69 @@
       "type": "array",
       "description": "Keywords for discoverability",
       "items": {"type": "string"}
+    },
+    "categories": {
+      "type": "array",
+      "description": "Canonical taxonomy axis (closed controlled vocabulary). Multi-label; directories stay physical/organizational only.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "security",
+          "development",
+          "review",
+          "testing",
+          "documentation",
+          "dependencies",
+          "supply-chain",
+          "compliance",
+          "incident-response",
+          "frontend"
+        ]
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "risk_tier": {
+      "type": "string",
+      "description": "Risk tier of the skill's actions (security-governance field; required for security skills via validator).",
+      "enum": ["low", "moderate", "high"]
+    },
+    "human_review_required": {
+      "type": "boolean",
+      "description": "When true, output of this skill must be reviewed by a human before action (security-governance field)."
+    },
+    "allowed_tools": {
+      "type": "array",
+      "description": "Allowlist of tools the skill may use; deny-by-default for anything not listed (security-governance field).",
+      "items": {"type": "string"}
+    },
+    "network_policy": {
+      "type": "string",
+      "description": "Network egress policy for the skill (security-governance field).",
+      "enum": ["deny", "allowlist", "allow"]
+    },
+    "write_policy": {
+      "type": "string",
+      "description": "Filesystem write policy for the skill (security-governance field).",
+      "enum": ["deny", "workspace", "allow"]
+    },
+    "script_policy": {
+      "type": "string",
+      "description": "Whether the skill may author or execute scripts (security-governance field).",
+      "enum": ["deny", "author-only", "allow"]
+    },
+    "source_inspiration": {
+      "type": "array",
+      "description": "Public sources used as INSPIRATION only (never copied). Each entry records the intake provenance (security-governance field).",
+      "items": {
+        "type": "object",
+        "required": ["url", "license", "intake_record"],
+        "properties": {
+          "url": {"type": "string"},
+          "license": {"type": "string"},
+          "intake_record": {"type": "string"}
+        }
+      }
     },
     "scope": {
       "type": "object",

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -65,6 +65,7 @@ def find_patterns(root: Path) -> dict[str, list[dict]]:
                         "title": frontmatter.get("title", "Untitled"),
                         "type": frontmatter.get("type", pattern_type),
                         "status": frontmatter.get("status", "experimental"),
+                        "categories": frontmatter.get("categories", []),
                     }
                 )
 
@@ -83,10 +84,44 @@ def find_patterns(root: Path) -> dict[str, list[dict]]:
                             "title": frontmatter.get("title", "Untitled"),
                             "type": "agent",
                             "status": frontmatter.get("status", "experimental"),
+                            "categories": frontmatter.get("categories", []),
                         }
                     )
 
     return patterns
+
+
+# Closed controlled vocabulary for the categories facet (issue #151). Kept in sync
+# with schemas/skill.schema.json properties.categories.items.enum.
+CATEGORY_VOCAB = [
+    "security",
+    "development",
+    "review",
+    "testing",
+    "documentation",
+    "dependencies",
+    "supply-chain",
+    "compliance",
+    "incident-response",
+    "frontend",
+]
+
+
+def facet_by_category(patterns: dict[str, list[dict]]) -> dict[str, list[str]]:
+    """Build a category -> [pattern id] facet over all patterns.
+
+    Every term in the controlled vocabulary appears (empty list if unused) so the
+    facet is a stable, complete view of the taxonomy.
+    """
+    facets: dict[str, list[str]] = {term: [] for term in CATEGORY_VOCAB}
+    for items in patterns.values():
+        for item in items:
+            for cat in item.get("categories", []) or []:
+                if cat in facets:
+                    facets[cat].append(item["id"])
+    for term in facets:
+        facets[term].sort()
+    return facets
 
 
 def generate_index(root: Path) -> dict:
@@ -101,6 +136,7 @@ def generate_index(root: Path) -> dict:
         "repo": "GSA-TTS/agentic-coding-patterns",
         "description": "Community patterns for agentic coding",
         "patterns": patterns,
+        "categories": facet_by_category(patterns),
         "stats": {
             "total_patterns": total,
             "skills": len(patterns["skills"]),

--- a/scripts/tests/test_generate_index.py
+++ b/scripts/tests/test_generate_index.py
@@ -153,3 +153,29 @@ class TestGenerateIndex:
 
         assert index["schema_version"] == "1.0"
         assert all(len(patterns) == 0 for patterns in index["patterns"].values())
+
+
+class TestCategoryFacet:
+    """Tests for the categories facet (issue #151)."""
+
+    def test_facet_includes_full_vocab(self, tmp_path):
+        """Every controlled-vocab term appears in the facet, even if unused."""
+        from scripts.generate_index import CATEGORY_VOCAB
+
+        index = generate_index(tmp_path)
+        assert set(index["categories"].keys()) == set(CATEGORY_VOCAB)
+        # Empty repo -> every facet bucket empty.
+        assert all(v == [] for v in index["categories"].values())
+
+    def test_facet_maps_categories_to_ids(self, temp_repo):
+        """A skill's declared categories show up under the right facet buckets."""
+        # temp_repo's skill has no categories by default; add one and rebuild.
+        skill = temp_repo / "skills" / "test-skill" / "SKILL.md"
+        text = skill.read_text()
+        text = text.replace("status: experimental", "status: experimental\ncategories: [security, review]", 1)
+        skill.write_text(text)
+
+        index = generate_index(temp_repo)
+        assert "test-skill" in index["categories"]["security"]
+        assert "test-skill" in index["categories"]["review"]
+        assert index["categories"]["frontend"] == []

--- a/scripts/tests/test_validate_frontmatter.py
+++ b/scripts/tests/test_validate_frontmatter.py
@@ -1,10 +1,12 @@
 """Tests for validate_frontmatter.py"""
 
 import json
+from pathlib import Path
 
 import pytest
 
 from scripts.validate_frontmatter import (
+    check_security_governance,
     extract_frontmatter,
     find_pattern_files,
     load_schema,
@@ -191,7 +193,7 @@ class TestValidateFile:
         file_path = temp_repo / "test.md"
         file_path.write_text(valid_skill_content)
 
-        success, errors = validate_file(file_path, schema)
+        success, errors, _warnings = validate_file(file_path, schema)
 
         assert success is True
         assert errors == []
@@ -211,7 +213,7 @@ Content.
         file_path = temp_repo / "test.md"
         file_path.write_text(content)
 
-        success, errors = validate_file(file_path, schema)
+        success, errors, _warnings = validate_file(file_path, schema)
 
         assert success is False
         assert len(errors) > 0
@@ -225,7 +227,7 @@ Content.
         file_path = temp_repo / "test.md"
         file_path.write_text(invalid_schema_content)
 
-        success, errors = validate_file(file_path, schema)
+        success, errors, _warnings = validate_file(file_path, schema)
 
         assert success is False
         assert len(errors) > 0
@@ -237,7 +239,7 @@ Content.
 
         file_path = temp_repo / "nonexistent.md"
 
-        success, errors = validate_file(file_path, schema)
+        success, errors, _warnings = validate_file(file_path, schema)
 
         assert success is False
         assert "failed to read" in errors[0].lower()
@@ -250,7 +252,64 @@ Content.
         file_path = temp_repo / "test.md"
         file_path.write_text(missing_frontmatter_content)
 
-        success, errors = validate_file(file_path, schema)
+        success, errors, _warnings = validate_file(file_path, schema)
 
         assert success is False
         assert "no valid yaml frontmatter" in errors[0].lower()
+
+
+class TestSecurityGovernance:
+    """Tests for the categories-gated security-governance rules (#151 + recon S4)."""
+
+    def test_security_category_requires_governance_fields(self, tmp_path):
+        """categories:[security] without governance fields => error."""
+        fm = {
+            "id": "x",
+            "categories": ["security", "review"],
+            "tags": ["security"],
+        }
+        errors, warnings = check_security_governance(tmp_path / "x" / "SKILL.md", fm)
+        assert errors, "expected an error for missing governance fields"
+        assert "security-governance field" in errors[0]
+        assert warnings == []
+
+    def test_security_category_with_governance_passes(self, tmp_path):
+        """categories:[security] WITH all governance fields => no error/warning."""
+        fm = {
+            "id": "x",
+            "categories": ["security"],
+            "risk_tier": "moderate",
+            "human_review_required": True,
+            "allowed_tools": [],
+            "network_policy": "deny",
+            "write_policy": "deny",
+            "script_policy": "deny",
+        }
+        errors, warnings = check_security_governance(tmp_path / "x" / "SKILL.md", fm)
+        assert errors == []
+        assert warnings == []
+
+    def test_s4_heuristic_warns_on_unlabeled_security_skill(self, tmp_path):
+        """Security-relevant by tags but not self-labeled => warning, not error."""
+        fm = {"id": "x", "categories": ["review"], "tags": ["owasp", "vulnerability"]}
+        errors, warnings = check_security_governance(tmp_path / "x" / "SKILL.md", fm)
+        assert errors == []
+        assert warnings and "does not declare categories: [security]" in warnings[0]
+
+    def test_s4_heuristic_warns_on_security_path(self, tmp_path):
+        """Path under a security/ dir segment triggers the heuristic too."""
+        fm = {"id": "x", "categories": ["review"], "tags": []}
+        errors, warnings = check_security_governance(
+            Path("agents/security-review/AGENTS.md"), fm
+        )
+        assert errors == []
+        assert warnings and "path:security" in warnings[0]
+
+    def test_non_security_skill_no_warning(self, tmp_path):
+        """A genuinely non-security skill is silent."""
+        fm = {"id": "x", "categories": ["frontend"], "tags": ["uswds", "html"]}
+        errors, warnings = check_security_governance(
+            Path("frontend/uswds-prototype/SKILL.md"), fm
+        )
+        assert errors == []
+        assert warnings == []

--- a/scripts/tests/test_validate_frontmatter.py
+++ b/scripts/tests/test_validate_frontmatter.py
@@ -299,17 +299,13 @@ class TestSecurityGovernance:
     def test_s4_heuristic_warns_on_security_path(self, tmp_path):
         """Path under a security/ dir segment triggers the heuristic too."""
         fm = {"id": "x", "categories": ["review"], "tags": []}
-        errors, warnings = check_security_governance(
-            Path("agents/security-review/AGENTS.md"), fm
-        )
+        errors, warnings = check_security_governance(Path("agents/security-review/AGENTS.md"), fm)
         assert errors == []
         assert warnings and "path:security" in warnings[0]
 
     def test_non_security_skill_no_warning(self, tmp_path):
         """A genuinely non-security skill is silent."""
         fm = {"id": "x", "categories": ["frontend"], "tags": ["uswds", "html"]}
-        errors, warnings = check_security_governance(
-            Path("frontend/uswds-prototype/SKILL.md"), fm
-        )
+        errors, warnings = check_security_governance(Path("frontend/uswds-prototype/SKILL.md"), fm)
         assert errors == []
         assert warnings == []

--- a/scripts/validate_frontmatter.py
+++ b/scripts/validate_frontmatter.py
@@ -63,9 +63,7 @@ def _collect_signal_text(frontmatter: dict[str, Any]) -> set[str]:
     return tokens
 
 
-def check_security_governance(
-    file_path: Path, frontmatter: dict[str, Any]
-) -> tuple[list[str], list[str]]:
+def check_security_governance(file_path: Path, frontmatter: dict[str, Any]) -> tuple[list[str], list[str]]:
     """Apply the categories-gated security-governance rules.
 
     Returns (errors, warnings):
@@ -80,9 +78,7 @@ def check_security_governance(
     is_security = isinstance(categories, list) and "security" in categories
 
     if is_security:
-        missing = [
-            f for f in SECURITY_GOVERNANCE_FIELDS if frontmatter.get(f) is None
-        ]
+        missing = [f for f in SECURITY_GOVERNANCE_FIELDS if frontmatter.get(f) is None]
         if missing:
             errors.append(
                 "categories includes 'security' but missing required "
@@ -102,9 +98,7 @@ def check_security_governance(
     signals |= _collect_signal_text(frontmatter) & SECURITY_SIGNAL_KEYWORDS
     if signals:
         warnings.append(
-            "looks security-relevant ("
-            + ", ".join(sorted(signals))
-            + ") but does not declare categories: [security]; "
+            "looks security-relevant (" + ", ".join(sorted(signals)) + ") but does not declare categories: [security]; "
             "add it (and the security-governance fields) or confirm it is out of scope"
         )
 

--- a/scripts/validate_frontmatter.py
+++ b/scripts/validate_frontmatter.py
@@ -15,6 +15,101 @@ from typing import Any
 import jsonschema
 import yaml
 
+# Security-governance fields required when a skill declares categories: [security].
+# Additive gate (issue #151): only enforced for security skills, so the existing
+# non-security skills keep validating.
+SECURITY_GOVERNANCE_FIELDS = [
+    "risk_tier",
+    "human_review_required",
+    "allowed_tools",
+    "network_policy",
+    "write_policy",
+    "script_policy",
+]
+
+# Heuristic signals that a skill is security-relevant even if it did NOT self-label
+# categories: [security] (recon finding S4 — prevents dodging the governance gate
+# by simply omitting the label). This is advisory (warning), not a hard failure.
+SECURITY_SIGNAL_KEYWORDS = {
+    "security",
+    "secure",
+    "vulnerability",
+    "vuln",
+    "exploit",
+    "injection",
+    "secrets",
+    "secret",
+    "credential",
+    "backdoor",
+    "least-privilege",
+    "privilege",
+    "owasp",
+    "cve",
+    "threat",
+    "incident",
+    "malware",
+    "supply-chain",
+}
+
+
+def _collect_signal_text(frontmatter: dict[str, Any]) -> set[str]:
+    """Lowercased token set from tags + triggers for the S4 heuristic."""
+    tokens: set[str] = set()
+    for field in ("tags", "triggers"):
+        values = frontmatter.get(field) or []
+        if isinstance(values, list):
+            for v in values:
+                tokens.add(str(v).lower())
+    return tokens
+
+
+def check_security_governance(
+    file_path: Path, frontmatter: dict[str, Any]
+) -> tuple[list[str], list[str]]:
+    """Apply the categories-gated security-governance rules.
+
+    Returns (errors, warnings):
+    - error  if categories contains 'security' but a governance field is missing
+    - warning if the skill looks security-relevant (dir/trigger/tag) but did NOT
+      declare categories: [security] (recon S4 — self-label dodge).
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    categories = frontmatter.get("categories") or []
+    is_security = isinstance(categories, list) and "security" in categories
+
+    if is_security:
+        missing = [
+            f for f in SECURITY_GOVERNANCE_FIELDS if frontmatter.get(f) is None
+        ]
+        if missing:
+            errors.append(
+                "categories includes 'security' but missing required "
+                f"security-governance field(s): {', '.join(missing)}"
+            )
+        return errors, warnings
+
+    # S4 heuristic: not self-labeled security — does it look security-relevant?
+    signals: set[str] = set()
+    # Match a `security`/`secure` path *segment* (e.g. agents/security-review/),
+    # not any substring (tmp dirs etc. can contain "security" incidentally).
+    for part in file_path.parts[:-1]:
+        seg = part.lower()
+        if seg == "security" or seg.startswith("security-") or seg.startswith("secure-"):
+            signals.add("path:security")
+            break
+    signals |= _collect_signal_text(frontmatter) & SECURITY_SIGNAL_KEYWORDS
+    if signals:
+        warnings.append(
+            "looks security-relevant ("
+            + ", ".join(sorted(signals))
+            + ") but does not declare categories: [security]; "
+            "add it (and the security-governance fields) or confirm it is out of scope"
+        )
+
+    return errors, warnings
+
 
 def load_schema(schema_path: Path) -> dict[str, Any]:
     """Load JSON Schema from file."""
@@ -45,28 +140,33 @@ def find_pattern_files(root: Path) -> list[Path]:
     return sorted(patterns)
 
 
-def validate_file(file_path: Path, schema: dict[str, Any]) -> tuple[bool, list[str]]:
-    """Validate a single file. Returns (success, errors)."""
+def validate_file(file_path: Path, schema: dict[str, Any]) -> tuple[bool, list[str], list[str]]:
+    """Validate a single file. Returns (success, errors, warnings)."""
     # Read file
     try:
         content = file_path.read_text()
     except Exception as e:
-        return False, [f"Failed to read file: {e}"]
+        return False, [f"Failed to read file: {e}"], []
 
     # Extract frontmatter
     frontmatter = extract_frontmatter(content)
     if frontmatter is None:
-        return False, ["No valid YAML frontmatter found"]
+        return False, ["No valid YAML frontmatter found"], []
 
     # Validate against schema
     try:
         jsonschema.validate(instance=frontmatter, schema=schema)
     except jsonschema.ValidationError as e:
-        return False, [f"Schema validation failed: {e.message}"]
+        return False, [f"Schema validation failed: {e.message}"], []
     except jsonschema.SchemaError as e:
-        return False, [f"Invalid schema: {e.message}"]
+        return False, [f"Invalid schema: {e.message}"], []
 
-    return True, []
+    # Categories-gated security-governance checks (issue #151 + recon S4)
+    gov_errors, gov_warnings = check_security_governance(file_path, frontmatter)
+    if gov_errors:
+        return False, gov_errors, gov_warnings
+
+    return True, [], gov_warnings
 
 
 def main() -> int:
@@ -92,9 +192,10 @@ def main() -> int:
 
     # Validate each file
     failed = 0
+    warned = 0
     for file_path in files:
         rel_path = file_path.relative_to(root)
-        success, errors = validate_file(file_path, schema)
+        success, errors, warnings = validate_file(file_path, schema)
 
         if success:
             print(f"✓ {rel_path}")
@@ -104,10 +205,16 @@ def main() -> int:
                 print(f"  - {error}")
             failed += 1
 
+        for warning in warnings:
+            print(f"  ⚠ {rel_path}: {warning}")
+            warned += 1
+
     # Summary
     total = len(files)
     passed = total - failed
     print(f"\n{passed}/{total} files passed validation")
+    if warned:
+        print(f"{warned} warning(s) (advisory; do not fail the build)")
 
     return 1 if failed > 0 else 0
 

--- a/workflows/issue-to-merge-request/SKILL.md
+++ b/workflows/issue-to-merge-request/SKILL.md
@@ -31,6 +31,11 @@ output:
       - "Real CUI"
       - "Internal URLs"
 
+categories:
+  - "development"
+  - "review"
+  - "testing"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/workflows/qa-round/SKILL.md
+++ b/workflows/qa-round/SKILL.md
@@ -31,6 +31,10 @@ output:
       - "Real CUI"
       - "Internal URLs"
 
+categories:
+  - "testing"
+  - "review"
+
 quality_gates:
   readability_max_grade: 10
   citations_required: false


### PR DESCRIPTION
Closes #151 (M1, EPIC #143). First substantive Security Skills Pack PR — establishes the taxonomy + governance foundation before any security skills are authored.

> **Behavioral/schema change — for human review, NOT admin-merged** (workspace standing rule). `needs-human-review` applied.

## What
**Schema (`schemas/skill.schema.json`) — all additive, no existing skill breaks:**
- `categories`: closed **10-term** controlled vocab (`security, development, review, testing, documentation, dependencies, supply-chain, compliance, incident-response, frontend`), multi-label, `uniqueItems`. Directories stay physical-only.
- security-governance fields (optional at schema level): `risk_tier`, `human_review_required`, `allowed_tools`, `network_policy`, `write_policy`, `script_policy`, `source_inspiration`.
- `description`: now defined in the schema (recon **A4** — was de-facto required but unvalidated).

**Validator (`scripts/validate_frontmatter.py`):**
- **Hard gate:** `categories:[security]` ⇒ the 6 governance fields are required (fails validation if missing).
- **S4 heuristic (recon finding):** a skill that *looks* security-relevant (path segment `security-*`/`secure-*`, or security tags/triggers like `owasp`/`vulnerability`/`secrets`) but does **not** declare `categories:[security]` emits an **advisory warning** — never fails the build — so the governance gate can't be dodged by omitting the self-label.

**Index (`scripts/generate_index.py`):** `INDEX.yaml` now has a `categories` facet (vocab term → `[pattern id]`), every term present even if unused; per-pattern entries gain `categories`.

**Backfill (no file moves):** all 21 real patterns get `categories` (templates excluded). The **5 security-relevant existing patterns** (`dependency-analysis`, `secure-code-review`, `safe-code-review`, `example-agentic-session`, `security-review-agent`) now carry `categories:[security]` + full governance fields (deny-by-default `network/write/script_policy`, `human_review_required: true`).

## Decisions for reviewers
- **Vocab kept at exactly 10 per the approved plan.** `incident-response` has **0 current fits** — intentional forward-looking slot for M2's `incident-evidence-review`. `outreach/` skills mapped to `documentation`; `planning` mapped to `development` (closest in-vocab fits). Flagging in case you'd rather add `outreach`/`planning` — that would diverge from the closed vocab in #151.
- **Hardened the 5 existing security skills now** (vs deferring to M2) per maintainer direction; governance values are conservative deny-by-default and open to review.

## Verification
- `make validate` → all pass, **0 warnings** (the 5 security skills are now gated, not warned)
- `python scripts/generate_index.py --check` → up to date
- `PYTHONPATH=scripts pytest scripts/tests` → **120 passed** (+9 new: gate, S4 heuristic, facet)
- `ruff check` + `markdownlint-cli2` → clean

AI-assisted: yes.