### PR TITLE
feat(agents): add zscaler-ca-certificate sbx mixin kit

### DIFF
--- a/agents/isolation/sbx/kits/README.md
+++ b/agents/isolation/sbx/kits/README.md
@@ -14,6 +14,7 @@ not agent behavior. (Behavioral patterns live in `skills/`, `prompts/`, etc.)
 |-----|---------|
 | [`usai-provider-kit/`](usai-provider-kit/) | Configure the agent to use the GSA USAi model provider (OpenCode today), with egress allow-listed. |
 | [`playbook-kit/`](playbook-kit/) | Clone the GSA agentic-coding-playbook at startup and link its `AGENTS.md` + skills into each agent's search paths. |
+| [`zscaler-ca-certificate/`](zscaler-ca-certificate/) | Install the public Zscaler Root CA into the sandbox trust store so HTTPS works behind a Zscaler inspecting proxy. Adapts the Docker CA example to work on the opencode base (initFiles + startup). |
 
 Each kit is self-contained: a `spec.yaml`, any `files/` payload, a
 `scripts/verify` host-side check, a `README.md`, a `TROUBLESHOOTING.md`, and

--- a/agents/isolation/sbx/kits/zscaler-ca-certificate/README.md
+++ b/agents/isolation/sbx/kits/zscaler-ca-certificate/README.md
@@ -1,0 +1,142 @@
+# zscaler-ca-certificate (sbx mixin kit)
+
+An [sbx](https://docs.docker.com/ai/sandboxes/) **mixin kit** that installs the
+public **Zscaler Root CA** into a sandbox's system trust store. With it, agents,
+SDKs, and CLIs inside the sandbox trust TLS certificates signed by a Zscaler
+HTTPS-inspecting proxy — so outbound HTTPS works on networks where Zscaler
+intercepts and re-signs TLS traffic.
+
+The kit embeds the certificate inline in its `spec.yaml` and installs it at
+sandbox start with `update-ca-certificates`. It downloads nothing and needs no
+network egress.
+
+It's adapted from the
+[Docker "Install an internal CA certificate" kit example](https://docs.docker.com/ai/sandboxes/customize/kit-examples/#install-an-internal-ca-certificate),
+but it does **not** use that example's `files/` + `commands.install` approach —
+that fails on the `opencode-docker` base. See
+[Why this differs from the Docker example](#why-this-differs-from-the-docker-example).
+
+## Usage
+
+```bash
+sbx run --kit <path-to-this-kit> <agent> /path/to/project
+```
+
+The kit is a `mixin`, so it composes with other kits — apply it alongside an
+agent/provider kit with additional `--kit` flags:
+
+```bash
+sbx run \
+  --kit <path-to>/zscaler-ca-certificate \
+  --kit <path-to>/usai-provider-kit \
+  opencode /path/to/project
+```
+
+## Prerequisites
+
+None beyond `sbx` (>= 0.34.0). The certificate is bundled in the kit, so there
+is no secret to set and no egress to allow-list.
+
+## What it does
+
+1. Embeds the PEM-encoded Zscaler Root CA inline in `spec.yaml` and, via
+   `commands.initFiles`, stages it at sandbox start in the agent home
+   (`/home/agent/zscaler-ca.crt`).
+2. In `commands.startup` (as root) moves it to
+   `/usr/local/share/ca-certificates/zscaler-ca.crt` and runs
+   `update-ca-certificates` to rebuild the system trust bundle. Tools that read
+   the system bundle then trust the proxy's certificates with no further
+   configuration.
+
+## Why this differs from the Docker example
+
+The [Docker "Install an internal CA certificate" example](https://docs.docker.com/ai/sandboxes/customize/kit-examples/#install-an-internal-ca-certificate)
+ships the cert under `files/home/` and copies it in a `commands.install` step:
+
+```yaml
+# Docker docs example — FAILS on the opencode-docker base
+commands:
+  install:
+    - command: "install -m 0644 /home/agent/internal-ca.crt /usr/local/share/ca-certificates/internal-ca.crt && update-ca-certificates"
+      user: "0"
+```
+
+On the `opencode-docker` base this fails `sbx create` with:
+
+```
+commands.install[0] (... && update-ca-certificates): exited 1
+install: No such file or directory
+```
+
+`commands.install` runs **before** sandbox setup lays down the `files/` payload
+and creates `/usr/local/share/ca-certificates/`, so at install time **neither
+the source cert nor the destination directory exists**. (Adding `install -D`
+doesn't help — that only fixes the missing destination, not the missing
+source.)
+
+This kit avoids the ordering trap by embedding the cert inline and writing it
+with `commands.initFiles`, which run *after* setup. One more wrinkle: initFiles
+run as the agent user (uid 1000), which can't write the root-owned
+`/usr/local/share/ca-certificates/` (that fails with `Permission denied`). So
+initFiles stages the cert in the writable agent home, and a root
+`commands.startup` step moves it into the system dir and runs
+`update-ca-certificates`. The tooling already ships in the base, so no packages
+are installed and no network is needed.
+
+Full analysis:
+[`docs/decisions/initfiles-startup-instead-of-files-install.md`](docs/decisions/initfiles-startup-instead-of-files-install.md).
+
+## About the certificate
+
+This is the well-known **shared** Zscaler Root CA used by many Zscaler customer
+organizations — it is not specific to one tenant, and as a root CA it is public.
+
+| Field | Value |
+|-------|-------|
+| Subject / Issuer | `CN=Zscaler Root CA, O=Zscaler Inc., C=US` (self-signed) |
+| SHA-256 fingerprint | `04:F6:1F:1D:13:AA:E1:D1:65:73:DC:2C:37:F7:96:FD:F4:AC:97:71:3A:69:59:EB:B1:1D:24:73:95:8B:1A:53` |
+| Valid | 2014-12-19 → 2042-05-06 |
+
+If you need to replace it with a different (e.g. tenant-specific) Zscaler root,
+replace the PEM block in the `commands.initFiles` entry in `spec.yaml`. It MUST
+be PEM (`-----BEGIN CERTIFICATE-----`). To convert a DER `.cer` to PEM first:
+
+```bash
+openssl x509 -inform DER -in zscaler.cer -outform PEM
+```
+
+If traffic can be signed by more than one internal proxy, add an `initFiles`
+entry per proxy CA (each a distinct `.crt` path); the single `startup`
+`update-ca-certificates` call picks up all of them.
+
+## Verifying
+
+```bash
+sbx kit validate <path-to-this-kit>   # static spec check
+<path-to-this-kit>/scripts/verify     # end-to-end: create a sandbox and assert trust
+```
+
+`scripts/verify` creates a throwaway sandbox, confirms the cert landed, checks
+its SHA-256 fingerprint matches the cert embedded in `spec.yaml`, and confirms
+`update-ca-certificates` wired it into `/etc/ssl/certs`. Set `KEEP=1` to leave
+the sandbox up for inspection.
+
+## Security note
+
+A root CA certificate is **public** — it carries only a public key and issuer
+identity, no private key — so committing it is safe. Installing it makes the
+sandbox **trust** certificates the Zscaler proxy issues, which is what lets the
+proxy decrypt and inspect the sandbox's HTTPS traffic. That TLS interception is
+the intended behavior of a Zscaler-managed network, not a leak introduced by
+this kit. Only apply this kit in environments where Zscaler inspection is
+expected.
+
+## Failure behavior
+
+`update-ca-certificates` runs in `commands.startup`, which replays on every
+sandbox start and is idempotent. Unlike `commands.install`, startup does not
+gate the agent entrypoint, so a failure there is logged but doesn't abort the
+sandbox. `scripts/verify` asserts the end state (cert present, fingerprint
+matches, trust bundle updated) to catch regressions. See
+[`TROUBLESHOOTING.md`](TROUBLESHOOTING.md) and
+[`docs/decisions/initfiles-startup-instead-of-files-install.md`](docs/decisions/initfiles-startup-instead-of-files-install.md).

--- a/agents/isolation/sbx/kits/zscaler-ca-certificate/TROUBLESHOOTING.md
+++ b/agents/isolation/sbx/kits/zscaler-ca-certificate/TROUBLESHOOTING.md
@@ -1,0 +1,86 @@
+# Troubleshooting — zscaler-ca-certificate kit
+
+These are failure modes specific to the Zscaler CA kit, which writes the public
+Zscaler Root CA into the sandbox system trust store at startup. They assume you
+applied the kit (`sbx run --kit <kit> <agent> <project>`).
+
+## HTTPS still fails with certificate errors inside the sandbox
+
+**Symptoms:** `curl`, `git`, `pip`, `npm`, etc. report errors like
+`SSL certificate problem: unable to get local issuer certificate` or
+`self-signed certificate in certificate chain` from inside the sandbox.
+
+**Cause:** the trust store wasn't updated, or the tool isn't reading the system
+trust store.
+
+**Fix / diagnose:**
+
+- Confirm the cert landed and is trusted — run `scripts/verify`, or manually:
+  ```bash
+  sbx exec <sandbox> -- sh -c 'ls -l /usr/local/share/ca-certificates/zscaler-ca.crt'
+  sbx exec <sandbox> -- sh -c 'ls -l /etc/ssl/certs | grep -i zscaler'
+  ```
+- If the cert is missing, `initFiles` didn't write it or `update-ca-certificates`
+  didn't run — check the sandbox startup logs.
+- If the cert is present and trusted but a specific tool still fails, that tool
+  uses its **own** CA bundle, not the system one. Point it at the system bundle:
+
+  | Tool | Setting |
+  |------|---------|
+  | Node.js | `NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt` |
+  | Python `requests` | `REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt` |
+  | Python / OpenSSL | `SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt` |
+  | Git | `git config --global http.sslCAInfo /etc/ssl/certs/ca-certificates.crt` |
+  | curl | `CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt` |
+
+  You can set the env vars for every shell via `/etc/sandbox-persistent.sh` (see
+  the [shell-customization kit example](https://docs.docker.com/ai/sandboxes/customize/kit-examples/#customize-the-shell-environment)).
+
+## Trust store wasn't updated
+
+**Symptoms:** the cert is at `/usr/local/share/ca-certificates/zscaler-ca.crt`
+but there's no matching entry under `/etc/ssl/certs`.
+
+**Cause:** the `commands.startup` `update-ca-certificates` step didn't run or
+errored.
+
+**Fix:**
+
+- **`update-ca-certificates: command not found`** — the base image isn't
+  Debian/Ubuntu-based (the command ships in the `ca-certificates` package). Use
+  this kit on a Debian-family base, or add an install step for `ca-certificates`
+  (which would also require allow-listing the apt mirrors via `caps.network`).
+- Startup runs as `user: "0"` so permissions shouldn't be the issue; confirm
+  that hasn't been changed in `spec.yaml`.
+- Check the sandbox startup logs for the `update-ca-certificates` output. Startup
+  replays on restart, so a stop/start re-runs it.
+
+## "skipping, it does not contain exactly one certificate or CRL"
+
+**Symptoms:** `update-ca-certificates` warns and ignores `zscaler-ca.crt`.
+
+**Cause:** the embedded cert isn't a single PEM-encoded certificate.
+`update-ca-certificates` requires PEM (`-----BEGIN CERTIFICATE-----`), not DER,
+and one cert per `.crt` file.
+
+**Fix:** ensure the `commands.initFiles` `content` block in `spec.yaml` is PEM.
+Convert a DER `.cer` before pasting it in:
+
+```bash
+openssl x509 -inform DER -in zscaler.cer -outform PEM
+```
+
+## Trusting the wrong / an unexpected certificate
+
+**Symptoms:** you want to confirm the sandbox trusts exactly the intended root.
+
+**Fix:** compare fingerprints. The embedded cert's SHA-256 should be
+`04:F6:1F:...:8B:1A:53` (the shared Zscaler Root CA). Check inside the sandbox:
+
+```bash
+sbx exec <sandbox> -- openssl x509 \
+  -in /usr/local/share/ca-certificates/zscaler-ca.crt -noout -fingerprint -sha256
+```
+
+If it differs, the PEM in `spec.yaml`'s `commands.initFiles` was replaced —
+confirm that was intentional (e.g. a tenant-specific root).

--- a/agents/isolation/sbx/kits/zscaler-ca-certificate/docs/decisions/initfiles-startup-instead-of-files-install.md
+++ b/agents/isolation/sbx/kits/zscaler-ca-certificate/docs/decisions/initfiles-startup-instead-of-files-install.md
@@ -1,0 +1,150 @@
+# Decision: Install the CA via `initFiles` + `startup`, not the docs' `files/` + `install`
+
+**Status:** accepted
+**Supersedes:** the approach in
+[`ship-ca-in-files-install-at-create.md`](ship-ca-in-files-install-at-create.md)
+
+## TL;DR
+
+The [Docker "Install an internal CA certificate" kit example](https://docs.docker.com/ai/sandboxes/customize/kit-examples/#install-an-internal-ca-certificate)
+ships the certificate under `files/home/` and copies it into the trust store
+with a `commands.install` step:
+
+```yaml
+# Docker docs example — does NOT work on the opencode-docker base
+commands:
+  install:
+    - command: "install -m 0644 /home/agent/internal-ca.crt /usr/local/share/ca-certificates/internal-ca.crt && update-ca-certificates"
+      user: "0"
+```
+
+On the `opencode-docker` base this **fails `sbx create`** with:
+
+```
+commands.install[0] (install -m 0644 /home/agent/zscaler-ca.crt /usr/local/share/ca-certificates/zscaler-ca.crt && update-ca-certificates): exited 1
+install: No such file or directory
+```
+
+This kit instead **embeds the PEM inline in `commands.initFiles`** (written
+directly to the system CA source dir) and runs `update-ca-certificates` in
+**`commands.startup`**. If you hit the error above on another base image, this
+is why and this is the fix.
+
+## Context
+
+A kit's lifecycle on sbx (observed on `sbx v0.34.0`,
+`docker/sandbox-templates:opencode-docker`) runs phases in this order:
+
+1. `commands.install` — runs **first**, during container creation, as root.
+2. base-image sandbox setup — lays down the kit's `files/` payload **and**
+   populates `/usr/local/share/ca-certificates/` (and the rest of the
+   ca-certificates machinery).
+3. `commands.initFiles` — written at sandbox start, **as the agent user
+   (uid 1000)**.
+4. `commands.startup` — runs at every start, after initFiles. Default user is
+   uid 1000, but a step can request `user: "0"`.
+
+The docs example assumes a base where `/usr/local/share/ca-certificates/` and
+the source cert already exist by the time `commands.install` runs. On
+`opencode-docker` neither is true at phase 1:
+
+- The `files/home/zscaler-ca.crt` payload hasn't been laid down yet, so the
+  **source** path doesn't exist.
+- `/usr/local/share/ca-certificates/` hasn't been created yet, so the
+  **destination** dir doesn't exist either.
+
+GNU `install` reports both as `install: No such file or directory`. We first
+tried `install -D` (to create the missing destination parent) — that still
+failed, because the *source* (`files/`) also isn't present at phase 1. The
+ordering, not the flag, is the problem.
+
+We confirmed by probing a kit-less `opencode` sandbox that the base **does**
+ship `update-ca-certificates` and `openssl`, and that
+`/usr/local/share/ca-certificates/` and `/etc/ssl/certs/ca-certificates.crt`
+exist **after** setup. So no package installation — and no network egress — is
+needed; only the timing has to change.
+
+There's a second gotcha that bites the obvious "just write initFiles to the
+system dir" fix: **initFiles run as uid 1000**, which cannot write the
+root-owned `/usr/local/share/ca-certificates/`. An initFiles entry targeting
+that path fails at create with:
+
+```
+commands.initFiles[0] (/usr/local/share/ca-certificates/zscaler-ca.crt): exited 2
+sh: 1: cannot create /usr/local/share/ca-certificates/zscaler-ca.crt: Permission denied
+```
+
+So the cert has to be staged somewhere uid 1000 can write, then moved into the
+system dir by a root step.
+
+## Decision
+
+**Don't use `files/` + `commands.install`. Stage the certificate (embedded
+inline) in the agent home via `commands.initFiles`, then move it into the system
+CA dir and rebuild the trust store in a root `commands.startup` step.**
+
+```yaml
+commands:
+  initFiles:
+    - path: /home/agent/zscaler-ca.crt      # writable by uid 1000
+      mode: "0644"
+      content: |
+        -----BEGIN CERTIFICATE-----
+        ...the Zscaler Root CA, PEM...
+        -----END CERTIFICATE-----
+  startup:
+    - command:
+        - sh
+        - -c
+        - |
+          set -eu
+          install -m 0644 /home/agent/zscaler-ca.crt \
+            /usr/local/share/ca-certificates/zscaler-ca.crt
+          update-ca-certificates
+      user: "0"
+```
+
+Why each piece:
+
+- **`initFiles` instead of `files/`** — initFiles are written at sandbox start
+  (phase 3), *after* the base populates the CA directory (phase 2). (The `files/`
+  payload of the docs example isn't available at phase 1 when `install` runs.)
+- **Stage in `/home/agent`, not the system dir** — initFiles run as uid 1000,
+  which can't write `/usr/local/share/ca-certificates/`. Writing the cert to the
+  writable agent home and moving it with a root startup step avoids the EACCES.
+- **Inline `content` instead of a `files/` payload** — keeps the cert and the
+  install logic in one declarative place; the kit has no `files/` tree at all.
+  The cert is a small, public, static blob, so inlining costs nothing.
+- **`install` + `update-ca-certificates` in `startup`, as root** — startup runs
+  after initFiles (phase 4) and can request root. Both the move into the system
+  dir and `update-ca-certificates` need root. The step is idempotent (`install`
+  overwrites the same path; `update-ca-certificates` regenerates the same
+  bundle), satisfying sbx's "startup must be idempotent" rule.
+- **Still no `caps.network`** — nothing is downloaded; the tooling is in the
+  base.
+
+## Consequences
+
+- **Trade-off vs. fail-closed-at-create:** the superseded design failed
+  `sbx create` if the trust update couldn't run. This design moves the work to
+  startup, which does **not** gate the agent entrypoint — a failed
+  `update-ca-certificates` would log but not stop the sandbox. We accept this
+  because the previous design didn't actually *work* on the target base, and
+  because `update-ca-certificates` failing on a base that ships it is
+  unlikely. `scripts/verify` asserts the end state (cert present, fingerprint
+  matches, trust bundle updated) to catch regressions.
+- The kit directory no longer contains a `files/` tree; the certificate lives
+  only in `spec.yaml`. `scripts/verify` extracts the inlined PEM to fingerprint
+  it, so it has no separate copy to drift from.
+- The cert briefly exists at `/home/agent/zscaler-ca.crt` as well as in the
+  system dir. It's a public root CA, so leaving the staged copy in place is
+  harmless; we don't bother deleting it.
+- The change is documented here and linked from `README.md` and
+  `TROUBLESHOOTING.md` so anyone copying the Docker example and hitting the same
+  `install: No such file or directory` (or the follow-on `Permission denied`)
+  error can find the fix.
+
+## See also
+
+- Docker kit examples — [Install an internal CA certificate](https://docs.docker.com/ai/sandboxes/customize/kit-examples/#install-an-internal-ca-certificate)
+- Docker kit spec reference — [Commands (`install`, `startup`, `initFiles`)](https://docs.docker.com/ai/sandboxes/customize/kit-reference/#commands)

--- a/agents/isolation/sbx/kits/zscaler-ca-certificate/docs/decisions/ship-ca-in-files-install-at-create.md
+++ b/agents/isolation/sbx/kits/zscaler-ca-certificate/docs/decisions/ship-ca-in-files-install-at-create.md
@@ -1,0 +1,104 @@
+# Decision: Ship the Zscaler CA in `files/` and install it at sandbox creation
+
+**Status:** superseded by
+[`initfiles-startup-instead-of-files-install.md`](initfiles-startup-instead-of-files-install.md)
+
+> **Superseded.** This design (`files/` payload + `commands.install`, following
+> the Docker docs example) does **not** work on the `opencode-docker` base:
+> `commands.install` runs before sandbox setup lays down `files/` and creates
+> `/usr/local/share/ca-certificates/`, so the copy fails with
+> `install: No such file or directory` and `sbx create` aborts. The kit now
+> embeds the cert inline via `commands.initFiles` and runs
+> `update-ca-certificates` in `commands.startup`. See the superseding record for
+> the full analysis. The original rationale is kept below for context.
+
+## Context
+
+Agents in an sbx sandbox running on a Zscaler-managed network fail TLS
+verification on every outbound HTTPS call: Zscaler intercepts the connection and
+re-signs it with the Zscaler Root CA, which the sandbox's default trust store
+doesn't recognize. The sandbox needs that root CA in its system trust store.
+
+The certificate involved is the **public, shared Zscaler Root CA** — a root CA
+cert is public (no private key), and this particular root is the one many
+Zscaler customer organizations share, so it is safe to commit to a public repo.
+
+[Docker's kit documentation](https://docs.docker.com/ai/sandboxes/customize/kit-examples/#install-an-internal-ca-certificate)
+shows the canonical pattern for exactly this: ship the cert under `files/home/`
+and `update-ca-certificates` in an install command. This kit follows it.
+
+## Decision
+
+**Vendor the certificate in the kit's `files/` tree and install it via
+`commands.install` at sandbox creation.**
+
+- `files/home/zscaler-ca.crt` — the PEM-encoded Zscaler Root CA. sbx maps
+  `files/home/` to `/home/agent/`, so it lands at `/home/agent/zscaler-ca.crt`.
+- `commands.install` (as `user: "0"`) copies it into
+  `/usr/local/share/ca-certificates/` and runs `update-ca-certificates`.
+
+### Why vendor in `files/` (not download)
+
+The cert is small, public, and static. Shipping it in the kit means the kit is
+**self-contained** — it validates and applies with no network access and no
+secret. Downloading it would add an egress allow-list (`caps.network`), a point
+of failure, and an integrity-verification burden (pin a digest) for no benefit.
+Consequently the kit declares **no `caps.network`** at all.
+
+### Why `commands.install`, not `commands.startup`
+
+`install` runs **once**, at create time, and a non-zero exit **fails
+`sbx create`**. The trust store only needs writing once, and a sandbox whose
+trust update failed is broken for HTTPS — failing loudly at create is the
+correct, fail-closed behavior. `startup` would re-run the same write on every
+start (wasteful) and is the right tool for things that must reconverge each boot
+or degrade gracefully; neither applies here. (Contrast the playbook kit, which
+*does* use `startup` precisely because it wants graceful degradation and
+self-heal.)
+
+### Why `user: "0"`
+
+Writing `/usr/local/share/ca-certificates/` and running
+`update-ca-certificates` require root. The agent otherwise runs as uid 1000;
+this single install step is the documented root exception. Nothing the agent
+does at runtime needs root.
+
+### Certificate format
+
+`update-ca-certificates` requires PEM-encoded files with a `.crt` extension, one
+certificate per file. The bundled cert is PEM. A DER `.cer` source must be
+converted (`openssl x509 -inform DER ... -outform PEM`) at authoring time.
+
+### `install -D`, not the docs example's plain `install`
+
+The [Docker docs example](https://docs.docker.com/ai/sandboxes/customize/kit-examples/#install-an-internal-ca-certificate)
+uses `install -m 0644 ... /usr/local/share/ca-certificates/...`. On the
+`opencode-docker` base that fails with `install: No such file or directory`,
+because the kit's `commands.install` runs *before* sandbox setup populates
+`/usr/local/share/ca-certificates/`, and GNU `install` won't create a missing
+target parent directory. Adding `-D` makes `install` create the parent dir,
+which is order- and base-image-independent. We confirmed (by probing a
+kit-less `opencode` sandbox) that `update-ca-certificates` and `openssl` already
+ship in the base, so no package install — and therefore no `caps.network`
+egress — is required; the fix is purely the `-D` flag.
+
+## Considered alternatives
+
+- **Download the cert at install/startup** — rejected: adds egress, a failure
+  mode, and digest-pinning overhead to deliver a tiny static public file.
+- **`commands.startup` with graceful degradation** — rejected: a missing trust
+  root should fail the sandbox, not silently produce one that can't verify TLS.
+- **`commands.initFiles`** — rejected: `initFiles` is for content that needs a
+  runtime value substituted (e.g. `${WORKDIR}`); a static cert doesn't, so a
+  plain `files/` payload is simpler and the documented approach.
+
+## Consequences
+
+- A sandbox with this kit trusts Zscaler-signed TLS; HTTPS works on the
+  intercepted network with no per-tool configuration for anything that reads the
+  system trust bundle.
+- The kit is fully self-contained, portable, and needs no network or secret.
+- Tools that maintain their own CA bundle (Node, some Python stacks, Git) still
+  need to be pointed at the system bundle — documented in `TROUBLESHOOTING.md`.
+- A failed trust-store update fails `sbx create` rather than producing a
+  silently-broken sandbox.

--- a/agents/isolation/sbx/kits/zscaler-ca-certificate/scripts/verify
+++ b/agents/isolation/sbx/kits/zscaler-ca-certificate/scripts/verify
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# verify — host-side validation for the zscaler-ca-certificate sbx mixin kit.
+#
+# Run on a host where `sbx` (>= 0.34.0) is installed and logged in. It validates
+# the kit spec, creates a sandbox with the kit applied, and confirms the Zscaler
+# Root CA was installed into the system trust store (the cert file landed, its
+# fingerprint matches the cert embedded in spec.yaml, and update-ca-certificates
+# wired it into /etc/ssl/certs).
+#
+# It creates a temporary sandbox named "zscaler-ca-verify-*" and removes it at
+# the end (and on interrupt). It does not touch your other sandboxes. Nothing
+# here is secret — a root CA certificate is public.
+#
+# Usage (from anywhere):
+#   path/to/zscaler-ca-certificate/scripts/verify
+#   KEEP=1 path/to/.../scripts/verify        # keep the sandbox for inspection
+#
+# No prerequisites beyond sbx itself: the certificate is embedded in the kit's
+# spec.yaml (commands.initFiles), so there is no secret to set and no egress to
+# allow.
+
+set -uo pipefail
+
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SPEC_FILE="$KIT_DIR/spec.yaml"
+SBX_NAME="zscaler-ca-verify-$$"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/zscaler-ca-verify.XXXXXX")"
+CREATE_LOG="$WORK/sbx-create.log"
+# Host-side copy of the cert, extracted from spec.yaml's inlined initFiles PEM.
+CERT_FILE="$WORK/zscaler-ca-from-spec.crt"
+KEEP="${KEEP:-0}"
+INSTALLED_PATH="/usr/local/share/ca-certificates/zscaler-ca.crt"
+
+pass=0
+fail=0
+ok()   { printf '  \033[32mPASS\033[0m %s\n' "$1"; pass=$((pass+1)); }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail+1)); }
+info() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+
+cleanup() {
+  if [ "$KEEP" = "1" ]; then
+    printf '\nKEEP=1 set; leaving sandbox %s and %s in place.\n' "$SBX_NAME" "$WORK" >&2
+    return
+  fi
+  sbx rm -f "$SBX_NAME" >/dev/null 2>&1 || true
+  rm -rf "$WORK" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+in_sbx() { sbx exec "$SBX_NAME" -- sh -c "$1" </dev/null 2>/dev/null || true; }
+
+# Normalize an openssl SHA-256 fingerprint line to just the hex (upper, colons).
+fp_of() { openssl x509 -in "$1" -noout -fingerprint -sha256 2>/dev/null | sed -E 's/.*=//'; }
+
+info "0. Preconditions"
+if ! command -v sbx >/dev/null 2>&1; then
+  echo "  sbx not on PATH. Install sbx >= 0.34.0 and retry." >&2
+  exit 1
+fi
+echo "  sbx version: $(sbx version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1)"
+[ -f "$SPEC_FILE" ] && ok "kit spec.yaml present" || { bad "spec.yaml missing"; exit 1; }
+
+# Extract the inlined PEM (commands.initFiles[].content) from spec.yaml into a
+# host-side file so we can fingerprint it and compare against the sandbox. We
+# pull the indented block between BEGIN/END CERTIFICATE and strip leading
+# whitespace — no YAML parser needed (keeps verify dependency-free).
+awk '
+  /-----BEGIN CERTIFICATE-----/ { grab=1 }
+  grab { sub(/^[[:space:]]+/, ""); print }
+  /-----END CERTIFICATE-----/   { grab=0 }
+' "$SPEC_FILE" > "$CERT_FILE"
+if grep -q 'BEGIN CERTIFICATE' "$CERT_FILE" 2>/dev/null; then
+  ok "cert embedded in spec.yaml (commands.initFiles) is PEM-encoded"
+else
+  bad "no PEM certificate found in spec.yaml commands.initFiles"; exit 1
+fi
+HOST_FP="$(fp_of "$CERT_FILE")"
+if [ -n "$HOST_FP" ]; then
+  ok "embedded cert parses (SHA-256 ${HOST_FP})"
+else
+  bad "embedded cert does not parse as an X.509 certificate"; exit 1
+fi
+
+info "1. sbx kit validate"
+if sbx kit validate "$KIT_DIR" >/dev/null 2>&1; then ok "kit validates"; else bad "kit failed validation"; fi
+
+info "2. Create a sandbox with the kit"
+echo "  creating $SBX_NAME (workspace $WORK)..."
+# A CA install is agent-agnostic; the lightweight `shell` base is enough.
+# Fall back to `opencode` if this sbx build doesn't accept `shell`.
+agent="shell"
+if ! sbx create --name "$SBX_NAME" --kit "$KIT_DIR" "$agent" "$WORK" >"$CREATE_LOG" 2>&1; then
+  agent="opencode"
+  if sbx create --name "$SBX_NAME" --kit "$KIT_DIR" "$agent" "$WORK" >"$CREATE_LOG" 2>&1; then
+    ok "sandbox created with --kit (agent: $agent)"
+  else
+    bad "sbx create failed (exit $?)"
+    sed 's/^/  | /' "$CREATE_LOG" >&2
+    exit 1
+  fi
+else
+  ok "sandbox created with --kit (agent: $agent)"
+fi
+sleep 2
+
+info "3. Certificate landed in the system CA source dir"
+if [ "$(in_sbx "test -f '$INSTALLED_PATH' && echo yes")" = "yes" ]; then
+  ok "cert present at $INSTALLED_PATH"
+else
+  bad "cert NOT found at $INSTALLED_PATH (initFiles did not write it?)"
+fi
+
+info "4. Installed cert matches the cert embedded in spec.yaml (SHA-256)"
+sbx_fp="$(in_sbx "openssl x509 -in '$INSTALLED_PATH' -noout -fingerprint -sha256 2>/dev/null | sed -E 's/.*=//'")"
+echo "  in-sandbox fingerprint: ${sbx_fp:-<none>}"
+if [ -z "$sbx_fp" ]; then
+  echo "  NOTE: could not read fingerprint in sandbox (no openssl?); skipping match." >&2
+elif [ "$sbx_fp" = "$HOST_FP" ]; then
+  ok "fingerprint matches the cert embedded in spec.yaml"
+else
+  bad "fingerprint mismatch (sandbox=$sbx_fp spec=$HOST_FP)"
+fi
+
+info "5. update-ca-certificates wired it into the trust bundle"
+# update-ca-certificates creates a subject-hash symlink under /etc/ssl/certs
+# that resolves back to our cert in /usr/local/share/ca-certificates.
+linked="$(in_sbx "for l in /etc/ssl/certs/*.0; do [ -L \"\$l\" ] || continue; case \"\$(readlink \"\$l\")\" in *zscaler-ca*) echo yes; break;; esac; done")"
+if [ "$linked" = "yes" ]; then
+  ok "/etc/ssl/certs has a hash symlink to zscaler-ca"
+else
+  # Fallback: the cert may have been concatenated into the bundle instead.
+  in_bundle="$(in_sbx "openssl x509 -in '$INSTALLED_PATH' -noout -subject_hash 2>/dev/null")"
+  if [ -n "$in_bundle" ] && [ "$(in_sbx "test -e /etc/ssl/certs/${in_bundle}.0 && echo yes")" = "yes" ]; then
+    ok "/etc/ssl/certs/${in_bundle}.0 present (trust bundle updated)"
+  else
+    bad "no trust-store entry for the Zscaler CA (update-ca-certificates may have failed)"
+    echo "  Inspect: sbx exec $SBX_NAME -- sh -c 'ls -l /etc/ssl/certs | grep -i zscaler'" >&2
+  fi
+fi
+
+info "6. HTTPS-through-Zscaler probe (informational)"
+cat <<'NOTE'
+  A real end-to-end test (an HTTPS request that traverses the Zscaler proxy and
+  succeeds because the sandbox now trusts the inspected cert) depends on running
+  inside the Zscaler-intercepted network. It is environment-specific and not run
+  here. To check it manually from inside such a network:
+    sbx exec <sandbox> -- curl -fsS https://example.com >/dev/null && echo OK
+NOTE
+
+info "Summary"
+printf '  %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] && printf '  \033[32mAll checks passed.\033[0m\n' || printf '  \033[31mSome checks failed — see notes above.\033[0m\n'
+
+[ "$fail" -eq 0 ]

--- a/agents/isolation/sbx/kits/zscaler-ca-certificate/spec.yaml
+++ b/agents/isolation/sbx/kits/zscaler-ca-certificate/spec.yaml
@@ -1,0 +1,113 @@
+# spec.yaml — zscaler-ca-certificate (an sbx mixin kit)
+#
+# Installs the public Zscaler Root CA into the sandbox system trust store, so
+# agents, SDKs, and CLIs trust TLS certificates signed by a Zscaler HTTPS-
+# inspecting proxy. Without it, every outbound HTTPS call from the sandbox fails
+# certificate verification when the egress is intercepted by Zscaler.
+#
+# Apply at sandbox creation with (local path):
+#   sbx run --kit <path-to-this-kit> <agent> <project>
+# The kit is a mixin, so it composes with other kits via repeated --kit flags.
+#
+# What it does, declaratively:
+#   - commands.initFiles: writes the PEM-encoded Zscaler Root CA into the agent
+#     home (/home/agent/zscaler-ca.crt), which uid 1000 can write.
+#   - commands.startup: as root, moves it into the system CA source dir and runs
+#     update-ca-certificates to rebuild the system trust bundle, idempotently,
+#     on every sandbox start.
+#
+# Design notes — why initFiles+startup, NOT files/+commands.install:
+#   The Docker docs example (and an earlier version of this kit) shipped the
+#   cert via files/home/ and copied it with `install ... && update-ca-
+#   certificates` in commands.install. On the opencode-docker base that FAILS:
+#   commands.install runs BEFORE the sandbox setup that lays down files/ and
+#   populates /usr/local/share/ca-certificates, so the source cert (and the dest
+#   dir) don't exist yet — install aborts with "install: No such file or
+#   directory" and fails `sbx create`. initFiles, by contrast, are written at
+#   sandbox start (after setup), and startup runs after that. See docs/decisions/.
+#
+#   - initFiles run as the agent user (uid 1000), which CANNOT write the
+#     root-owned /usr/local/share/ca-certificates. So we stage the cert in the
+#     writable agent home and let the root startup step move it into place
+#     (writing directly to the system dir from initFiles fails with EACCES).
+#   - commands.startup (user "0"): both the move into the system dir and
+#     update-ca-certificates need root. The step is idempotent (install
+#     overwrites the same path; update-ca-certificates regenerates the same
+#     bundle), so replaying it on every start is safe.
+#   - NO caps.network: the certificate is embedded in this spec. Nothing is
+#     downloaded, so the kit needs no egress allow-list and adds no network
+#     attack surface.
+#
+# Security: a root CA certificate is PUBLIC, not a secret — it contains only the
+# public key and issuer identity. This is the well-known shared "Zscaler Root CA"
+# (CN=Zscaler Root CA, O=Zscaler Inc.; SHA-256
+# 04:F6:1F:1D:13:AA:E1:D1:65:73:DC:2C:37:F7:96:FD:F4:AC:97:71:3A:69:59:EB:B1:1D:24:73:95:8B:1A:53),
+# safe to commit. Trusting it lets the Zscaler proxy decrypt and inspect the
+# sandbox's TLS traffic — that is the intended effect of HTTPS inspection, not a
+# leak of the sandbox's data. See README.md "Security note".
+schemaVersion: "2"
+kind: mixin
+name: zscaler-ca-certificate
+displayName: Zscaler Root CA
+description: >
+  Installs the public Zscaler Root CA into the sandbox system trust store so
+  agents and SDKs trust TLS certificates signed by a Zscaler HTTPS-inspecting
+  proxy. Embeds the certificate in the kit (no download, no egress) and rebuilds
+  the trust bundle with update-ca-certificates at sandbox start.
+
+commands:
+  # Written at sandbox start, AFTER base-image setup. initFiles are written as
+  # the agent user (uid 1000), which cannot write to the root-owned system CA
+  # dir — so we stage the cert in the agent's home (writable) and let the root
+  # startup step below move it into place. The content is embedded inline (PEM);
+  # update-ca-certificates requires PEM files with a .crt extension.
+  initFiles:
+    - path: /home/agent/zscaler-ca.crt
+      mode: "0644"
+      content: |
+        -----BEGIN CERTIFICATE-----
+        MIIE0zCCA7ugAwIBAgIJANu+mC2Jt3uTMA0GCSqGSIb3DQEBCwUAMIGhMQswCQYD
+        VQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTERMA8GA1UEBxMIU2FuIEpvc2Ux
+        FTATBgNVBAoTDFpzY2FsZXIgSW5jLjEVMBMGA1UECxMMWnNjYWxlciBJbmMuMRgw
+        FgYDVQQDEw9ac2NhbGVyIFJvb3QgQ0ExIjAgBgkqhkiG9w0BCQEWE3N1cHBvcnRA
+        enNjYWxlci5jb20wHhcNMTQxMjE5MDAyNzU1WhcNNDIwNTA2MDAyNzU1WjCBoTEL
+        MAkGA1UEBhMCVVMxEzARBgNVBAgTCkNhbGlmb3JuaWExETAPBgNVBAcTCFNhbiBK
+        b3NlMRUwEwYDVQQKEwxac2NhbGVyIEluYy4xFTATBgNVBAsTDFpzY2FsZXIgSW5j
+        LjEYMBYGA1UEAxMPWnNjYWxlciBSb290IENBMSIwIAYJKoZIhvcNAQkBFhNzdXBw
+        b3J0QHpzY2FsZXIuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+        qT7STSxZRTgEFFf6doHajSc1vk5jmzmM6BWuOo044EsaTc9eVEV/HjH/1DWzZtcr
+        fTj+ni205apMTlKBW3UYR+lyLHQ9FoZiDXYXK8poKSV5+Tm0Vls/5Kb8mkhVVqv7
+        LgYEmvEY7HPY+i1nEGZCa46ZXCOohJ0mBEtB9JVlpDIO+nN0hUMAYYdZ1KZWCMNf
+        5J/aTZiShsorN2A38iSOhdd+mcRM4iNL3gsLu99XhKnRqKoHeH83lVdfu1XBeoQz
+        z5V6gA3kbRvhDwoIlTBeMa5l4yRdJAfdpkbFzqiwSgNdhbxTHnYYorDzKfr2rEFM
+        dsMU0DHdeAZf711+1CunuQIDAQABo4IBCjCCAQYwHQYDVR0OBBYEFLm33UrNww4M
+        hp1d3+wcBGnFTpjfMIHWBgNVHSMEgc4wgcuAFLm33UrNww4Mhp1d3+wcBGnFTpjf
+        oYGnpIGkMIGhMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTERMA8G
+        A1UEBxMIU2FuIEpvc2UxFTATBgNVBAoTDFpzY2FsZXIgSW5jLjEVMBMGA1UECxMM
+        WnNjYWxlciBJbmMuMRgwFgYDVQQDEw9ac2NhbGVyIFJvb3QgQ0ExIjAgBgkqhkiG
+        9w0BCQEWE3N1cHBvcnRAenNjYWxlci5jb22CCQDbvpgtibd7kzAMBgNVHRMEBTAD
+        AQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAw0NdJh8w3NsJu4KHuVZUrmZgIohnTm0j+
+        RTmYQ9IKA/pvxAcA6K1i/LO+Bt+tCX+C0yxqB8qzuo+4vAzoY5JEBhyhBhf1uK+P
+        /WVWFZN/+hTgpSbZgzUEnWQG2gOVd24msex+0Sr7hyr9vn6OueH+jj+vCMiAm5+u
+        kd7lLvJsBu3AO3jGWVLyPkS3i6Gf+rwAp1OsRrv3WnbkYcFf9xjuaf4z0hRCrLN2
+        xFNjavxrHmsH8jPHVvgc1VD0Opja0l/BRVauTrUaoW6tE+wFG5rEcPGS80jjHK4S
+        pB5iDj2mUZH1T8lzYtuZy0ZPirxmtsk3135+CKNa2OCAhhFjE0xd
+        -----END CERTIFICATE-----
+      description: Stage the Zscaler Root CA in the agent home (writable by uid 1000)
+
+  startup:
+    # Move the staged cert into the system CA source dir and rebuild the trust
+    # bundle. Runs as root (writing /usr/local/share/ca-certificates and running
+    # update-ca-certificates both require it). Idempotent: `install` overwrites
+    # the same file each start and update-ca-certificates regenerates the same
+    # bundle, so replaying on every start is safe.
+    - command:
+        - sh
+        - -c
+        - |
+          set -eu
+          install -m 0644 /home/agent/zscaler-ca.crt \
+            /usr/local/share/ca-certificates/zscaler-ca.crt
+          update-ca-certificates
+      user: "0"
+      description: Install the Zscaler Root CA into the system trust store


### PR DESCRIPTION
## Summary

Adds a sbx **mixin kit** that installs the public **Zscaler Root CA** into a sandbox's system trust store, so agents, SDKs, and CLIs trust TLS certificates signed by a Zscaler HTTPS-inspecting proxy. Adapted from the Docker [Install an internal CA certificate](https://docs.docker.com/ai/sandboxes/customize/kit-examples/#install-an-internal-ca-certificate) kit example.

Location: `agents/isolation/sbx/kits/zscaler-ca-certificate/`. Targets the `feat/sbx-kits` branch (PR #191), which introduces the `agents/isolation/sbx/kits/` tree.

## Spec choices worth flagging for review

- **Does not use the docs example's `files/` + `commands.install` approach** — it fails on the `opencode-docker` base. `commands.install` runs before sandbox setup lays down `files/` and creates `/usr/local/share/ca-certificates/`, so the copy aborts with `install: No such file or directory`.
- **`initFiles` stages in the agent home, not the system dir** — `initFiles` run as uid 1000, which can't write the root-owned CA dir (`Permission denied`). The cert is staged at `/home/agent/zscaler-ca.crt`, then a root `commands.startup` step moves it into place and runs `update-ca-certificates`.
- **Cert embedded inline in `spec.yaml`** (no `files/` tree). It's the public, shared Zscaler Root CA (SHA-256 `04:F6:1F:...:8B:1A:53`, valid to 2042) — a root CA is public, safe to commit.
- **No `caps.network`** — nothing is downloaded; the CA tooling ships in the base.
- **Trade-off:** trust update moved from create-time (fail-closed) to startup (logs but doesn't gate the entrypoint). Documented in the decision records; `scripts/verify` asserts the end state to catch regressions.

The divergence from the Docker example is documented in `docs/decisions/initfiles-startup-instead-of-files-install.md` and the README's "Why this differs from the Docker example" section, including the literal error strings, so anyone searching after copying the docs example finds the fix.

## Test plan

- `sbx kit validate` — passes.
- `scripts/verify` (host-side e2e) — **8/8 checks pass** on `sbx v0.34.0` / `opencode-docker`: cert staged, moved into the system dir, fingerprint matches the embedded PEM, and `update-ca-certificates` wired a hash symlink into `/etc/ssl/certs`.
- `markdownlint-cli2` — 0 errors.
- repo `validate_repo.py` — all validators pass.
- An HTTPS-through-Zscaler probe is environment-dependent and left as a documented manual step.

## Origin

Authored for GSA-TTS to support agentic-coding sandboxes on Zscaler-managed networks, following the Docker sbx kit example and the existing kits in this repo (usai-provider, playbook).