### PR TITLE
feat(integrations): add Zed editor integration (relocated from quickstart)

### DIFF
--- a/docs/decisions/0001-integrations-area.md
+++ b/docs/decisions/0001-integrations-area.md
@@ -1,6 +1,6 @@
 ---
 title: "Add an integrations/ area for tool/editor guides and portable configs"
-status: "accepted — implementation pending first integration"
+status: "accepted"
 date: "2026-06-30"
 decision_makers: ["William Zujkowski", "OpenCode Agent"]
 category: "repository-structure"
@@ -90,3 +90,9 @@ Conventions:
 
 - Indexing/validation of `integrations/` content can be folded into existing
   tooling incrementally; initial entries are plain Markdown + config files.
+
+## Implementation
+
+The first integration — `editors/zed/` (a portable `tasks.json` + setup guide,
+relocated from the quickstart repo where it was out of scope) — landed alongside
+this ADR, so the area is populated rather than hollow.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -50,4 +50,4 @@ integrations/
 
 | Integration | Tool | Description |
 |-------------|------|-------------|
-| _(none yet)_ | | |
+| [editors/zed](editors/zed/) | Zed editor | One-click OpenCode-in-SBX launch + diagnostics via Zed's task runner; portable `tasks.json` + setup guide. |

--- a/integrations/editors/zed/README.md
+++ b/integrations/editors/zed/README.md
@@ -1,0 +1,125 @@
+# Zed Editor + OpenCode in Docker Sandboxes (SBX)
+
+A portable integration for running a containerized OpenCode agent inside a Docker
+sandbox (SBX) while editing on your host with the [Zed editor](https://zed.dev).
+Copy [`tasks.json`](tasks.json) into your project's `.zed/` directory to get
+one-click sandbox launch and diagnostics from Zed's task runner.
+
+> This is a community integration pattern, not federal policy. Environment setup
+> (installing `sbx`, configuring USAi) is covered by the
+> [quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart) repo;
+> this guide assumes you already have a working SBX + USAi setup and focuses on
+> wiring it into Zed.
+
+## Why Zed + SBX
+
+- **Instant sync** — the SBX container mounts your workspace, so anything the
+  agent writes inside the sandbox appears immediately in Zed on your host.
+- **Interactive approvals** — Zed's task runner provides a real pseudo-TTY, so
+  you can answer the agent's confirmation prompts (e.g. approving an edit) inside
+  the editor.
+- **Host stays protected** — the agent runs commands and tests inside the
+  container, not on your host.
+
+## Prerequisites
+
+You need a working SBX + USAi environment first (see the
+[quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart)):
+
+- **Zed** installed on your host.
+- The **`sbx` CLI** installed (e.g. `brew install docker/tap/sbx` on macOS).
+- Your **USAi API key** stored as an SBX secret (USAi is a custom endpoint):
+
+  ```bash
+  sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY
+  ```
+
+## Install the Zed tasks
+
+Copy the integration's task file into your project:
+
+```bash
+mkdir -p .zed
+cp path/to/integrations/editors/zed/tasks.json .zed/tasks.json
+```
+
+Adjust the sandbox name / commands in `.zed/tasks.json` to match your project if
+needed.
+
+## Use it
+
+1. Open Zed's command palette (`Cmd+Shift+P` / `Ctrl+Shift+P`), type
+   `task: spawn`, press `Enter` (or `Cmd+Alt+T` / `Ctrl+Alt+T`).
+2. Run **`OpenCode: Environment Diagnostics`** to confirm `sbx` is installed and
+   the `USAI_API_KEY` secret is set.
+3. Run **`OpenCode: Run Agent`** — this launches OpenCode in SBX (creating the
+   sandbox if needed) and opens an interactive terminal panel.
+4. Respond to the agent's approval prompts (`y`/`n`) directly in the Zed terminal
+   panel when it asks before editing files or running mutating commands.
+
+### Tasks provided
+
+| Task Label | Description | Underlying Command |
+|------------|-------------|--------------------|
+| `OpenCode: Run Agent` | Launches OpenCode inside SBX (secrets auto-injected; creates sandbox if needed) | `sbx run opencode .` |
+| `OpenCode: Environment Diagnostics` | Checks that `sbx` is installed and the `USAI_API_KEY` secret is set | inline `sbx` checks |
+
+## Alternative: integrated terminal
+
+Prefer to run commands yourself? Open Zed's integrated terminal (`Ctrl + ~`):
+
+```bash
+# verify sbx + the USAi key secret
+command -v sbx && sbx secret ls | grep USAI_API_KEY
+
+# run the agent (creates the sandbox automatically if needed)
+sbx run opencode .
+```
+
+## Mounting a shared config (optional)
+
+If your team mounts a shared OpenCode config into sandboxes (rather than copying
+it per project), the quickstart repo's `qsbx` wrapper handles that — it mounts
+the clone and symlinks the config into the sandbox home, then attaches:
+
+```bash
+./qsbx run opencode /path/to/your/project
+```
+
+See the [quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart) for
+`qsbx` details. The `tasks.json` here drives the Zed tasks; copy it into any
+project's `.zed/` directory and adjust the sandbox name to match.
+
+## Troubleshooting
+
+### "Task command not found"
+
+The tasks call `sbx` directly — ensure the `sbx` CLI is installed and on your
+`PATH`. You can edit `.zed/tasks.json` to adjust commands for your environment.
+
+### "USAI_API_KEY not found"
+
+USAi is a custom endpoint, so set the secret with `sbx secret set-custom`:
+
+```bash
+sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY
+```
+
+After setting the secret, recreate the sandbox so it picks up the new value
+(e.g. `sbx rm <name>` then re-run the launch task).
+
+### SSL/TLS certificate errors ("unable to get local issuer certificate")
+
+On TLS-intercepting federal networks (e.g. ZScaler on GFE), OpenCode may fail to
+connect with a certificate error. This is an environment/proxy issue, not a Zed
+issue — see the quickstart's
+[Known Failure Modes](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/KNOWN_FAILURE_MODES.md)
+for the certificate-handling guidance. Never disable TLS verification with real
+credentials.
+
+### Terminal output frozen or unresponsive
+
+If a task stops responding to keystrokes, close the terminal pane (`Cmd + W`) and
+re-trigger the task from the palette. If problems persist, run
+`sbx run opencode .` directly in Zed's integrated terminal (`Ctrl + ~`) instead
+of the task runner.

--- a/integrations/editors/zed/tasks.json
+++ b/integrations/editors/zed/tasks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "label": "OpenCode: Run Agent",
+    "command": "sbx run opencode .",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "OpenCode: Environment Diagnostics",
+    "command": "command -v sbx >/dev/null 2>&1 && echo '[OK] sbx installed' || echo '[FAIL] sbx not found'; sbx secret ls 2>/dev/null | grep -q USAI_API_KEY && echo '[OK] USAI_API_KEY secret set' || echo '[FAIL] USAI_API_KEY secret not found'",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  }
+]


### PR DESCRIPTION
## Summary

First real content for the `integrations/` area (ADR 0001): a **portable Zed editor integration** for launching the containerized OpenCode agent inside an SBX sandbox. This is the **patterns-side** of relocating Zed content out of the quickstart repo (whose deliberately-minimal SBX-onboarding scope doesn't cover editor integrations).

> **Stacked on #194** (community-governance) — base is `feat/community-governance` so the `integrations/` ADR + README it depends on are present. Retarget to `main` after #194 merges. Paired with the quickstart removal PR (cross-linked below).

## Changes
- `integrations/editors/zed/tasks.json` — the portable Zed task config (copy into a project's `.zed/`).
- `integrations/editors/zed/README.md` — generic, repo-agnostic setup guide **rewritten** from the quickstart's `docs/ZED_SETUP.md`: defers env setup (`sbx`/USAi) to the quickstart, **fixes the cross-repo links** (KNOWN_FAILURE_MODES now points at the quickstart GitHub URL), and frames it as a reusable community integration.
- `integrations/README.md` — index lists the Zed integration.
- ADR 0001 → `accepted` (implemented) with an Implementation note (area is populated, not hollow).

## Verification
- `make validate` passes; `markdownlint-cli2` 0 errors; `tasks.json` valid JSON.

## Related
- Quickstart removal (deletes `.zed/tasks.json` + `docs/ZED_SETUP.md`, cleans README): _linked in a follow-up comment._
- Depends on #194.

🤖 AI-assisted (OpenCode). Requesting human review — please do not admin-merge.