### PR TITLE
feat(integrations): vendor git-ssh-sign sbx mixin kit

### DIFF
--- a/integrations/README.md
+++ b/integrations/README.md
@@ -61,3 +61,4 @@ integrations/
 | [isolation/sbx-kits/usai-provider-kit](isolation/sbx-kits/usai-provider-kit/) | sbx | Mixin kit: configure OpenCode to use the GSA USAi model provider, with egress allow-listed. |
 | [isolation/sbx-kits/playbook-kit](isolation/sbx-kits/playbook-kit/) | sbx | Mixin kit: clone the GSA playbook at sandbox startup and link its AGENTS.md + skills into each agent. |
 | [isolation/sbx-kits/zscaler-ca-certificate](isolation/sbx-kits/zscaler-ca-certificate/) | sbx | Mixin kit: install the public Zscaler Root CA into the sandbox trust store for HTTPS-inspecting proxies. |
+| [isolation/sbx-kits/git-ssh-sign](isolation/sbx-kits/git-ssh-sign/) | sbx | Mixin kit: sign git commits/tags with the host-forwarded SSH key (vendored from sbx-kits-contrib). |

--- a/integrations/isolation/sbx-kits/README.md
+++ b/integrations/isolation/sbx-kits/README.md
@@ -15,6 +15,7 @@ not agent behavior. (Behavioral patterns live in `skills/`, `prompts/`, etc.)
 | [`usai-provider-kit/`](usai-provider-kit/) | Configure the agent to use the GSA USAi model provider (OpenCode today), with egress allow-listed. |
 | [`playbook-kit/`](playbook-kit/) | Clone the GSA agentic-coding-playbook at startup and link its `AGENTS.md` + skills into each agent's search paths. |
 | [`zscaler-ca-certificate/`](zscaler-ca-certificate/) | Install the public Zscaler Root CA into the sandbox trust store, so HTTPS works on Zscaler-inspected hosts. |
+| [`git-ssh-sign/`](git-ssh-sign/) | Sign git commits and tags with the SSH key forwarded from the host agent (vendored from sbx-kits-contrib). |
 
 Each kit is self-contained: a `spec.yaml`, any `files/` payload, a
 `scripts/verify` host-side check, a `README.md`, a `TROUBLESHOOTING.md`, and

--- a/integrations/isolation/sbx-kits/git-ssh-sign/LICENSE
+++ b/integrations/isolation/sbx-kits/git-ssh-sign/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Docker, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/integrations/isolation/sbx-kits/git-ssh-sign/NOTICE
+++ b/integrations/isolation/sbx-kits/git-ssh-sign/NOTICE
@@ -1,0 +1,21 @@
+git-ssh-sign sbx mixin kit
+Copyright 2026 GSA-TTS
+
+This kit is vendored (copied) from the Docker sbx-kits-contrib repository:
+
+  https://github.com/docker/sbx-kits-contrib/tree/main/git-ssh-sign
+  Source commit: d259d157af15649d1f90902cae397ebe1f2b1e3d
+
+The original work is:
+
+  Copyright 2026 Docker, Inc.
+  Licensed under the Apache License, Version 2.0.
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Modifications by GSA-TTS (see docs/decisions/vendored-from-sbx-kits-contrib.md):
+  - Ported spec.yaml from schemaVersion "1" to "2" (memory -> agentContext).
+  - Dropped the unused files/.config/git/hooks/pre-commit (upstream's own
+    documentation disavows it; the install step unsets core.hooksPath).
+  - Added README.md, TROUBLESHOOTING.md, scripts/verify, and this NOTICE.
+
+A copy of the Apache License, Version 2.0 accompanies this NOTICE (LICENSE).

--- a/integrations/isolation/sbx-kits/git-ssh-sign/README.md
+++ b/integrations/isolation/sbx-kits/git-ssh-sign/README.md
@@ -1,0 +1,78 @@
+# git-ssh-sign (sbx mixin kit)
+
+An [sbx](https://docs.docker.com/ai/sandboxes/) **mixin kit** that configures
+git inside the sandbox to sign commits and tags using the SSH key forwarded from
+your host's SSH agent. Works with any base agent kit (OpenCode, Claude, Codex, …).
+
+Your **private key never leaves the host** — the sandbox forwards the SSH agent,
+and signing resolves the public key from that agent at signing time.
+
+> Vendored from [docker/sbx-kits-contrib](https://github.com/docker/sbx-kits-contrib/tree/main/git-ssh-sign)
+> (Apache-2.0; see [`NOTICE`](NOTICE) and [`LICENSE`](LICENSE)) and ported to the
+> sbx v2 spec. See [`docs/decisions/`](docs/decisions/).
+
+## Prerequisites
+
+On the **host**, load your signing key into the SSH agent before starting the
+sandbox:
+
+```console
+ssh-add ~/.ssh/id_ed25519
+```
+
+If no key is loaded, git signing fails **with a clear error** — commits are
+refused rather than silently unsigned (fail-closed). Verify inside the sandbox:
+
+```console
+$ ssh-add -L
+ssh-ed25519 AAAA... you@example.com
+```
+
+## Usage
+
+```console
+sbx run <agent> --kit "<this-kit-ref>" ~/my-project
+```
+
+The kit is a `mixin`, so it composes with other kits via additional `--kit`
+flags.
+
+## Verifying
+
+```console
+$ git log --show-signature -1
+Good "git" signature for you@example.com with ED25519 key SHA256:...
+```
+
+See [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md) if signing fails.
+
+## How it works
+
+Git signing needs two things when it signs a commit: the signing *config* (what
+format, how to find a key) and the *key material* from the forwarded agent.
+
+- **Config — written at install time to the system gitconfig.** The install
+  command sets `gpg.format ssh`, `commit.gpgSign true`, `tag.gpgSign true`,
+  `gpg.ssh.defaultKeyCommand`, and `gpg.ssh.allowedSignersFile`. System config is
+  read at git startup and is never overwritten by the sandbox, so it's always
+  present when `git commit` begins.
+- **Key material — resolved at signing time.** `gpg.ssh.defaultKeyCommand` points
+  at `~/.config/git/ssh-signing-key-command`, which reads the first public key
+  from `ssh-add -L`, writes `allowed_signers` for verification, and prints the
+  key in git's inline `key::…` format. Nothing is written at create/startup time,
+  when the forwarded agent may not be connected yet.
+
+The kit does **not** set `core.hooksPath` or install a pre-commit hook, so
+project-level hooks and hook managers run independently of commit signing.
+
+## Verifying the kit
+
+Run the bundled host-side check (needs `sbx` and a key in your SSH agent):
+
+```console
+./scripts/verify
+```
+
+It validates the spec, creates a throwaway sandbox with the kit, and confirms
+the system signing config is in place and the key command resolves. `KEEP=1`
+keeps the sandbox for inspection.

--- a/integrations/isolation/sbx-kits/git-ssh-sign/README.md
+++ b/integrations/isolation/sbx-kits/git-ssh-sign/README.md
@@ -9,7 +9,8 @@ and signing resolves the public key from that agent at signing time.
 
 > Vendored from [docker/sbx-kits-contrib](https://github.com/docker/sbx-kits-contrib/tree/main/git-ssh-sign)
 > (Apache-2.0; see [`NOTICE`](NOTICE) and [`LICENSE`](LICENSE)) and ported to the
-> sbx v2 spec. See [`docs/decisions/`](docs/decisions/).
+> sbx v2 spec. See [`docs/decisions/`](docs/decisions/) and the public-source
+> [intake record](docs/security-skill-intake.md).
 
 ## Prerequisites
 

--- a/integrations/isolation/sbx-kits/git-ssh-sign/TROUBLESHOOTING.md
+++ b/integrations/isolation/sbx-kits/git-ssh-sign/TROUBLESHOOTING.md
@@ -44,20 +44,53 @@ git config --system --get gpg.format            # ssh
 A repo-local `commit.gpgsign=false` or `--no-gpg-sign` overrides the system
 setting; check `git config --show-origin --get commit.gpgSign`.
 
-## The signing email doesn't match my key's identity
+## My commit is signed locally but shows "Unverified" on GitHub
 
-**Cause:** `allowed_signers` is generated from `git config user.email`. If that
-isn't set, the kit falls back to `agent@sandbox.local`, which won't match your
-key's principal for verification.
+**This is not a kit bug** — it's how GitHub decides the "Verified" badge, which
+is separate from local signature checks.
 
-**Fix:** set your identity (the playbook/provider setup or your own config):
+GitHub marks an SSH-signed commit **Verified** only when **both** are true:
+
+1. The commit's `user.email` matches an **email verified on your GitHub account**, and
+2. The signing key is registered on that account **as a _signing_ key** (Settings
+   → SSH and GPG keys → *New SSH key* → key type **Signing Key**). An
+   authentication-only key does not make commits verified.
+
+Note what GitHub does **not** use: the SSH key's *comment/principal* and this
+kit's local `allowed_signers` file are irrelevant to the GitHub badge. So a
+mismatch between your committer email and the key comment does not cause
+"Unverified" — an unverified account email or an unregistered signing key does.
+
+**Fix:**
+
+- Set `user.email` to an address verified on your GitHub account. Identity
+  (`user.email` / `user.name`) belongs to your base agent / provider setup, not
+  to this signing mixin — set it there (or globally) so every kit sees it:
+
+  ```console
+  git config --global user.email you@verified-on-github.example
+  ```
+
+- Add the **public** half of your signing key to GitHub as a **Signing Key**
+  (the same key can also be an auth key; add it twice, once per type).
+
+Then make a **new** commit — verification applies going forward.
+
+## Local `git log --show-signature` says the signer is unknown
+
+**Cause:** local verification uses this kit's `allowed_signers` file, which the
+signing-key command generates from `git config user.email` at signing time. If
+`user.email` was unset when the commit was made, the kit falls back to
+`agent@sandbox.local`, so the recorded principal won't match the identity you
+expect. `allowed_signers` is **local-only** and has no bearing on GitHub's badge
+(see above).
+
+**Fix:** set your identity (in the base/provider setup or globally), then commit
+again so the key command regenerates `allowed_signers` from the current email:
 
 ```console
 git config --global user.email you@example.com
 ```
-
-Then make a new commit (the key command regenerates `allowed_signers` from the
-current email at signing time).
 
 ## I want to commit without signing
 

--- a/integrations/isolation/sbx-kits/git-ssh-sign/TROUBLESHOOTING.md
+++ b/integrations/isolation/sbx-kits/git-ssh-sign/TROUBLESHOOTING.md
@@ -1,0 +1,71 @@
+# Troubleshooting — git-ssh-sign kit
+
+Failure modes specific to the git commit-signing kit. Assumes the kit is applied
+to a sandbox (`sbx run <agent> --kit <kit> ...`).
+
+## Commits fail with "no SSH agent" / "no keys in SSH agent"
+
+**Symptom:** `git commit` fails; stderr shows
+`[git-ssh-sign] no SSH agent - cannot sign commits` or `no keys in SSH agent`.
+
+**Cause:** the sandbox forwards the host's SSH agent, but the host agent has no
+key loaded (or the agent isn't running).
+
+**Fix:** on the **host**, load your key, then retry the commit:
+
+```console
+ssh-add ~/.ssh/id_ed25519
+ssh-add -L        # should now list your key
+```
+
+Inside the sandbox, confirm the forwarded agent exposes it:
+
+```console
+$ ssh-add -L
+ssh-ed25519 AAAA... you@example.com
+```
+
+If it's still empty inside the sandbox, the agent isn't loaded on the host or the
+sandbox was created before you loaded it — reload on the host and start a fresh
+session.
+
+## Commit signing worked but verification shows "No signature"
+
+**Cause:** the commit was created outside this kit's git (e.g. a different tool),
+or `commit.gpgSign` was overridden by a repo-local or global config.
+
+**Fix:** confirm the system config is in place:
+
+```console
+git config --system --get commit.gpgSign        # true
+git config --system --get gpg.format            # ssh
+```
+
+A repo-local `commit.gpgsign=false` or `--no-gpg-sign` overrides the system
+setting; check `git config --show-origin --get commit.gpgSign`.
+
+## The signing email doesn't match my key's identity
+
+**Cause:** `allowed_signers` is generated from `git config user.email`. If that
+isn't set, the kit falls back to `agent@sandbox.local`, which won't match your
+key's principal for verification.
+
+**Fix:** set your identity (the playbook/provider setup or your own config):
+
+```console
+git config --global user.email you@example.com
+```
+
+Then make a new commit (the key command regenerates `allowed_signers` from the
+current email at signing time).
+
+## I want to commit without signing
+
+The kit is deliberately fail-closed (signing is expected). To bypass for a single
+commit:
+
+```console
+git commit --no-gpg-sign ...
+```
+
+To disable for a repo, set `git config commit.gpgsign false` in that repo.

--- a/integrations/isolation/sbx-kits/git-ssh-sign/TROUBLESHOOTING.md
+++ b/integrations/isolation/sbx-kits/git-ssh-sign/TROUBLESHOOTING.md
@@ -53,10 +53,10 @@ GitHub marks an SSH-signed commit **Verified** only when **both** are true:
 
 1. The commit's `user.email` matches an **email verified on your GitHub account**, and
 2. The signing key is registered on that account **as a _signing_ key** (Settings
-   → SSH and GPG keys → *New SSH key* → key type **Signing Key**). An
+   → SSH and GPG keys → _New SSH key_ → key type **Signing Key**). An
    authentication-only key does not make commits verified.
 
-Note what GitHub does **not** use: the SSH key's *comment/principal* and this
+Note what GitHub does **not** use: the SSH key's _comment/principal_ and this
 kit's local `allowed_signers` file are irrelevant to the GitHub badge. So a
 mismatch between your committer email and the key comment does not cause
 "Unverified" — an unverified account email or an unregistered signing key does.

--- a/integrations/isolation/sbx-kits/git-ssh-sign/docs/decisions/vendored-from-sbx-kits-contrib.md
+++ b/integrations/isolation/sbx-kits/git-ssh-sign/docs/decisions/vendored-from-sbx-kits-contrib.md
@@ -1,0 +1,66 @@
+# Decision: vendor git-ssh-sign from sbx-kits-contrib
+
+**Status:** accepted
+
+## Context
+
+Federal contributors (and their agents) are expected to sign commits. Docker's
+[sbx-kits-contrib](https://github.com/docker/sbx-kits-contrib) publishes a
+`git-ssh-sign` mixin that configures git to sign with the SSH key forwarded from
+the host agent. It does exactly what we need.
+
+We could apply it directly by remote reference
+(`git+https://github.com/docker/sbx-kits-contrib.git#…&dir=git-ssh-sign`), but
+that would (a) add a second remote kit source to every consumer's
+`kit.allowedSources` allowlist and (b) leave a supply-chain dependency on a repo
+we don't control, resolved fresh at sandbox-create time.
+
+## Decision
+
+**Vendor (copy) the kit into this repo**, under
+`integrations/isolation/sbx-kits/git-ssh-sign/`, with attribution.
+
+- **Provenance:** copied from `docker/sbx-kits-contrib` at commit
+  `d259d157af15649d1f90902cae397ebe1f2b1e3d`. Recorded in `NOTICE`.
+- **License:** the upstream kit is Apache-2.0. We retain a copy of the license
+  (`LICENSE`) and an attribution `NOTICE` in the kit directory, as Apache-2.0
+  §4 requires for redistribution. (This repo is otherwise CC0; the Apache-2.0
+  terms apply to this vendored subtree.)
+- **Supply chain:** vendoring means consumers resolve this kit from the same
+  pinned `GSA-TTS/agentic-coding-patterns` source they already trust for the
+  other kits — no additional `kit.allowedSources` entry, and changes arrive only
+  via reviewed PRs here.
+
+### Modifications from upstream
+
+1. **Ported spec `schemaVersion "1"` → `"2"`** for consistency with the other
+   kits in this directory. The only surface change is `memory:` → `agentContext:`;
+   sbx normalizes v1 into the same canonical form, so behavior is identical.
+2. **Dropped `files/home/.config/git/hooks/pre-commit`.** Upstream ships this
+   file but its own README states the kit "does not set `core.hooksPath` and does
+   not install a pre-commit hook," and the `install` step actively unsets
+   `core.hooksPath` when it points at that hooks dir. The file is vestigial and
+   contradicts the documented design, so it is omitted. Signing works via
+   `gpg.ssh.defaultKeyCommand`, not a hook.
+3. **Added** `README.md`, `TROUBLESHOOTING.md`, `scripts/verify`, and this
+   record, matching the house style of the sibling kits.
+
+The signing logic itself (system-gitconfig install + signing-time key command)
+is copied verbatim.
+
+## Consequences
+
+- Commit signing is available as a first-class, reviewed kit alongside the USAi
+  provider, playbook, and CA kits.
+- The kit is **fail-closed**: with no SSH key in the forwarded agent, git refuses
+  to sign rather than producing unsigned commits. The `agentic-coding-quickstart`
+  wrapper (`qsbx`) warns before attaching if the host has no key loaded, so users
+  aren't surprised mid-commit; the kit is unchanged for that ergonomics.
+- We take on a small maintenance duty: periodically reconcile against upstream
+  `git-ssh-sign` for fixes (the pinned source commit in `NOTICE` is the diff
+  base).
+
+## Links
+
+- Upstream: <https://github.com/docker/sbx-kits-contrib/tree/main/git-ssh-sign>
+- [Docker: signed commits in sandboxes](https://docs.docker.com/ai/sandboxes/usage/#signed-commits)

--- a/integrations/isolation/sbx-kits/git-ssh-sign/docs/decisions/vendored-from-sbx-kits-contrib.md
+++ b/integrations/isolation/sbx-kits/git-ssh-sign/docs/decisions/vendored-from-sbx-kits-contrib.md
@@ -64,3 +64,5 @@ is copied verbatim.
 
 - Upstream: <https://github.com/docker/sbx-kits-contrib/tree/main/git-ssh-sign>
 - [Docker: signed commits in sandboxes](https://docs.docker.com/ai/sandboxes/usage/#signed-commits)
+- [Public-source intake record](../security-skill-intake.md) — provenance chain
+  for the vendored copy (AGENTS.md §4.3)

--- a/integrations/isolation/sbx-kits/git-ssh-sign/docs/security-skill-intake.md
+++ b/integrations/isolation/sbx-kits/git-ssh-sign/docs/security-skill-intake.md
@@ -1,0 +1,93 @@
+# Public-Source Intake — git-ssh-sign
+
+This kit draws on a **public source**. Per the repository AGENTS.md §4.3 and the
+[Public Skill Intake Checklist](../../../../../templates/security-skill-intake.md),
+every pattern that uses a public source records an intake here and references it
+from the PR.
+
+> **Note on "inspiration" vs "vendored copy":** the intake checklist is written
+> around the *inspiration, not copying* case (the default rule for skills). This
+> kit is the other, explicitly-licensed case: it is a **verbatim vendored copy**
+> of an Apache-2.0 work, redistributed under that license with attribution. The
+> no-copy rule in §4.3 governs unlicensed reuse of prompt/skill/script bodies; it
+> does not forbid licensed redistribution. The provenance for the copy lives in
+> [`NOTICE`](NOTICE), [`LICENSE`](LICENSE), and the decision record
+> [`docs/decisions/vendored-from-sbx-kits-contrib.md`](decisions/vendored-from-sbx-kits-contrib.md).
+> This record makes that provenance chain explicit in one place.
+
+## Intake record
+
+```yaml
+intake:
+  skill_id: git-ssh-sign
+  source:
+    name: docker/sbx-kits-contrib — git-ssh-sign
+    url: https://github.com/docker/sbx-kits-contrib/tree/main/git-ssh-sign
+    commit: d259d157af15649d1f90902cae397ebe1f2b1e3d
+    license: Apache-2.0
+    type: repo
+  reviewed_by: "@mogul"
+  review_date: "2026-07-02"
+  relationship: vendored-copy   # not inspiration-only; a licensed verbatim copy
+  concepts_used: |
+    The full kit design is reused: a two-part mechanism where signing CONFIG is
+    written to the system gitconfig at install time and the signing KEY is
+    resolved at signing time from the forwarded SSH agent via
+    gpg.ssh.defaultKeyCommand. The private key never enters the container.
+  content_imported: |
+    The signing logic (system-gitconfig install commands + the signing-time
+    key-resolution command) is copied verbatim under Apache-2.0, with LICENSE
+    and NOTICE retained per Apache-2.0 §4. This is a LICENSED copy, not the
+    prohibited unlicensed reuse the intake checklist otherwise guards against.
+  content_NOT_imported: |
+    The vestigial files/.config/git/hooks/pre-commit from upstream was
+    deliberately NOT vendored — upstream's own README disavows it and the
+    install step unsets core.hooksPath. See the decision record.
+  scripts_present_in_source: "yes (spec install commands + key-resolution command)"
+  scripts_disposition: |
+    The upstream scripts are the licensed subject of this vendoring and are
+    copied verbatim under Apache-2.0. scripts/verify is original to this repo
+    (host-side check), not imported.
+  network_assumptions: |
+    The source assumes NO network egress; signing resolves a local forwarded
+    SSH agent. This kit preserves that: spec.yaml declares zero caps.network.
+    No token, telemetry, or external service is contacted.
+  safety_concerns: |
+    No weaponized payloads, no secret handling, no unsafe shell. The private
+    key stays in the host SSH agent; only the PUBLIC key is read (ssh-add -L).
+    The kit is fail-closed: with no key available, signing errors rather than
+    silently producing unsigned commits.
+  license_concerns: |
+    Apache-2.0 requires retaining the license text and attribution notices on
+    redistribution (§4). LICENSE and NOTICE are retained in the kit directory;
+    the modified spec.yaml carries a change notice (schemaVersion port, dropped
+    hook) in NOTICE and the decision record.
+  decision: adopt-vendored
+  decision_notes: |
+    Vendoring (vs. remote reference) closes a supply-chain dependency: consumers
+    resolve the kit from the same pinned GSA-TTS/agentic-coding-patterns source
+    they already trust, with no extra kit.allowedSources entry, and updates
+    arrive only via reviewed PRs here. See the decision record for the full
+    rationale.
+```
+
+## Checklist
+
+- [x] License recorded (Apache-2.0); reuse terms respected — `LICENSE` + `NOTICE`
+      retained, change notice included.
+- [x] Copied content is a **licensed** verbatim copy (Apache-2.0), not the
+      unlicensed reuse the checklist prohibits.
+- [x] Network assumptions reviewed: source is zero-egress; this kit is
+      deny-by-default on network (no `caps.network`).
+- [x] No safety concern reproduced (no payloads, no secret handling; public key
+      only; fail-closed).
+- [x] This intake record is referenced from the PR and cross-linked from the
+      decision record and README.
+
+## References
+
+- [`NOTICE`](NOTICE) — attribution + pinned upstream commit
+- [`LICENSE`](LICENSE) — Apache-2.0 text
+- [`docs/decisions/vendored-from-sbx-kits-contrib.md`](decisions/vendored-from-sbx-kits-contrib.md) — vendoring decision
+- [Public Skill Intake Checklist](../../../../../templates/security-skill-intake.md)
+- [Security Skill Governance Standard](../../../../../docs/security-skill-governance.md)

--- a/integrations/isolation/sbx-kits/git-ssh-sign/scripts/verify
+++ b/integrations/isolation/sbx-kits/git-ssh-sign/scripts/verify
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# verify — host-side validation for the git-ssh-sign sbx mixin kit.
+#
+# Run on a host where `sbx` (>= 0.34.0) is installed and logged in, AND with a
+# signing key loaded in your SSH agent (`ssh-add ~/.ssh/id_ed25519`). It
+# validates the kit spec, creates a sandbox with the kit applied, and confirms
+# git's system-level SSH signing config is in place and the signing key command
+# resolves the forwarded agent key. As a full end-to-end check it also makes a
+# throwaway signed commit and verifies the signature.
+#
+# It creates a temporary sandbox named "git-ssh-sign-verify-*" and removes it at
+# the end (and on interrupt). It does not touch your other sandboxes. No secret
+# is written — the private key stays in your host's SSH agent.
+#
+# Usage (from anywhere):
+#   path/to/git-ssh-sign/scripts/verify
+#   KEEP=1 path/to/.../scripts/verify        # keep the sandbox for inspection
+
+set -uo pipefail
+
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SBX_NAME="git-ssh-sign-verify-$$"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/git-ssh-sign-verify.XXXXXX")"
+CREATE_LOG="$WORK/sbx-create.log"
+KEEP="${KEEP:-0}"
+
+pass=0
+fail=0
+ok()   { printf '  \033[32mPASS\033[0m %s\n' "$1"; pass=$((pass+1)); }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail+1)); }
+info() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+
+cleanup() {
+  if [ "$KEEP" = "1" ]; then
+    printf '\nKEEP=1 set; leaving sandbox %s and %s in place.\n' "$SBX_NAME" "$WORK" >&2
+    return
+  fi
+  sbx rm -f "$SBX_NAME" >/dev/null 2>&1 || true
+  rm -rf "$WORK" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+in_sbx() { sbx exec "$SBX_NAME" -- sh -c "$1" </dev/null 2>/dev/null || true; }
+
+info "0. Preconditions"
+if ! command -v sbx >/dev/null 2>&1; then
+  echo "  sbx not on PATH. Install sbx >= 0.34.0 and retry." >&2
+  exit 1
+fi
+echo "  sbx version: $(sbx version 2>/dev/null | grep -oE 'v?[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1)"
+[ -f "$KIT_DIR/spec.yaml" ] && ok "kit spec.yaml present" || { bad "spec.yaml missing"; exit 1; }
+if ssh-add -L >/dev/null 2>&1; then
+  ok "host SSH agent has a key loaded (signing can succeed)"
+else
+  echo "  NOTE: no key in the host SSH agent. The kit installs fine, but signing" >&2
+  echo "        will fail until you run: ssh-add ~/.ssh/id_ed25519" >&2
+fi
+
+info "1. sbx kit validate"
+if sbx kit validate "$KIT_DIR" >/dev/null 2>&1; then ok "kit validates"; else bad "kit failed validation"; fi
+
+info "2. Create a sandbox with the kit"
+echo "  creating $SBX_NAME (workspace $WORK)..."
+if sbx create --name "$SBX_NAME" --kit "$KIT_DIR" opencode "$WORK" >"$CREATE_LOG" 2>&1; then
+  ok "sandbox created with --kit"
+else
+  bad "sbx create failed (exit $?)"
+  sed 's/^/  | /' "$CREATE_LOG" >&2
+  exit 1
+fi
+
+info "3. System signing config is in place"
+[ "$(in_sbx 'git config --system --get gpg.format')" = "ssh" ] \
+  && ok "gpg.format = ssh" || bad "gpg.format not ssh"
+[ "$(in_sbx 'git config --system --get commit.gpgSign')" = "true" ] \
+  && ok "commit.gpgSign = true" || bad "commit.gpgSign not true"
+[ "$(in_sbx 'git config --system --get tag.gpgSign')" = "true" ] \
+  && ok "tag.gpgSign = true" || bad "tag.gpgSign not true"
+[ "$(in_sbx 'test -x "$HOME/.config/git/ssh-signing-key-command" && echo yes')" = "yes" ] \
+  && ok "signing-key command present and executable" || bad "signing-key command missing"
+
+info "4. End-to-end signed commit (requires a key in the forwarded agent)"
+if [ "$(in_sbx 'ssh-add -L >/dev/null 2>&1 && echo yes')" = "yes" ]; then
+  out=$(in_sbx '
+    set -e
+    d=$(mktemp -d)
+    cd "$d"
+    git init -q
+    git config user.email verify@example.com
+    git config user.name "Verify"
+    echo hi > f
+    git add f
+    git commit -q -m "signed test" >/dev/null 2>&1
+    git log --show-signature -1 2>&1 | grep -qiE "good .* signature|ssh key" && echo SIGNED || echo UNSIGNED
+  ')
+  [ "$out" = "SIGNED" ] && ok "commit was signed and verified" || bad "commit not signed (got: ${out:-none})"
+else
+  echo "  SKIP: no key in the forwarded SSH agent inside the sandbox." >&2
+  echo "        Load one on the host (ssh-add) and re-run for the full check." >&2
+fi
+
+info "Summary"
+printf '  %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] && printf '  \033[32mAll checks passed.\033[0m\n' || printf '  \033[31mSome checks failed — see notes above.\033[0m\n'
+
+[ "$fail" -eq 0 ]

--- a/integrations/isolation/sbx-kits/git-ssh-sign/spec.yaml
+++ b/integrations/isolation/sbx-kits/git-ssh-sign/spec.yaml
@@ -1,0 +1,80 @@
+# spec.yaml — git-ssh-sign (an sbx mixin kit)
+#
+# Configures git inside the sandbox to sign commits and tags with the SSH key
+# forwarded from the host's SSH agent — the private key never leaves the host.
+# Vendored from docker/sbx-kits-contrib (git-ssh-sign) at commit
+# d259d157af15649d1f90902cae397ebe1f2b1e3d, Apache-2.0 (see NOTICE), and ported
+# from that kit's schemaVersion "1" to "2". See docs/decisions/.
+#
+# Two-part design (unchanged from upstream):
+#   - commands.install (root): write the SSH-signing config to the SYSTEM
+#     gitconfig at create time. System config is read at git startup and is not
+#     overwritten by the sandbox, so the signing config is always present.
+#   - commands.initFiles: drop a key-resolution command that git runs at
+#     SIGNING time (gpg.ssh.defaultKeyCommand). It reads the first public key
+#     from `ssh-add -L`, so no key material is written at create/startup time,
+#     when the forwarded agent may not be connected yet.
+#
+# If no SSH agent / key is available, git signing fails with a clear error
+# (fail-closed). qsbx warns about a missing host key before attaching so the
+# user isn't surprised mid-commit; see the agentic-coding-quickstart wrapper.
+schemaVersion: "2"
+kind: mixin
+name: git-ssh-sign
+displayName: Git SSH Commit Signing
+description: >
+  Configures git to sign commits and tags using the SSH key forwarded from the
+  host's SSH agent. Works with any base agent kit. The private key stays on the
+  host; signing config is written to the system gitconfig and the signing key is
+  resolved from the SSH agent at signing time.
+
+commands:
+  initFiles:
+    - path: /home/agent/.config/git/ssh-signing-key-command
+      mode: "0755"
+      description: Resolve the forwarded SSH agent key for Git SSH signing
+      content: |
+        #!/bin/sh
+        set -e
+
+        if [ -z "$SSH_AUTH_SOCK" ]; then
+            echo "[git-ssh-sign] no SSH agent - cannot sign commits" >&2
+            exit 1
+        fi
+
+        key=$(ssh-add -L 2>/dev/null | head -n 1)
+        if [ -z "$key" ]; then
+            echo "[git-ssh-sign] no keys in SSH agent - cannot sign commits" >&2
+            exit 1
+        fi
+
+        config_dir="$GIT_SSH_SIGN_CONFIG_DIR"
+        if [ -z "$config_dir" ]; then
+            config_dir="/home/agent/.config/git"
+        fi
+        mkdir -p "$config_dir"
+
+        email=$(git config user.email 2>/dev/null || printf '%s' "agent@sandbox.local")
+        printf '%s %s\n' "$email" "$key" > "$config_dir/allowed_signers"
+        printf 'key::%s\n' "$key"
+
+  install:
+    - command: |
+        git config --system gpg.format ssh
+        git config --system --unset-all user.signingKey || true
+        git config --system commit.gpgSign true
+        git config --system tag.gpgSign true
+        git config --system gpg.ssh.defaultKeyCommand /home/agent/.config/git/ssh-signing-key-command
+        git config --system gpg.ssh.allowedSignersFile /home/agent/.config/git/allowed_signers
+        if [ "$(git config --system --get core.hooksPath || true)" = "/home/agent/.config/git/hooks" ]; then
+            git config --system --unset-all core.hooksPath
+        fi
+      user: "0"
+      description: Configure SSH commit signing with a dynamic key command
+
+agentContext: |
+  ## Git commit signing
+
+  This sandbox is configured to sign git commits with your host's SSH key.
+  Commits and tags are signed automatically. Use `git log --show-signature`
+  to verify signatures on existing commits.


### PR DESCRIPTION
## Summary

Vendors the `git-ssh-sign` mixin kit from [docker/sbx-kits-contrib](https://github.com/docker/sbx-kits-contrib/tree/main/git-ssh-sign) into `integrations/isolation/sbx-kits/`. It configures git in the sandbox to sign commits and tags with the SSH key forwarded from the host agent — the private key never leaves the host.

Vendoring (rather than applying the upstream repo by remote reference) closes a
supply-chain dependency: consumers resolve this kit from the same pinned
`GSA-TTS/agentic-coding-patterns` source they already trust, with no additional
`kit.allowedSources` entry, and updates arrive only via reviewed PRs here.

## Type of Change

- [x] New integration/kit

## Motivation

Federal contributors (and their agents) are expected to sign commits. This makes
that the default in a sandbox, without shipping key material — signing config is
written to the system gitconfig at install and the key is resolved from
`ssh-add -L` at signing time.

## Attribution / License

Upstream is Apache-2.0. Per §4, the kit directory retains `LICENSE` and a
`NOTICE` crediting the source repo and the exact commit vendored
(`d259d157af15649d1f90902cae397ebe1f2b1e3d`).

Public-source provenance is recorded in the AGENTS.md §4.3 intake record at
[`docs/security-skill-intake.md`](integrations/isolation/sbx-kits/git-ssh-sign/docs/security-skill-intake.md),
cross-linked from the vendoring decision record and the README. The kit is a
licensed verbatim copy (not inspiration-only); the record documents that
distinction.

## Modifications from upstream

Documented in `docs/decisions/vendored-from-sbx-kits-contrib.md`:
- Ported `spec.yaml` `schemaVersion` `"1"` → `"2"` (`memory:` → `agentContext:`) for
  consistency with the other kits here; behavior is identical.
- Dropped the vestigial `files/.config/git/hooks/pre-commit` — upstream's own
  README states the kit doesn't use a pre-commit hook, and the install step
  unsets `core.hooksPath`.
- Added `README.md`, `TROUBLESHOOTING.md`, and a host-side `scripts/verify`.

## Testing

- [x] `make validate` (all validators pass)
- [x] `make test` (`pytest scripts/tests/` — 127 passed)
- [x] `sbx kit validate` on the kit; `bash -n scripts/verify`

No `INDEX.yaml` impact (no `SKILL.md`/`AGENTS.md` added).

## Safety Checklist

- [x] No secrets, PII, CUI, internal URLs, or proprietary information. The kit
      writes no key material; the private key stays in the host SSH agent.

_AI-assisted: authored with an AI coding agent under human review._

