### PR TITLE
docs(security-skills): governance standard + intake checklist + AGENTS.md alignment (#150, #149, #152)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 ---
 id: agentic-patterns-agent-rules
-version: "1.0.0"
+version: "1.1.0"
 title: "Agentic Coding Patterns — Agent Behavior Rules"
 description: "Behavioral contract for AI agents contributing to and using community patterns for agentic coding"
 type: agent
@@ -17,7 +17,7 @@ output:
 quality_gates:
   readability_max_grade: 10
   citations_required: false
-last_updated: "2026-05-20"
+last_updated: "2026-06-24"
 ---
 
 # AGENTS.md — Agentic Coding Patterns Repository
@@ -139,10 +139,65 @@ quality_gates:
 **Recommended fields:**
 
 - `triggers`: Keywords for pattern discovery
-- `tags`: For categorization
+- `tags`: Free-form keywords for discovery
 - `portability`: Tool compatibility flags
 - `scope.intended_use`: What the pattern is for
 - `scope.exclusions`: What NOT to use it for
+
+### 4.1 Categories Taxonomy
+
+`categories` is the **canonical taxonomy axis** — a closed, controlled
+vocabulary used for INDEX faceting and the security-governance gate. Directory
+location is physical/organizational only and does **not** determine taxonomy.
+A pattern may carry multiple categories (it is often both `development` and
+`review`).
+
+Controlled vocabulary (10 terms, closed enum — see `schemas/skill.schema.json`):
+
+```
+security, development, review, testing, documentation,
+dependencies, supply-chain, compliance, incident-response, frontend
+```
+
+`tags` stays free-form for discovery; `categories` is the controlled axis.
+
+### 4.2 Security-Governance Fields
+
+A **security skill** is any pattern that declares `categories: [security]`. Such
+patterns MUST also declare the security-governance fields, enforced by the
+validator (a missing field fails validation):
+
+```yaml
+categories: ["security", "review"]
+risk_tier: moderate            # low | moderate | high
+human_review_required: true    # always true for security skills
+allowed_tools: []              # deny-by-default allowlist
+network_policy: deny           # deny | allowlist | allow
+write_policy: deny             # deny | workspace | allow
+script_policy: deny            # deny | author-only | allow
+# source_inspiration: [...]    # optional; public sources used as inspiration only
+```
+
+These fields are **additive and optional at the schema level** (existing
+non-security patterns are unaffected) but **required for security skills** via
+the validator. The validator also emits an **advisory warning** when a pattern
+looks security-relevant (by path segment, tags, or triggers) but does not
+declare `categories: [security]`, so the gate cannot be dodged by omitting the
+label.
+
+The behavioral authority for security skills is the **playbook**
+[`AGENTS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md);
+this repo references it and does not duplicate policy. See
+[`docs/security-skill-governance.md`](docs/security-skill-governance.md) for the
+full governance model.
+
+### 4.3 Public-Source Inspiration (No Copying)
+
+Patterns may be **inspired** by public skills, blogs, or tools, but MUST NOT copy
+scripts, prompt bodies, or full skill bodies from them. Each public source used
+as inspiration gets an intake record
+([`templates/security-skill-intake.md`](templates/security-skill-intake.md))
+referenced from the pattern's PR, and is recorded under `source_inspiration`.
 
 ---
 
@@ -392,6 +447,7 @@ make clean              # Remove generated files
 
 | Date | Version | Change |
 |------|---------|--------|
+| 2026-06-24 | 1.1.0 | Add §4.1 categories taxonomy, §4.2 security-governance fields, §4.3 public-source no-copy rule; reference playbook authority |
 | 2026-05-20 | 0.1.0 | Initial release for patterns repository |
 
 ---

--- a/docs/security-skill-governance.md
+++ b/docs/security-skill-governance.md
@@ -1,0 +1,122 @@
+# Security Skill Governance Standard
+
+> **Authority:** The [agentic-coding-playbook `AGENTS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md)
+> and [`docs/CODING_PRACTICES.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md)
+> are the behavioral and policy authority. This document references that policy;
+> it does not duplicate or restate it. Where this standard and the playbook
+> appear to differ, the playbook wins.
+
+This standard defines the governance model for **security skills** in this
+repository — what they are, the hard safety rules they operate under, and the
+review and tool/network/write/script policies they must declare.
+
+## Priority order
+
+Security skills follow the playbook priority order, unchanged:
+
+```
+safety > correctness > compliance > simplicity > performance
+```
+
+When a security skill's guidance would trade safety for any lower priority, the
+skill MUST choose safety.
+
+## What is a "security skill"
+
+A pattern is a **security skill** when its frontmatter declares:
+
+```yaml
+categories:
+  - security
+```
+
+`categories` is the canonical taxonomy axis (closed controlled vocabulary; see
+[`schemas/skill.schema.json`](../schemas/skill.schema.json)). Physical directory
+location is organizational only and does **not** determine whether a skill is a
+security skill — the `categories` label does.
+
+A skill is security-relevant (and SHOULD carry `categories: [security]`) when it
+reviews, produces, or reasons about: vulnerabilities, secrets/credentials,
+authentication/authorization, supply-chain or dependency risk, least-privilege
+and permission scope, prompt-injection / untrusted-input boundaries, incident
+evidence, or compliance claims about security controls.
+
+> The validator emits an **advisory warning** when a skill looks
+> security-relevant (by path segment, tags, or triggers) but does not declare
+> `categories: [security]`. The warning never fails the build; it exists so the
+> governance gate below cannot be silently dodged by omitting the label. Either
+> add the label (and the required fields) or confirm in review that the skill is
+> genuinely out of scope.
+
+## Hard safety rules (non-negotiable)
+
+Every security skill — and every artifact it instructs an agent to produce —
+MUST NOT contain:
+
+| Prohibited | Why |
+|------------|-----|
+| Secrets, API keys, tokens, passwords | Security risk; see playbook prohibited content |
+| Real PII, real CUI | Privacy / classification |
+| Internal URLs or hostnames | Information disclosure |
+| **Working exploit payloads / weaponized PoC code** | Responsible disclosure |
+| Live attack tooling or step-by-step intrusion recipes | Responsible disclosure |
+
+**Conceptual vulnerability descriptions and remediation guidance ARE allowed**
+(e.g. "this endpoint is vulnerable to SQL injection because input is concatenated
+into the query; use parameterized queries"). **A runnable exploit that
+demonstrates the vulnerability is NOT** — describe the class and the fix, never
+ship the weapon.
+
+## Required governance frontmatter
+
+A security skill (`categories: [security]`) MUST declare all of the following
+fields (enforced by the validator — a missing field fails validation):
+
+| Field | Meaning | Default posture |
+|-------|---------|-----------------|
+| `risk_tier` | `low` \| `moderate` \| `high` — blast radius of the skill's actions | choose the highest plausible tier |
+| `human_review_required` | bool — output must be human-reviewed before action | `true` for all security skills |
+| `allowed_tools` | allowlist of tools the skill may use | **deny-by-default**: list nothing the skill does not need |
+| `network_policy` | `deny` \| `allowlist` \| `allow` | `deny` unless a specific host is justified |
+| `write_policy` | `deny` \| `workspace` \| `allow` | `deny` for review skills; `workspace` only if it must write |
+| `script_policy` | `deny` \| `author-only` \| `allow` | `deny`; `author-only` for skills that draft (but never execute) scripts |
+
+Optional but recommended:
+
+| Field | Meaning |
+|-------|---------|
+| `source_inspiration` | public sources used as **inspiration only** (never copied); each entry records `url`, `license`, and a pointer to its intake record — see the [public skill intake checklist](../templates/security-skill-intake.md) |
+
+### Deny-by-default principle
+
+`allowed_tools`, `network_policy`, `write_policy`, and `script_policy` are
+**deny-by-default**. A security skill should request the *minimum* capability it
+needs and justify any grant above `deny` in its body. This mirrors the playbook's
+least-privilege posture.
+
+## Human-review gates
+
+- Every security skill carries `human_review_required: true` **and** the
+  `needs-human-review` label on its PR. No security skill is auto-merged or
+  admin-merged.
+- Behavioral-contract, `AGENTS.md`, and schema changes are **PR-only** (never
+  admin-merged) per the workspace standing rule.
+- One security skill per PR, so each gets a focused review.
+
+## Public-source inspiration (no copying)
+
+Security skills are frequently inspired by public skills, blog posts, or tools.
+Inspiration is allowed; **copying is not**. Before a security skill that draws on
+a public source is merged, an intake record (see
+[`templates/security-skill-intake.md`](../templates/security-skill-intake.md))
+MUST be completed and referenced from the PR. No public scripts, prompt bodies,
+or full skill bodies are copied into this repository.
+
+## References
+
+- Playbook behavioral authority: [`AGENTS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md)
+- Playbook coding/security practices: [`docs/CODING_PRACTICES.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md)
+- Playbook prompt-injection defense: [`docs/PROMPT-INJECTION-DEFENSE.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/PROMPT-INJECTION-DEFENSE.md)
+- Schema: [`schemas/skill.schema.json`](../schemas/skill.schema.json)
+- Taxonomy + governance fields: [`docs/security-skills-pack-plan.md`](security-skills-pack-plan.md)
+- Public-source intake: [`templates/security-skill-intake.md`](../templates/security-skill-intake.md)

--- a/templates/security-skill-intake.md
+++ b/templates/security-skill-intake.md
@@ -1,0 +1,73 @@
+# Public Skill Intake Checklist
+
+Use this checklist whenever a **security skill** (or any skill) draws on a
+**public source** — another skill, a blog post, a tool, or a repository — as
+**inspiration**. Inspiration is allowed; **copying is not**. Complete one intake
+record per public source and reference it from the skill's PR.
+
+> See the [Security Skill Governance Standard](../docs/security-skill-governance.md)
+> for how this fits the governance model, and the playbook
+> [`AGENTS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md)
+> for the behavioral authority.
+
+## Hard rule: no copying
+
+You MUST NOT copy from the public source into this repository:
+
+- ❌ Scripts or executable code
+- ❌ Prompt bodies / system prompts
+- ❌ Full skill bodies or substantial prose passages
+
+You MAY take:
+
+- ✅ Concepts, structure ideas, and the *categories of checks* to perform
+- ✅ Publicly known facts (e.g. "OWASP A03 is injection")
+
+When in doubt, write it yourself from understanding — do not paste.
+
+## Intake record (copy this block into the skill PR or a tracked note)
+
+```yaml
+intake:
+  skill_id: <the skill this inspires>
+  source:
+    name: <source name>
+    url: <source url>
+    license: <SPDX id or "unknown"; if license forbids reuse, note it>
+    type: <skill | blog | tool | repo | docs>
+  reviewed_by: <github handle>
+  review_date: <YYYY-MM-DD>
+  concepts_used: |
+    <what ideas/structure you took — in your own words>
+  content_NOT_imported: |
+    <explicit confirmation of what you deliberately did NOT copy
+     (scripts, prompt bodies, full skill text)>
+  scripts_present_in_source: <yes | no>
+  network_assumptions: |
+    <does the source assume network egress, external services, telemetry?
+     what did you do about it (deny-by-default here)?>
+  safety_concerns: |
+    <any weaponized payloads, unsafe shell, secret handling, prompt-injection
+     surface in the source — and how this skill avoids reproducing them>
+  license_concerns: |
+    <attribution required? share-alike? any reuse restriction?>
+  decision: <adopt-as-inspiration | reject | needs-more-review>
+  decision_notes: |
+    <why>
+```
+
+## Checklist (PR author confirms each)
+
+- [ ] No scripts, prompt bodies, or full skill bodies were copied from the source.
+- [ ] The source's license has been recorded; any reuse restriction is noted and respected.
+- [ ] If the source contains scripts, they were **not** imported (and the skill's `script_policy` reflects deny / author-only).
+- [ ] Network assumptions in the source were reviewed; this skill is **deny-by-default** on network unless a host is justified.
+- [ ] Any safety concern in the source (weaponized payloads, unsafe shell, secret handling) is explicitly **not** reproduced here.
+- [ ] The skill frontmatter records the source under `source_inspiration` (`url`, `license`, `intake_record`).
+- [ ] This intake record is referenced from the skill's PR.
+
+## References
+
+- [Security Skill Governance Standard](../docs/security-skill-governance.md)
+- [Skill schema](../schemas/skill.schema.json) (`source_inspiration` field)
+- Playbook authority: [`AGENTS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md)


### PR DESCRIPTION
Closes #150, #149, and #152 (M1, EPIC #143). Combined: the governance standard cross-links the intake checklist, and AGENTS.md links both — repo-wide Link Check would 404 if they merged separately.

> **Docs / behavioral-contract change — for human review, NOT admin-merged.** `needs-human-review` applied.

Closes #150 and #149 (M1, EPIC #143). Combined into one PR because the governance standard cross-links the intake checklist and the repo-wide link-check would 404 if they merged separately.

> **Docs/governance change — for human review, NOT admin-merged.** `needs-human-review` applied.

## #150 — `docs/security-skill-governance.md`
- References the playbook [`AGENTS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md) + `CODING_PRACTICES.md` as the behavioral **authority** (does not duplicate policy; playbook wins on conflict).
- States `safety > correctness > compliance > simplicity > performance`.
- Defines **"security skill" = `categories: [security]`** (the taxonomy label, not the directory); documents the validator's advisory **S4 warning** for security-relevant skills that don't self-label.
- **Hard safety rules:** no secrets / PII / CUI / internal URLs / **working exploit payloads**. Conceptual vuln descriptions + remediation **are** allowed; runnable exploits are **not**.
- **Required governance frontmatter** (`risk_tier`, `human_review_required`, `allowed_tools`, `network/write/script_policy`) with **deny-by-default** posture; optional `source_inspiration`.
- Human-review gates: `human_review_required` + `needs-human-review` label, PR-only, one skill per PR, never admin-merged.

## #149 — `templates/security-skill-intake.md`
- Intake record + checklist for any **public source used as INSPIRATION only**.
- Forbids copying scripts / prompt bodies / full skill bodies; records source/url/license/concepts-used/content-NOT-imported/scripts-present/network-assumptions/safety+license concerns/decision.
- Every later security-skill PR references an intake record.

## Dependency
Both reference the `categories` + governance fields introduced in **#151 (PR #185)**. They stand alone as docs but are most meaningful read alongside #185.

## Verification
- Relative links verified resolving (governance ↔ intake ↔ schema)
- `markdownlint-cli2` → 0 errors; `make validate` → all pass; `generate-check` → up to date

AI-assisted: yes.

## #152 — `AGENTS.md` alignment (folded in)
- §4.1 categories taxonomy (closed 10-term vocab; canonical axis; directories physical-only).
- §4.2 security-governance fields (additive; required for security skills via validator; documents the advisory S4 warning).
- §4.3 public-source no-copy rule + intake template reference.
- References the playbook `AGENTS.md` as behavioral authority (no policy duplication).
- Frontmatter `1.0.0` -> `1.1.0`; `last_updated` bump; version-history row.