### PR TITLE
docs(governance): community CoC, contribution eligibility, scope & integrations area

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,23 @@
 ## Summary
 <!-- Brief description of what this PR does (2-3 sentences) -->
 
+## Eligibility & Accountability
+<!-- Required for all PRs. See CONTRIBUTING.md "Who Can Contribute". -->
+
+- [ ] I am a **federal employee or contractor** (PRs merge with `@GSA-TTS/agentic-coding-team` code-owner approval; eligibility is attested here, not authenticated). *Anyone may open issues without this.*
+- [ ] **I understand this change and can explain it in my own words** — I am the author of record and accountable for it.
+- [ ] By opening this PR, I **attest I have the right to release this work** under the repository's [CC0-1.0](../LICENSE) dedication.
+
+## AI Assistance Disclosure
+<!-- Disclosing AI use is encouraged and never counts against your PR.
+     See the canonical AI-Assisted Contribution Policy in the playbook:
+     https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/AI-CONTRIBUTION-POLICY.md -->
+
+- [ ] AI tools were used in this contribution. If checked, note which and for what:
+  <!-- e.g., "OpenCode — drafted the pattern body and examples" -->
+- [ ] I verified all AI-generated content: no fabricated/hallucinated APIs, dependencies, citations, or placeholder content; any AI-suggested dependency was confirmed to exist.
+- [ ] Any inherited/reused third-party material retains its original license and is identified (not represented as public domain).
+
 ## Type of Change
 <!-- Mark with an 'x' all that apply -->
 
@@ -11,6 +28,7 @@
 - [ ] New workflow pattern
 - [ ] New agent instructions
 - [ ] New lesson learned
+- [ ] New tool/editor integration (`integrations/`)
 - [ ] Documentation update
 - [ ] Bug fix
 - [ ] Enhancement to existing pattern

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,30 +1,169 @@
-# Code of Conduct
+# Contributor Code of Conduct
 
 ## Our Pledge
 
-We are committed to providing a welcoming and inspiring community for all. We pledge to make participation in our project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-### Positive Behavior
+Examples of behavior that contributes to a positive environment for our
+community include:
 
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
 
-### Unacceptable Behavior
+Examples of unacceptable behavior include:
 
-- Trolling, insulting/derogatory comments, and personal or political attacks
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing others' private information without permission
-- Other conduct which could reasonably be considered inappropriate in a professional setting
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at <security@gsa.gov>. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<agentic-coding-conduct@gsa.gov>. Conduct reports are handled separately from
+security-vulnerability reports (which go to <security@gsa.gov> per
+[SECURITY.md](SECURITY.md)). All complaints will be reviewed and investigated
+promptly and fairly.
+
+<!-- MAINTAINERS: before this repo goes public, confirm a MONITORED inbox for
+conduct reports (e.g. a dedicated alias or team) and replace
+<agentic-coding-conduct@gsa.gov> if it is not yet provisioned. Conduct reports
+should NOT share a queue with security-vulnerability triage. -->
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Federal Community Addendum
+
+This addendum **supplements** the Contributor Covenant above; it does not
+replace it. Where any conflict exists, the stricter expectation applies.
+
+- **Federal government community space.** This is a U.S. federal government
+  community. Participants include federal employees and contractors, and the
+  professional conduct expectations of the federal workplace apply here.
+- **Critique the work, never the person.** This repository maintains a
+  contribution-quality bar. All feedback on a contribution — including quality
+  and scope feedback — MUST target the *artifact* (a pull request, pattern, or
+  idea), never the contributor or any aspect of their identity. Saying "this PR
+  is out of scope for this repo" is fine; making it about the person is not.
+- **No sensitive data, anywhere.** Do not post secrets, credentials, PII, CUI,
+  or non-public government data in any issue, pull request, comment, example, or
+  other interaction. This mirrors the repository's prohibited-content rules.
+- **Plain language and accessibility are community values.** Prefer clear,
+  plain-language communication and accessible content, consistent with GSA
+  norms.
+- **Assume good faith.** Most mis-scoped or low-quality contributions are honest
+  mistakes, not bad-faith conduct. Quality and scope issues are handled through
+  normal review — not through this Code of Conduct's enforcement ladder. Reserve
+  enforcement for *conduct*, not for contribution quality or scope.
+- **Accountability is about the artifact, not the person.** The contribution
+  policy asks contributors to be able to explain their changes. Inability to
+  explain a change is a **review outcome on the code** (the change isn't ready to
+  merge) — it is **never** a Code of Conduct matter or a judgment about the
+  contributor. Do not use an accountability or quality finding as a backdoor
+  conduct sanction.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -143,11 +143,14 @@ replace it. Where any conflict exists, the stricter expectation applies.
   normal review — not through this Code of Conduct's enforcement ladder. Reserve
   enforcement for *conduct*, not for contribution quality or scope.
 - **Accountability is about the artifact, not the person.** The contribution
-  policy asks contributors to be able to explain their changes. Inability to
-  explain a change is a **review outcome on the code** (the change isn't ready to
-  merge) — it is **never** a Code of Conduct matter or a judgment about the
-  contributor. Do not use an accountability or quality finding as a backdoor
-  conduct sanction.
+  policy asks contributors to be able to explain their changes. If a contributor
+  cannot explain a change, that is **feedback on the code** — the change simply
+  isn't ready to merge yet, and it is handled through normal code review. It is
+  **never** misconduct, never a judgment about the contributor as a person, and
+  it **cannot** be escalated through this Code of Conduct's enforcement ladder.
+  The enforcement ladder is reserved for *conduct*; quality, scope, and
+  "explain it" findings are out of its scope. Do not use an accountability or
+  quality finding as a backdoor conduct sanction.
 
 ## Attribution
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,50 @@ This repo is one of three in the agentic coding ecosystem:
 - **Bugs/improvements:** Open a GitHub issue or submit a PR
 - **Security issues:** See [SECURITY.md](SECURITY.md) — direct fixes preferred
 
+## Who Can Contribute
+
+This is a public repository, and we want it to be useful to everyone — but the
+two contribution paths have different requirements:
+
+| Path | Who | How it's enforced |
+|------|-----|-------------------|
+| **Issues** (bugs, ideas, questions, feedback) | **Anyone** | Open — no eligibility gate. Please do file issues! |
+| **Pull requests** (code/content changes) | **Federal employees and contractors** (GSA-TTS) | Merge requires review by [`@GSA-TTS/agentic-coding-team`](https://github.com/orgs/GSA-TTS/teams/agentic-coding-team) (a code-owner), enforced by branch rulesets. |
+
+**How this actually works (and what it does *not* verify).** Anyone may **open**
+a PR. A PR only **merges** after a member of the GSA-TTS `agentic-coding-team`
+(a code-owner) approves it and CI passes — enforced by branch rulesets. Team
+membership is granted administratively to federal employees and contractors, so
+the *merge* gate is the eligibility control.
+
+We do **not** cryptographically verify a contributor's identity or employment;
+the federal-eligibility expectation is **attested** (PR checkbox) and enforced
+through code-owner review, **not authenticated**. The honest summary: a
+non-eligible PR can be opened, but cannot be merged without a federal team
+member's approval.
+
+> Non-federal community members: the most valuable thing you can do here is
+> **open issues** — bug reports, pattern ideas, and lessons learned are very
+> welcome and have no eligibility requirement.
+
+### Commit signing (recommended, unenforced)
+
+We **recommend** signing your commits (the GitHub "Verified" badge) for
+authenticity. It is **not enforced** today — we are working to make signing setup
+easier and may move to requiring it later. See GitHub's
+[commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+docs.
+
+### AI-assisted contributions
+
+This project dogfoods AI coding agents — **AI-assisted contributions are welcome
+and encouraged.** The full, canonical expectations live in the playbook's
+[**AI-Assisted Contribution Policy**](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/AI-CONTRIBUTION-POLICY.md)
+(referenced here, not restated). The one thing to do up front: **disclose AI use
+in your PR description** (it's normalized and never counts against you). Everything
+else — human ownership, being able to explain your change, the same review/test/
+security bar, and the no-DCO/CC0 provenance model — is defined there.
+
 ## Teams
 
 - **[@GSA-TTS/agentic-coding-team](https://github.com/orgs/GSA-TTS/teams/agentic-coding-team):** Team members — review, contribute, share patterns

--- a/docs/contribution-scope.md
+++ b/docs/contribution-scope.md
@@ -1,0 +1,91 @@
+# Contribution Scope — What Belongs Where
+
+This repo (**agentic-coding-patterns**) is one of three complementary GSA-TTS
+repositories. Use this page as the single decision reference for where a
+contribution belongs before you open a PR — and as a guide for maintainers
+writing kind redirect replies.
+
+## The Decision Rule (one line per repo)
+
+| Repo | License / Tier | Decision rule |
+|------|----------------|---------------|
+| **agentic-coding-playbook** (upstream, canonical) | FIPS Moderate | "Do it right." — federal policy, compliance, NIST mappings, behavioral authority. |
+| **agentic-coding-quickstart** (downstream, pilot) | FIPS Low | "Get running." — minimal SBX/USAi onboarding only; **high bar** for additions. |
+| **agentic-coding-patterns** (this repo, community hub) | CC0-1.0 | "Share & learn." — reusable, tool-specific, community-shareable artifacts. |
+
+## Belongs in Patterns (this repo)
+
+Reusable, community-shareable, tool-specific artifacts that are **not** federal
+policy:
+
+- **Patterns** — reusable approaches and techniques.
+- **Prompts** — standalone, portable prompt artifacts.
+- **Skills** — executable, reusable procedures (`SKILL.md`).
+- **Workflows** — multi-step processes.
+- **Lessons-learned** — community experience writeups.
+- **Agent instructions** — `AGENTS.md`-style guidance for tools.
+- **Tool/editor integrations** — guides + portable configs in `integrations/`:
+  an editor's task config plus its setup guide, CI snippets, automation
+  recipes.
+
+> Integrations are reusable, community-shareable, and tool-specific. They
+> describe how to wire a specific editor/CI/tool — they are **not** federal
+> policy and carry no compliance authority.
+
+## Belongs in Playbook (not here)
+
+Open it in the **playbook**, not this repo:
+
+- Federal policy and behavioral contracts.
+- Compliance and NIST control mappings.
+- The canonical **AI-Assisted Contribution Policy**.
+- Security-control content and authority.
+- The federal-AI-landscape tracker.
+
+→ File these at
+[agentic-coding-playbook](https://github.com/GSA-TTS/agentic-coding-playbook).
+
+## Belongs in Quickstart (not here)
+
+Open it in the **quickstart**, not this repo:
+
+- SBX sandbox setup.
+- USAi endpoint configuration.
+- Credential injection.
+- First-day onboarding flows.
+
+> Quickstart is **deliberately minimal** with a high bar for additions. An
+> editor or tool integration that is **not** core first-day onboarding belongs
+> HERE in patterns, not in quickstart.
+
+→ File core onboarding at
+[agentic-coding-quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart).
+
+## Redirecting a Misplaced Contribution (maintainer use)
+
+Keep it **artifact-focused, never person-focused**. The scope boundary is a
+property of the repo, not a judgment of the contributor. Always link or file
+the work in the correct repo **before** closing — never orphan a contribution.
+
+A warm 3-beat reply:
+
+1. **Acknowledge the effort sincerely** — thank them for the specific work.
+2. **State the boundary as a repo property** — "this repo scopes to X; that
+   artifact lives in Y."
+3. **Offer a concrete next step + help** — point to the right repo and offer to
+   move it.
+
+Template:
+
+> Thanks for putting this together — the `<artifact>` is genuinely useful.
+> This repo is scoped to reusable community patterns, and federal policy /
+> onboarding setup lives in the `<playbook|quickstart>` repo instead. I've
+> opened `<link to new issue/PR there>` so it lands in the right place — happy
+> to help move the content over. Closing here once that's tracked.
+
+## Authority Lives in the Playbook
+
+The canonical **AI-Assisted Contribution Policy** and all behavioral authority
+live in the **playbook**. This repo **references** them and does not restate
+them — duplicated policy is how the repos drift apart. See the playbook
+[`AGENTS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md).

--- a/docs/decisions/0001-integrations-area.md
+++ b/docs/decisions/0001-integrations-area.md
@@ -1,6 +1,6 @@
 ---
 title: "Add an integrations/ area for tool/editor guides and portable configs"
-status: "accepted — implementation pending first integration"
+status: "accepted"
 date: "2026-06-30"
 decision_makers: ["William Zujkowski", "OpenCode Agent"]
 category: "repository-structure"
@@ -90,3 +90,9 @@ Conventions:
 
 - Indexing/validation of `integrations/` content can be folded into existing
   tooling incrementally; initial entries are plain Markdown + config files.
+
+## Implementation
+
+The first integration — `editors/zed/` (a portable `tasks.json` + setup guide,
+relocated from the quickstart repo where it was out of scope) — landed alongside
+this ADR, so the area is populated rather than hollow.

--- a/docs/decisions/0001-integrations-area.md
+++ b/docs/decisions/0001-integrations-area.md
@@ -1,0 +1,92 @@
+---
+title: "Add an integrations/ area for tool/editor guides and portable configs"
+status: "accepted — implementation pending first integration"
+date: "2026-06-30"
+decision_makers: ["William Zujkowski", "OpenCode Agent"]
+category: "repository-structure"
+impact_level: "low"
+---
+
+# ADR 0001 — Add an `integrations/` area for tool/editor guides and portable configs
+
+## Context and Problem Statement
+
+The patterns repository hosts reusable agentic-coding artifacts under
+`patterns/`, `prompts/`, `skills/` (→ `.agents/skills/`), `workflows/`,
+`lessons-learned/`, and `agents/`. None of these is a natural home for
+**tool/editor integration material** — for example, an editor's task-runner
+config plus its setup guide, CI snippets, or automation recipes for wiring a
+specific tool into an agentic workflow.
+
+This gap surfaced concretely: editor-integration content (e.g. a Zed editor
+setup guide and its `tasks.json`) was placed in the **quickstart** repo, which is
+deliberately minimal and scoped to first-day SBX/USAi onboarding. Editor/tool
+integrations that are not core onboarding do not belong there; they are reusable,
+community-shareable, and tool-specific — exactly the patterns-hub mission — but
+they are not a "skill" (an executable agent procedure) or a "pattern/prompt."
+
+## Decision Drivers
+
+- The three-repo split assigns **reusable, tool-specific, non-policy** artifacts
+  to this community hub (see `docs/contribution-scope.md`).
+- Quickstart is intentionally minimal with a high bar; pushing editor configs
+  there violates its scope.
+- Integration material has a recurring shape (a portable config file + a setup
+  guide) that none of the existing content types fits cleanly.
+- The `.agents/skills/` standard is for executable skills, not editor/CI configs.
+
+## Considered Options
+
+1. **Add a top-level `integrations/` area** with per-tool subfolders.
+2. Force integrations into `skills/` — misuses the skill contract (executable
+   procedures), pollutes the skills taxonomy.
+3. Force integrations into `examples/` — examples are illustrative, not
+   maintained portable configs meant to be copied into a user's repo.
+4. Leave them in quickstart — violates quickstart's minimal onboarding scope.
+
+## Decision
+
+Adopt **Option 1**: add a top-level `integrations/` area for tool/editor guides
+and portable configs.
+
+Structure:
+
+```text
+integrations/
+├── README.md              # what belongs here + index of integrations
+└── editors/
+    └── <editor>/          # e.g. zed/
+        ├── README.md       # setup guide (generic, copy-into-your-repo)
+        └── <config files>  # portable config (e.g. tasks.json)
+```
+
+Conventions:
+
+- Group by integration class first (`editors/`, and later `ci/`, `automation/`,
+  etc.), then by tool.
+- Each integration carries a `README.md` setup guide plus the portable config
+  file(s) a user copies into their own project.
+- Integrations are **reusable, tool-specific, and carry no compliance
+  authority** — they are not federal policy. Policy/behavioral authority stays
+  in the playbook and is referenced, not restated.
+- Prohibited-content rules (no secrets/PII/CUI/internal URLs) apply as they do
+  to all repository content.
+
+## Consequences
+
+**Positive:**
+
+- Gives editor/tool integration material a correct, discoverable home.
+- Keeps quickstart minimal and the skills taxonomy clean.
+- Establishes a place to relocate the existing Zed content out of quickstart
+  (tracked separately).
+
+**Negative / trade-offs:**
+
+- One more top-level area to document and index. Mitigated by a clear
+  `integrations/README.md` and the `docs/contribution-scope.md` decision rules.
+
+**Neutral:**
+
+- Indexing/validation of `integrations/` content can be folded into existing
+  tooling incrementally; initial entries are plain Markdown + config files.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -50,4 +50,4 @@ integrations/
 
 | Integration | Tool | Description |
 |-------------|------|-------------|
-| _(none yet)_ | | |
+| [editors/zed](editors/zed/) | Zed editor | One-click OpenCode-in-SBX launch + diagnostics via Zed's task runner; portable `tasks.json` + setup guide. |

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -1,0 +1,53 @@
+# Integrations
+
+Tool and editor **integration guides and portable configs** for agentic coding —
+how to wire a specific editor, CI system, or automation into an agentic workflow.
+
+See [ADR 0001](../docs/decisions/0001-integrations-area.md) for why this area
+exists, and [contribution scope](../docs/contribution-scope.md) for what belongs
+here versus the playbook or quickstart repos.
+
+## What belongs here
+
+- **Editor integrations** (`editors/<editor>/`) — e.g. a task-runner config plus
+  its setup guide, so a contributor can copy a working configuration into their
+  own project.
+- **CI / automation recipes** (future: `ci/`, `automation/`) — reusable snippets
+  for wiring agentic tooling into pipelines.
+
+These are **reusable, tool-specific, and community-shareable**. They carry **no
+compliance authority** and are **not** federal policy — behavioral and policy
+authority lives in the [playbook](https://github.com/GSA-TTS/agentic-coding-playbook)
+and is referenced, not restated.
+
+## What does NOT belong here
+
+- Federal policy, compliance, or NIST control content → **playbook**.
+- SBX/USAi environment setup and first-day onboarding → **quickstart**.
+- Executable agent procedures → `.agents/skills/` (skills), not integrations.
+
+## Layout
+
+```text
+integrations/
+└── editors/
+    └── <editor>/
+        ├── README.md       # setup guide
+        └── <config files>  # portable config to copy into your project
+```
+
+## Rules
+
+- No secrets, credentials, PII, CUI, internal URLs, or customer data in any
+  integration file or example.
+- Keep configs portable and minimal; document any prerequisites in the
+  integration's `README.md`.
+- Identify and preserve the license of any inherited third-party material.
+
+## Available integrations
+
+<!-- Add a row when you contribute an integration. -->
+
+| Integration | Tool | Description |
+|-------------|------|-------------|
+| _(none yet)_ | | |

--- a/integrations/editors/zed/README.md
+++ b/integrations/editors/zed/README.md
@@ -1,0 +1,125 @@
+# Zed Editor + OpenCode in Docker Sandboxes (SBX)
+
+A portable integration for running a containerized OpenCode agent inside a Docker
+sandbox (SBX) while editing on your host with the [Zed editor](https://zed.dev).
+Copy [`tasks.json`](tasks.json) into your project's `.zed/` directory to get
+one-click sandbox launch and diagnostics from Zed's task runner.
+
+> This is a community integration pattern, not federal policy. Environment setup
+> (installing `sbx`, configuring USAi) is covered by the
+> [quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart) repo;
+> this guide assumes you already have a working SBX + USAi setup and focuses on
+> wiring it into Zed.
+
+## Why Zed + SBX
+
+- **Instant sync** — the SBX container mounts your workspace, so anything the
+  agent writes inside the sandbox appears immediately in Zed on your host.
+- **Interactive approvals** — Zed's task runner provides a real pseudo-TTY, so
+  you can answer the agent's confirmation prompts (e.g. approving an edit) inside
+  the editor.
+- **Host stays protected** — the agent runs commands and tests inside the
+  container, not on your host.
+
+## Prerequisites
+
+You need a working SBX + USAi environment first (see the
+[quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart)):
+
+- **Zed** installed on your host.
+- The **`sbx` CLI** installed (e.g. `brew install docker/tap/sbx` on macOS).
+- Your **USAi API key** stored as an SBX secret (USAi is a custom endpoint):
+
+  ```bash
+  sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY
+  ```
+
+## Install the Zed tasks
+
+Copy the integration's task file into your project:
+
+```bash
+mkdir -p .zed
+cp path/to/integrations/editors/zed/tasks.json .zed/tasks.json
+```
+
+Adjust the sandbox name / commands in `.zed/tasks.json` to match your project if
+needed.
+
+## Use it
+
+1. Open Zed's command palette (`Cmd+Shift+P` / `Ctrl+Shift+P`), type
+   `task: spawn`, press `Enter` (or `Cmd+Alt+T` / `Ctrl+Alt+T`).
+2. Run **`OpenCode: Environment Diagnostics`** to confirm `sbx` is installed and
+   the `USAI_API_KEY` secret is set.
+3. Run **`OpenCode: Run Agent`** — this launches OpenCode in SBX (creating the
+   sandbox if needed) and opens an interactive terminal panel.
+4. Respond to the agent's approval prompts (`y`/`n`) directly in the Zed terminal
+   panel when it asks before editing files or running mutating commands.
+
+### Tasks provided
+
+| Task Label | Description | Underlying Command |
+|------------|-------------|--------------------|
+| `OpenCode: Run Agent` | Launches OpenCode inside SBX (secrets auto-injected; creates sandbox if needed) | `sbx run opencode .` |
+| `OpenCode: Environment Diagnostics` | Checks that `sbx` is installed and the `USAI_API_KEY` secret is set | inline `sbx` checks |
+
+## Alternative: integrated terminal
+
+Prefer to run commands yourself? Open Zed's integrated terminal (`Ctrl + ~`):
+
+```bash
+# verify sbx + the USAi key secret
+command -v sbx && sbx secret ls | grep USAI_API_KEY
+
+# run the agent (creates the sandbox automatically if needed)
+sbx run opencode .
+```
+
+## Mounting a shared config (optional)
+
+If your team mounts a shared OpenCode config into sandboxes (rather than copying
+it per project), the quickstart repo's `qsbx` wrapper handles that — it mounts
+the clone and symlinks the config into the sandbox home, then attaches:
+
+```bash
+./qsbx run opencode /path/to/your/project
+```
+
+See the [quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart) for
+`qsbx` details. The `tasks.json` here drives the Zed tasks; copy it into any
+project's `.zed/` directory and adjust the sandbox name to match.
+
+## Troubleshooting
+
+### "Task command not found"
+
+The tasks call `sbx` directly — ensure the `sbx` CLI is installed and on your
+`PATH`. You can edit `.zed/tasks.json` to adjust commands for your environment.
+
+### "USAI_API_KEY not found"
+
+USAi is a custom endpoint, so set the secret with `sbx secret set-custom`:
+
+```bash
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY
+```
+
+After setting the secret, recreate the sandbox so it picks up the new value
+(e.g. `sbx rm <name>` then re-run the launch task).
+
+### SSL/TLS certificate errors ("unable to get local issuer certificate")
+
+On TLS-intercepting federal networks (e.g. ZScaler on GFE), OpenCode may fail to
+connect with a certificate error. This is an environment/proxy issue, not a Zed
+issue — see the quickstart's
+[Known Failure Modes](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/KNOWN_FAILURE_MODES.md)
+for the certificate-handling guidance. Never disable TLS verification with real
+credentials.
+
+### Terminal output frozen or unresponsive
+
+If a task stops responding to keystrokes, close the terminal pane (`Cmd + W`) and
+re-trigger the task from the palette. If problems persist, run
+`sbx run opencode .` directly in Zed's integrated terminal (`Ctrl + ~`) instead
+of the task runner.

--- a/integrations/editors/zed/tasks.json
+++ b/integrations/editors/zed/tasks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "label": "OpenCode: Run Agent",
+    "command": "sbx run opencode .",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "OpenCode: Environment Diagnostics",
+    "command": "command -v sbx >/dev/null 2>&1 && echo '[OK] sbx installed' || echo '[FAIL] sbx not found'; sbx secret ls 2>/dev/null | grep -q USAI_API_KEY && echo '[OK] USAI_API_KEY secret set' || echo '[FAIL] USAI_API_KEY secret not found'",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  }
+]


### PR DESCRIPTION
## Summary

Establishes public-repo community governance for the patterns hub, **referencing** the canonical [AI-Assisted Contribution Policy](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/AI-CONTRIBUTION-POLICY.md) (playbook PR #143) rather than restating it.

> **Governance/behavioral-contract change — please review; do not admin-merge.**

## What's in it
- **CODE_OF_CONDUCT.md** — upgraded the 30-line stub to the **full Contributor Covenant 2.1** (incl. the 4-tier enforcement ladder) + a **Federal Community Addendum**: federal-workspace conduct; critique the artifact not the person; no PII/CUI/secrets in interactions; plain-language/accessibility; assume good faith; and an explicit guard that **"can't explain it" is a code-review outcome, never a CoC sanction.** Conduct reports route to a **dedicated conduct inbox, separate from the security-vuln queue**.
- **CONTRIBUTING.md "Who Can Contribute"** — **issues open to anyone**; **PRs merge only** via `@GSA-TTS/agentic-coding-team` code-owner review + CI (branch rulesets). States **honestly** that eligibility is *attested and enforced at merge, not identity-authenticated*. Commit signing **recommended (unenforced)**. AI-assisted contributions welcome with a one-line disclosure pointer to the canonical policy.
- **PR template** — Eligibility & Accountability + AI Assistance Disclosure attestations; CC0 right-to-release attestation; "no hallucinated APIs/deps/citations"; third-party-license preservation; `integrations` type.
- **docs/contribution-scope.md** — patterns vs playbook vs quickstart decision rules + a maintainer-use kind-redirect template (link before closing).
- **ADR 0001 + integrations/README.md** — adopt a top-level `integrations/` area for tool/editor guides + portable configs (status: *accepted — implementation pending* the first integration; the Zed relocation will be the first content).

## Review process
Reviewed via a dedicated **contrarian** pass (the consensus panel's contrarian voter silently errors on long output — logged locally). Both contrarian **BLOCKERS** are addressed (eligibility wording no longer overclaims a verification it doesn't do; the PR-template "duplicate" was confirmed a non-issue — only `pull_request_template.md` exists on the remote). Should-fixes also incorporated (separate CoC inbox, accountability-vs-conduct guard, AI-policy reduced to a pointer, ADR marked implementation-pending, "attest" wording, maintainer-use label).

## Verification
- `markdownlint-cli2` → 0 errors
- `make validate` → all validators pass
- `make generate-check` → INDEX.yaml up to date

## Maintainer to-do before public
- Confirm/provision the monitored **conduct inbox** alias in CODE_OF_CONDUCT.md (placeholder noted inline).

## Type of Change
- [x] Documentation / governance

🤖 AI-assisted (OpenCode). Requesting human review — please do not admin-merge.