### PR TITLE
feat(schema): add name field + tighten skill schema (additionalProperties: false)

### DIFF
--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -4,6 +4,7 @@
   "title": "Agentic Coding Pattern Schema",
   "description": "Schema for validating agentic coding patterns (skills, prompts, workflows, lessons)",
   "type": "object",
+  "additionalProperties": false,
   "required": [
     "id",
     "version",
@@ -22,6 +23,11 @@
       "description": "Unique pattern identifier in kebab-case",
       "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
     },
+    "name": {
+      "type": "string",
+      "description": "Agent Skills (agentskills.io) interop name; kebab-case and SHOULD equal `id` and the containing directory name.",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+    },
     "description": {
       "type": "string",
       "description": "Short human-readable summary of the pattern (1-2 sentences)",
@@ -38,6 +44,11 @@
       "description": "Human-readable title",
       "minLength": 3,
       "maxLength": 100
+    },
+    "last_updated": {
+      "type": "string",
+      "description": "Date the pattern was last updated (YYYY-MM-DD).",
+      "format": "date"
     },
     "type": {
       "type": "string",
@@ -64,6 +75,7 @@
     "requires": {
       "type": "object",
       "description": "Pattern dependencies",
+      "additionalProperties": false,
       "required": ["anchors"],
       "properties": {
         "anchors": {
@@ -83,6 +95,7 @@
     "output": {
       "type": "object",
       "description": "Output format and contract",
+      "additionalProperties": false,
       "required": ["format", "contract"],
       "properties": {
         "format": {
@@ -92,6 +105,7 @@
         },
         "contract": {
           "type": "object",
+          "additionalProperties": false,
           "required": ["required_sections", "prohibited_content"],
           "properties": {
             "required_sections": {
@@ -114,6 +128,7 @@
     "quality_gates": {
       "type": "object",
       "description": "Quality requirements for output",
+      "additionalProperties": false,
       "required": ["readability_max_grade", "citations_required"],
       "properties": {
         "readability_max_grade": {
@@ -130,6 +145,7 @@
     "portability": {
       "type": "object",
       "description": "Platform compatibility flags",
+      "additionalProperties": false,
       "properties": {
         "opencode": {"type": "boolean", "default": true},
         "cursor": {"type": "boolean", "default": true},
@@ -203,6 +219,7 @@
       "description": "Public sources used as INSPIRATION only (never copied). Each entry records the intake provenance (security-governance field).",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "required": ["url", "license", "intake_record"],
         "properties": {
           "url": {"type": "string"},
@@ -213,6 +230,7 @@
     },
     "scope": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "intended_use": {
           "type": "array",
@@ -226,6 +244,7 @@
     },
     "compliance": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "frameworks": {
           "type": "array",
@@ -242,6 +261,7 @@
     },
     "deprecated": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["as_of", "reason"],
       "properties": {
         "as_of": {"type": "string", "format": "date"},
@@ -257,6 +277,7 @@
       "type": "array",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "required": ["version", "date", "summary"],
         "properties": {
           "version": {"type": "string"},

--- a/scripts/tests/test_validate_frontmatter.py
+++ b/scripts/tests/test_validate_frontmatter.py
@@ -309,3 +309,88 @@ class TestSecurityGovernance:
         errors, warnings = check_security_governance(Path("frontend/uswds-prototype/SKILL.md"), fm)
         assert errors == []
         assert warnings == []
+
+
+class TestRealSchemaStrictness:
+    """Tests against the REAL repo schema (schemas/skill.schema.json), which sets
+    additionalProperties: false — so unknown/typo'd keys are rejected, not tolerated."""
+
+    @pytest.fixture
+    def real_schema(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        return load_schema(repo_root / "schemas" / "skill.schema.json")
+
+    def _base(self):
+        """A minimal valid skill frontmatter dict."""
+        return {
+            "id": "x-skill",
+            "version": "1.0.0",
+            "title": "X Skill",
+            "type": "skill",
+            "status": "experimental",
+            "owners": ["@GSA-TTS/agentic-coding-team"],
+            "primary_personas": ["developers"],
+            "requires": {"anchors": []},
+            "output": {
+                "format": "markdown",
+                "contract": {
+                    "required_sections": ["Summary"],
+                    "prohibited_content": ["Secrets"],
+                },
+            },
+            "quality_gates": {"readability_max_grade": 10, "citations_required": False},
+        }
+
+    def test_base_is_valid(self, real_schema):
+        import jsonschema
+
+        jsonschema.validate(instance=self._base(), schema=real_schema)
+
+    def test_name_field_accepted(self, real_schema):
+        import jsonschema
+
+        fm = self._base()
+        fm["name"] = "x-skill"
+        jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_unknown_top_level_key_rejected(self, real_schema):
+        """A typo'd/unknown top-level key now fails (additionalProperties: false)."""
+        import jsonschema
+
+        fm = self._base()
+        fm["complaince"] = {"frameworks": ["NIST"]}  # typo of 'compliance'
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_unknown_nested_key_rejected(self, real_schema):
+        """Unknown key inside a nested object (compliance) is rejected."""
+        import jsonschema
+
+        fm = self._base()
+        fm["compliance"] = {"nist_control": ["AC-6"]}  # singular typo
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_nist_control_pattern_enforced(self, real_schema):
+        """A malformed control id fails the ^[A-Z]{2}-\\d+ pattern."""
+        import jsonschema
+
+        fm = self._base()
+        fm["compliance"] = {"nist_controls": ["not-a-control"]}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_well_formed_nist_control_accepted(self, real_schema):
+        import jsonschema
+
+        fm = self._base()
+        fm["compliance"] = {"frameworks": ["NIST SP 800-53"], "nist_controls": ["AC-6", "AU-2"]}
+        jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_last_updated_accepted(self, real_schema):
+        """AGENTS.md-style last_updated is an allowed field."""
+        import jsonschema
+
+        fm = self._base()
+        fm["last_updated"] = "2026-07-01"
+        jsonschema.validate(instance=fm, schema=real_schema)


### PR DESCRIPTION
## Summary

Hardens `schemas/skill.schema.json` so unknown/typo'd frontmatter keys **fail validation** instead of being silently tolerated. This is the validation gate the upcoming security-skills pack passes through, so it lands **first** (before the skills PR).

## Why

The schema already *defined* the security-governance fields (M1) — but with no `additionalProperties: false`, a typo like `complaince:` or `nist_control:` (singular) passed validation silently, and the `nist_controls` `^[A-Z]{2}-\d+` pattern couldn't actually catch anything (a misspelled key just went unchecked). The gate looked strict but wasn't.

## Changes
- **Add `name`** (agentskills.io interop): kebab-case, SHOULD equal `id` + the directory name. Was previously tolerated (undefined), now validated. Aligns with the workspace's stated agentskills.io adoption.
- **Add `last_updated`** (date): used by AGENTS.md-style patterns; was tolerated.
- **Set `additionalProperties: false`** at the top level **and** on every nested object (`requires`, `output`, `output.contract`, `quality_gates`, `portability`, `source_inspiration` items, `scope`, `compliance`, `deprecated`, `changelog` items).

## Audit before flipping strict
Scanned all 21 existing patterns + `AGENTS.md` for out-of-schema keys before enabling `additionalProperties: false`. Only `last_updated` (on `AGENTS.md`) was unlisted → added it. No other stragglers; nested objects clean.

## Tests
New `TestRealSchemaStrictness` validates against the **real** repo schema (not a fixture stub):
- `name`, `last_updated`, well-formed `nist_controls` → accepted
- unknown **top-level** key, unknown **nested** key (`nist_control` typo), malformed control id → **rejected**

`make test` → **127 passed**. `make validate` → green on all existing patterns.

## Sequencing
Lands before the security-skills-pack PR so those 7 skills are authored + merged under the strict gate (name/compliance/changelog validated for real, not just tolerated).

## Type of Change
- [x] Schema/tooling hardening (+ tests)

🤖 AI-assisted (OpenCode). Requesting human review.