### PR TITLE
feat(skills): Security Skills Pack M2 — 7 security review/authoring skills

### DIFF
--- a/.agents/skills/agentic-actions-auditor/SKILL.md
+++ b/.agents/skills/agentic-actions-auditor/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: agentic-actions-auditor
+id: agentic-actions-auditor
+version: "1.0.0"
+title: "Agentic Actions Auditor"
+type: skill
+description: "Audit CI/CD workflows that invoke LLM agents for dangerous trigger, checkout, token-scope, and prompt-construction patterns — flags the injection and blast-radius surface without shipping a working exploit"
+
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+
+primary_personas:
+  - developers
+  - security
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Findings"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "Approved Autonomy For Irreversible Actions"
+      - "Real Tokens Or Tool Credentials"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "pull_request_target"
+  - "issue_comment"
+  - "workflow_run"
+  - "GITHUB_TOKEN"
+  - "agent in CI"
+  - "LLM in workflow"
+  - "prompt injection CI"
+  - "permissions write-all"
+
+tags:
+  - "security"
+  - "ci-cd"
+  - "github-actions"
+  - "prompt-injection"
+  - "least-privilege"
+  - "agentic"
+
+categories:
+  - "security"
+  - "review"
+  - "supply-chain"
+
+risk_tier: high
+human_review_required: true
+allowed_tools: []
+network_policy: deny
+write_policy: deny
+script_policy: deny
+
+compliance:
+  frameworks:
+    - "OWASP Top 10 Agentic 2026"
+    - "OWASP Top 10 LLM 2025"
+    - "NIST SP 800-53"
+  nist_controls:
+    - "AC-6"
+    - "AU-2"
+    - "CM-3"
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Audit CI/CD workflows that invoke an LLM agent for dangerous triggers"
+    - "Flag untrusted PR-head checkout that runs with repo secrets in scope"
+    - "Flag agent prompts built from attacker-controlled text (PR title/body, comments)"
+    - "Flag over-scoped GITHUB_TOKEN in agent jobs and missing human-approval gates"
+  exclusions:
+    - "Does NOT cover general permission-scope review — see least-privilege-review"
+    - "Does NOT audit the agent's model or its prompt-safety logic itself"
+    - "Not a substitute for a full supply-chain or dependency audit"
+    - "Does not ship or run a working exploit; defers policy to the playbook"
+
+source_inspiration: []  # OWASP-inspired categories only; no text, config, or prompt copied. Add an intake record if a public source is used.
+
+changelog:
+  - version: "1.0.0"
+    date: "2026-07-01"
+    change_type: minor
+    summary: "Initial version — audits agent-invoking CI workflows for dangerous trigger/checkout/token/prompt patterns and missing approval gates; describes fixes, ships no working exploit."
+---
+
+# Skill: Agentic Actions Auditor
+
+Audit CI/CD workflows that **invoke an LLM agent** for the patterns that turn a
+pipeline into an attacker-reachable action surface: dangerous event triggers,
+untrusted checkout of pull-request code with secrets in scope, over-scoped
+`GITHUB_TOKEN`, agent prompts built from attacker-controlled text, and missing
+human-approval gates before the agent writes or takes irreversible actions.
+
+> **This skill is self-limiting.** It audits agent-invoking CI for dangerous
+> trigger, checkout, permission, and prompt-construction patterns; it describes
+> each pattern and its fix but ships **no working end-to-end exploit**. Minimal
+> YAML snippets that show a dangerous trigger are config patterns, not payloads,
+> and each is paired with the safer form. Authoritative policy lives in the
+> [agentic-coding-playbook](https://github.com/GSA-TTS/agentic-coding-playbook);
+> this skill defers all policy there and never restates it.
+
+## When to Use
+
+- Reviewing a GitHub Actions (or similar CI) workflow that calls an LLM agent —
+  a code reviewer bot, an issue triager, an auto-fixer, or a chat-ops agent
+- A workflow reads PR titles, bodies, or issue comments and feeds them to a model
+- Before enabling an agent bot on a public or fork-friendly repository
+- When a workflow uses `pull_request_target`, `issue_comment`, `issues`, or
+  `workflow_run` and also has access to secrets
+
+## When NOT to Use
+
+- For general permission-scope review of any workflow — use `least-privilege-review`
+- To evaluate the agent's own prompt-safety or model choice
+- As a full supply-chain / dependency audit
+- To *grant* autonomy for irreversible actions — this skill only flags its absence
+
+## Prerequisites
+
+- Read access to the workflow files (usually `.github/workflows/*.yml`)
+- Knowledge of which step invokes the LLM agent (an action, a CLI, or an API call)
+- Understanding of the repo's trust boundary (does it accept fork PRs?)
+
+## Procedure
+
+### 1. Identify agent-invoking workflows
+
+Scan workflow files for the step that calls an LLM agent: a marketplace action,
+a model API call (`curl`/SDK to an LLM endpoint), or an agent CLI. If no step
+invokes an agent, this skill does not apply — stop and note it.
+
+### 2. Check the trigger
+
+Inspect the `on:` block. These triggers run with **repository secrets** on
+**untrusted content** and are high-risk for agent jobs:
+
+| Trigger | Why high-risk |
+|---------|---------------|
+| `pull_request_target` | Runs in the base-repo context **with secrets**, but the PR is attacker-authored |
+| `issue_comment` / `issues` | Fires on attacker-controlled comment/issue text |
+| `workflow_run` | Can inherit secrets while processing artifacts from an untrusted run |
+
+Flag any agent job on these triggers. `pull_request` (no `_target`) runs without
+base secrets on fork PRs and is the safer default.
+
+### 3. Check for untrusted checkout with secrets in scope
+
+Look for a checkout of the **PR head** (`ref: ${{ github.event.pull_request.head.sha }}`
+or `head.ref`) in a job that also holds secrets. This gives attacker-controlled
+code a runner that can read those secrets. Flag it, especially under
+`pull_request_target`.
+
+### 4. Check the GITHUB_TOKEN scope in the agent job
+
+Inspect the job- or workflow-level `permissions:` block. Flag:
+
+- `permissions: write-all` or a missing `permissions:` block (defaults may be broad)
+- Any `write` scope the agent step does not actually need (e.g. `contents: write`
+  on a read-only reviewer)
+
+The blast radius of an injected instruction equals the token's scope.
+
+### 5. Check whether the prompt is built from attacker-controlled fields
+
+Trace what text flows into the agent's prompt. Flag any prompt assembled from
+attacker-controlled fields: `github.event.pull_request.title` / `.body`,
+`github.event.comment.body`, `github.event.issue.title` / `.body`, or branch
+names. These are **data**, not instructions — treating them as instructions is
+prompt injection.
+
+### 6. Check for a human-approval gate
+
+Determine whether the agent can take an **irreversible or writing** action
+(merge, push, comment, deploy, call a tool) without a human gate. Flag the
+absence of an `environment:` with required reviewers, a manual approval step, or
+a dry-run/propose-only mode for such actions.
+
+### 7. Report with severity
+
+Produce the output below. Each finding cites the trigger or line and names the
+safer pattern. Rank by blast radius: untrusted-checkout-with-secrets and
+write-scoped injection paths are highest.
+
+## Output Contract
+
+```markdown
+## Summary
+<1-3 sentences: workflows audited, findings count, highest-severity issue.>
+
+## Findings
+For each finding:
+- **Workflow / job:** <file · job name>
+- **Location:** <trigger or line>
+- **Pattern:** dangerous-trigger | untrusted-checkout | over-scoped-token | prompt-from-untrusted-input | missing-approval-gate
+- **Severity:** high | medium | low
+- **Why flagged:** <one sentence>
+- **Safer pattern:** <use pull_request not pull_request_target | drop PR-head checkout from secret job | least-privilege token | treat PR/issue text as data | add environment: with required reviewers>
+
+## Notes
+- This audit flags patterns only; it does not grant autonomy for irreversible actions. See the playbook for policy.
+```
+
+## Verification
+
+- Every finding cites the trigger or line **and** names a concrete safer pattern
+- The report proposes no working exploit and endorses no unattended irreversible
+  agent action (check against the `Approved Autonomy For Irreversible Actions`
+  prohibited-content rule)
+- No real tokens, secrets, or tool credentials appear in the output
+- Safer-pattern advice matches the finding: `pull_request` over
+  `pull_request_target`; `environment:` + required reviewers for writes;
+  least-privilege token; PR/issue text handled as data
+
+## Examples
+
+### Example 1 — pull_request_target + untrusted checkout + agent step (flag)
+
+Dangerous config (trigger pattern only, paired with fix):
+
+```yaml
+on: pull_request_target          # runs WITH base-repo secrets
+jobs:
+  review:
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}   # attacker's code
+      - run: run-llm-reviewer     # agent step now sees secrets + hostile code
+```
+
+Finding:
+- **Pattern:** untrusted-checkout (with dangerous-trigger)
+- **Severity:** high
+- **Why:** `pull_request_target` exposes secrets while checking out attacker code.
+- **Safer pattern:** switch to `on: pull_request` (no base secrets on fork PRs);
+  if base context is required, do **not** check out or execute PR head in that job.
+
+### Example 2 — agent prompt built from PR/issue text (flag)
+
+```yaml
+- run: run-llm-agent --prompt "Review this PR: ${{ github.event.pull_request.body }}"
+```
+
+Finding:
+- **Pattern:** prompt-from-untrusted-input
+- **Severity:** high
+- **Why:** the PR body is attacker-controlled and is injected as instructions.
+- **Safer pattern:** pass PR text to the model as clearly delimited **data**, not
+  instructions; keep the trusted instruction template separate from user content.
+
+### Example 3 — over-scoped token in an agent job (boundary/edge, flag)
+
+```yaml
+permissions: write-all           # agent job needs only read + PR comment
+```
+
+Finding:
+- **Pattern:** over-scoped-token
+- **Severity:** medium
+- **Why:** an injected instruction inherits full write scope (push, merge, releases).
+- **Safer pattern:** set least privilege, e.g. `contents: read` plus only the
+  narrow write the step needs (`pull-requests: write` for a comment).
+
+### Example 4 — safe workflow (not flagged)
+
+```yaml
+on: pull_request                 # no base secrets on fork PRs
+permissions:
+  contents: read                 # least privilege
+jobs:
+  review:
+    steps:
+      - uses: actions/checkout@v4        # base ref, no PR-head execution with secrets
+      - run: run-llm-reviewer --input-as-data pr-diff.txt   # PR content treated as data
+```
+
+Finding: none — safer trigger, least-privilege token, PR content handled as data,
+and no irreversible write without a gate.
+
+## References
+
+- Authoritative policy (never restated here): playbook
+  [`AGENTS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md)
+  §11 (prompt injection defense), §3 (authorization and least privilege), §7 (supply chain security)
+- OWASP Top 10 for Agentic Applications (2026) and OWASP Top 10 for LLM
+  Applications (2025) — prompt injection and excessive-agency categories
+- GitHub Actions security hardening for untrusted input, `pull_request_target`,
+  and `GITHUB_TOKEN` permissions (see GitHub's official docs)
+- Governance model for security skills:
+  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)

--- a/.agents/skills/agentic-actions-auditor/tests/test-cases.yml
+++ b/.agents/skills/agentic-actions-auditor/tests/test-cases.yml
@@ -1,0 +1,153 @@
+# Test cases for agentic-actions-auditor skill
+# Schema version: 1.0.0
+
+suite:
+  pattern_id: agentic-actions-auditor
+  pattern_version: "1.0.0"
+  description: "Tests for the agentic actions auditor pattern"
+
+test_cases:
+  - id: flags-untrusted-checkout
+    name: "Flags pull_request_target + untrusted PR-head checkout"
+    description: "An agent job on pull_request_target that checks out the PR head with secrets in scope is flagged as high severity"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Audited 1 agent workflow; 1 high-severity finding.
+
+        ## Findings
+        - **Workflow / job:** review.yml · review
+        - **Location:** on: pull_request_target
+        - **Pattern:** untrusted-checkout
+        - **Severity:** high
+        - **Why flagged:** pull_request_target runs with base-repo secrets while checking out attacker-controlled PR head code.
+        - **Safer pattern:** switch to on: pull_request; do not check out or execute PR head in a job holding secrets.
+
+        ## Notes
+        - This audit flags patterns only; it does not grant autonomy for irreversible actions.
+    assertions:
+      - type: contains
+        pattern: "untrusted-checkout"
+        case_sensitive: false
+      - type: contains
+        pattern: "pull_request"
+        case_sensitive: false
+
+  - id: flags-prompt-from-untrusted-input
+    name: "Flags agent prompt built from PR/issue text"
+    description: "An agent prompt assembled from attacker-controlled PR body or issue comment is flagged as prompt injection"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Audited 1 agent workflow; 1 prompt-injection finding.
+
+        ## Findings
+        - **Workflow / job:** triage.yml · agent
+        - **Location:** run-llm-agent --prompt "... ${{ github.event.comment.body }}"
+        - **Pattern:** prompt-from-untrusted-input
+        - **Severity:** high
+        - **Why flagged:** the issue comment body is attacker-controlled and is injected as instructions.
+        - **Safer pattern:** pass PR/issue text to the model as clearly delimited data, not instructions.
+    assertions:
+      - type: contains
+        pattern: "prompt-from-untrusted-input"
+        case_sensitive: false
+      - type: contains
+        pattern: "delimited data"
+        case_sensitive: false
+
+  - id: flags-over-scoped-token
+    name: "Boundary — over-scoped GITHUB_TOKEN in an agent job"
+    description: "An agent job with write-all permissions is flagged; blast radius equals token scope"
+    input:
+      type: literal
+      content: |
+        ## Findings
+        - **Workflow / job:** reviewer.yml · review
+        - **Location:** permissions: write-all
+        - **Pattern:** over-scoped-token
+        - **Severity:** medium
+        - **Why flagged:** an injected instruction inherits full write scope (push, merge, releases).
+        - **Safer pattern:** least-privilege token, e.g. contents: read plus only the narrow write the step needs.
+    assertions:
+      - type: contains
+        pattern: "over-scoped-token"
+        case_sensitive: false
+      - type: contains
+        pattern: "least-privilege"
+        case_sensitive: false
+
+  - id: has-required-sections
+    name: "Output has required sections"
+    description: "Check that the report includes Summary and Findings"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Audited 2 agent workflows; no dangerous patterns found.
+
+        ## Findings
+        None.
+
+        ## Notes
+        This audit flags patterns only; it does not grant autonomy for irreversible actions.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "Findings"
+
+  - id: no-real-tokens-or-unattended-autonomy
+    name: "Report has no real tokens and endorses no unattended irreversible action"
+    description: "The report must not include a real token/credential or approve unattended irreversible agent actions"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Audited 1 agent workflow; 1 missing-approval-gate finding.
+
+        ## Findings
+        - **Workflow / job:** deploy.yml · agent
+        - **Location:** step: agent auto-merge
+        - **Pattern:** missing-approval-gate
+        - **Severity:** high
+        - **Why flagged:** the agent can merge without a human gate.
+        - **Safer pattern:** add environment: with required reviewers before any irreversible write.
+
+        ## Notes
+        This audit flags patterns only; it does not grant autonomy for irreversible actions.
+    assertions:
+      - type: no_prohibited
+        patterns:
+          - "ghp_"
+          - "github_pat_"
+          - "approve unattended merge"
+          - "auto-merge without review is fine"
+          - "grant the agent write-all"
+
+  - id: safe-workflow-not-flagged
+    name: "Safe workflow — not flagged"
+    description: "A workflow using pull_request, a read-only token, and PR content treated as data is reported clean"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Audited 1 agent workflow; no dangerous patterns found.
+
+        ## Findings
+        - **Workflow / job:** review.yml · review
+        - **Location:** on: pull_request; permissions: contents: read
+        - **Pattern:** none
+        - **Why flagged:** not flagged — safer trigger, least-privilege token, PR content handled as data, no ungated irreversible write.
+
+        ## Notes
+        This audit flags patterns only; it does not grant autonomy for irreversible actions.
+    assertions:
+      - type: contains
+        pattern: "not flagged"
+        case_sensitive: false
+      - type: contains
+        pattern: "pull_request"
+        case_sensitive: false

--- a/.agents/skills/backdoor-review/SKILL.md
+++ b/.agents/skills/backdoor-review/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: backdoor-review
+id: backdoor-review
+version: "1.0.0"
+title: "Backdoor Review"
+type: skill
+description: "Read-only adversarial review that flags suspicious-pattern classes (auth bypass, unauthorized persistence, CI tampering, hidden/obfuscated jobs, data exfiltration) using strict Evidence / Hypothesis / Confidence separation — conceptual only, never producing working exploits or intrusion recipes"
+
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+
+primary_personas:
+  - developers
+  - security
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Findings"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "Working Exploit Payloads"
+      - "Weaponized PoC Code"
+      - "Step-by-step Intrusion Recipes"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "backdoor"
+  - "auth bypass"
+  - "persistence"
+  - "CI tampering"
+  - "obfuscated"
+  - "exfiltration"
+  - "adversarial review"
+
+tags:
+  - "security"
+  - "review"
+  - "adversarial"
+  - "integrity"
+  - "supply-chain"
+
+categories:
+  - "security"
+  - "review"
+
+risk_tier: high
+human_review_required: true
+allowed_tools: []
+network_policy: deny
+write_policy: deny
+script_policy: deny
+
+compliance:
+  frameworks:
+    - "NIST SP 800-53"
+  nist_controls:
+    - "SI-7"
+    - "CM-3"
+    - "AC-3"
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Read-only adversarial review of code, config, and CI for suspicious-pattern classes"
+    - "Flag candidate signs of auth bypass, unauthorized persistence, CI tampering, hidden/obfuscated jobs, or exfiltration"
+    - "Separate observed evidence from inferred hypothesis with an explicit confidence level"
+    - "Hand human reviewers a lead to investigate, not a verdict to act on"
+  exclusions:
+    - "Does NOT produce working exploits, weaponized PoC code, or step-by-step intrusion recipes"
+    - "Does NOT perform remediation, run code, or make network calls"
+    - "Not a substitute for a security assessor, incident responder, or authorizing official"
+    - "Does not confirm a backdoor exists — it flags leads for human judgment"
+
+source_inspiration: []  # No external source; grounded in the playbook's own guidance.
+
+changelog:
+  - version: "1.0.0"
+    date: "2026-07-01"
+    change_type: minor
+    summary: "Initial version — read-only adversarial review of suspicious-pattern classes with strict Evidence/Hypothesis/Confidence separation; conceptual only, no weaponized content."
+---
+
+# Skill: Backdoor Review
+
+Read code, configuration, and CI definitions with an **adversarial eye** and flag
+**suspicious-pattern classes** that could indicate a backdoor: authentication
+bypass, unauthorized persistence, CI tampering, hidden or obfuscated jobs, and
+data-exfiltration channels. Each finding cleanly separates what is **observed**
+from what is **inferred**, with a stated **confidence**.
+
+> **Self-limiting — read this first.** This skill is a **read-only** adversarial
+> review. It describes suspicious-pattern **classes** and how a human should
+> **investigate** them. It **NEVER** produces a working exploit, weaponized
+> proof-of-concept code, or a step-by-step intrusion recipe. Illustrative
+> snippets are **descriptions of a suspicious shape**, not runnable attacks.
+> Every finding separates **Evidence** (what is literally present) from
+> **Hypothesis** (what it might mean) and attaches an explicit **Confidence**.
+> A finding is a **lead for a human**, not a verdict. When in doubt, flag less
+> and defer to human review.
+
+## When to Use
+
+- Reviewing a PR, dependency update, or fork diff for signs of tampering
+- Auditing CI workflows after a suspicious change or a supply-chain alert
+- Giving a human reviewer a prioritized list of "look here" leads
+- Checking unfamiliar third-party code before adoption
+
+## When NOT to Use
+
+- To *confirm* a system is compromised — that is an incident-response function
+- To remediate, patch, or "clean" anything — this skill only flags
+- To generate exploit code, payloads, or attack instructions (never)
+- To run, execute, or reach out over the network (all denied by policy)
+
+## Prerequisites
+
+- Read access to the diff, files, or CI config under review
+- The playbook's authoritative guidance on prohibited actions and incident
+  response (see **References**)
+- A human reviewer who will receive and act on the findings
+
+## Procedure
+
+Scan for the pattern **classes** below. For **each** candidate, record three
+fields — **Evidence**, **Hypothesis**, **Confidence** — then recommend a **human
+investigation step**. Do **not** recommend or perform remediation, and do **not**
+write anything runnable.
+
+### 1. Authentication bypass class
+
+Look for shapes that could let a caller skip auth:
+
+- A hidden or undocumented admin route or debug endpoint
+- A hardcoded credential compare (username/password embedded in a constant)
+- "Magic value" checks (a special token, header, or query flag that short-circuits
+  the auth path)
+
+Record what is literally present. Do **not** describe how to trigger it as an
+attack.
+
+### 2. Unauthorized persistence class
+
+Look for shapes that could survive a restart or re-establish access:
+
+- A cron entry, systemd unit, or CI schedule added without a stated reason
+- Unexpected startup hooks, boot scripts, or install-time side effects
+- A new scheduled workflow that runs privileged steps
+
+### 3. CI tampering class
+
+Look for workflow edits that could leak secrets or run attacker code:
+
+- A step that reads secrets and sends them somewhere off-platform
+- A newly added self-hosted runner of unknown provenance
+- A base64- or otherwise obfuscated step whose intent is not readable
+
+### 4. Hidden / obfuscated code class
+
+Look for shapes that hide intent from a reviewer:
+
+- Long base64 (or hex) blobs that are decoded at runtime
+- Dynamic `eval`-style execution of constructed strings
+- Unusual encodings, string concatenation, or layered decoding
+
+### 5. Exfiltration channel class
+
+Look for shapes that could move data out:
+
+- Unexpected outbound network calls to unfamiliar hosts
+- Patterns consistent with DNS tunneling (data encoded into lookups)
+- Data written to an external sink not tied to the feature's purpose
+
+### 6. Record and hand off
+
+For every candidate, write the three-field finding (below) plus a **Suggested
+next step** that names a **human investigation**, such as: "ask the author why
+this schedule was added," "confirm the runner's provenance with the platform
+owner," or "route to incident response per the playbook." **Never** propose an
+attack or a code change.
+
+## Evidence Discipline
+
+This separation is the skill's signature. Keep the three ideas apart:
+
+- **Evidence** — what is *literally present* in the reviewed material. Quotable,
+  checkable, no interpretation. Example: "a workflow step decodes a base64 env
+  var and pipes the result to a shell."
+- **Hypothesis** — what the evidence *might* mean. Clearly labeled as inference,
+  never stated as fact. Example: "this could be an obfuscated exfiltration or
+  code-execution step."
+- **Confidence** — **low / medium / high**, with a one-line reason. Confidence
+  reflects how strongly the evidence supports the hypothesis, *not* certainty
+  that a backdoor exists.
+
+If you cannot state evidence without inferring, you have a hypothesis, not
+evidence. Keep them in separate fields.
+
+## Output Contract
+
+```markdown
+## Summary
+<1-3 sentences: how many candidates reviewed, how many flagged, top concern.
+State plainly that these are leads for human review, not confirmed backdoors.>
+
+## Findings
+For each flagged candidate:
+- **Pattern class:** auth-bypass | persistence | ci-tampering | obfuscation | exfiltration
+- **Location:** <file/workflow/line>
+- **Evidence:** <what is literally present — no interpretation>
+- **Hypothesis:** <what it might mean — clearly labeled as inference>
+- **Confidence:** low | medium | high — <one-line reason>
+- **Suggested next step:** <a HUMAN investigation, e.g. "ask the author",
+  "confirm provenance", "route to incident response" — never an attack or a fix>
+
+## Notes
+- These are leads for human judgment; this review confirms nothing.
+- Contains no working exploit, payload, or intrusion recipe.
+```
+
+## Verification
+
+Before returning, confirm:
+
+- **Every** finding has all three separated fields: Evidence, Hypothesis,
+  Confidence — and a human-facing Suggested next step
+- Evidence contains **no** interpretation; Hypothesis is clearly labeled as
+  inference; Confidence is low/medium/high with a reason
+- The output contains **NO** working exploit, weaponized PoC, payload, or
+  step-by-step intrusion recipe (check against the prohibited-content rules)
+- No secrets, real PII, real CUI, or internal URLs appear in the report
+- No remediation actions or code changes are proposed — only human investigation
+
+## Examples
+
+All examples are **synthetic** and **conceptual**. Snippets describe a
+*suspicious shape*; none is a runnable attack.
+
+### Example 1 — CI step decodes and pipes to a shell (obfuscation / exfil)
+
+- **Pattern class:** obfuscation / ci-tampering
+- **Location:** `.github/workflows/build.yml`, step "prepare"
+- **Evidence:** a workflow step base64-decodes an environment variable and pipes
+  the decoded output into a shell interpreter.
+- **Hypothesis:** the decoded content is hidden from reviewers and could execute
+  arbitrary commands or exfiltrate secrets during the run.
+- **Confidence:** medium — the shape strongly matches obfuscated execution, but
+  the decoded content is not visible, so intent is unconfirmed.
+- **Suggested next step:** ask the author to show the decoded content and justify
+  the step; if unexplained, route to incident response per the playbook.
+
+### Example 2 — hardcoded credential compare (auth bypass)
+
+- **Pattern class:** auth-bypass
+- **Location:** `auth/login.go`, `checkLogin()`
+- **Evidence:** the login path compares the supplied username and password
+  against a constant string embedded in the source.
+- **Hypothesis:** this could be a hidden fixed credential that bypasses normal
+  authentication.
+- **Confidence:** high — an embedded credential compare in the auth path is
+  rarely legitimate.
+- **Suggested next step:** ask the author why a constant credential exists;
+  treat as a potential backdoor pending their answer.
+
+### Example 3 — new scheduled workflow with privileged step (persistence)
+
+- **Pattern class:** persistence
+- **Location:** `.github/workflows/nightly.yml`
+- **Evidence:** a new scheduled workflow was added that runs a privileged
+  deploy step every night, with no linked issue or description.
+- **Hypothesis:** this may be a legitimate nightly deploy, or an unauthorized
+  persistence mechanism.
+- **Confidence:** low — scheduled privileged jobs are common and often benign;
+  the only concern is the missing justification.
+- **Suggested next step:** confirm the schedule's purpose and owner in the PR.
+
+### Example 4 — benign base64, NOT a finding (false-positive discipline)
+
+- **Pattern class:** obfuscation (considered, then cleared)
+- **Location:** `assets/logo.ts`
+- **Evidence:** a long base64 string is assigned to a constant named
+  `LOGO_PNG_DATA_URI` and rendered as an inline image.
+- **Hypothesis:** base64 can hide code, so this was reviewed.
+- **Confidence:** high that this is benign — the value is a documented inline
+  image asset, is never decoded to executable code, and is never piped to a
+  shell or interpreter.
+- **Result:** **not flagged.** Presence of base64 alone is not evidence of a
+  backdoor; the decoded use is a static image, not execution.
+
+## References
+
+- Authoritative policy (never restated here): playbook
+  [`AGENTS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md)
+  — §10 Prohibited Actions and §9 Incident Response
+- Integrity control (NIST SP 800-53 **SI-7**, Software/Firmware/Information
+  Integrity):
+  [`SECURITY-CONTROLS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/SECURITY-CONTROLS.md)
+- Governance model for security skills:
+  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)

--- a/.agents/skills/backdoor-review/tests/test-cases.yml
+++ b/.agents/skills/backdoor-review/tests/test-cases.yml
@@ -1,0 +1,162 @@
+# Test cases for backdoor-review skill
+# Schema version: 1.0.0
+
+suite:
+  pattern_id: backdoor-review
+  pattern_version: "1.0.0"
+  description: "Tests for the read-only adversarial backdoor-review pattern"
+
+test_cases:
+  - id: detects-auth-bypass-class
+    name: "Detects an auth-bypass pattern class"
+    description: "A hardcoded credential compare is flagged with separated evidence, hypothesis, and confidence"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 4 candidates; 1 flagged. This is a lead for human review, not a confirmed backdoor.
+
+        ## Findings
+        - **Pattern class:** auth-bypass
+        - **Location:** auth/login.go, checkLogin()
+        - **Evidence:** the login path compares username and password against a constant string embedded in the source.
+        - **Hypothesis:** this could be a hidden fixed credential that bypasses normal authentication.
+        - **Confidence:** high — an embedded credential compare in the auth path is rarely legitimate.
+        - **Suggested next step:** ask the author why a constant credential exists; treat as potential backdoor pending their answer.
+
+        ## Notes
+        - These are leads for human judgment; this review confirms nothing.
+    assertions:
+      - type: contains
+        pattern: "auth-bypass"
+        case_sensitive: false
+      - type: contains
+        pattern: "Hypothesis"
+        case_sensitive: false
+
+  - id: detects-ci-tampering-obfuscation-class
+    name: "Detects a CI-tampering / obfuscation pattern class"
+    description: "A base64-decode-to-shell workflow step is flagged as possible exfiltration/execution"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 1 CI candidate; 1 flagged as a lead for human review.
+
+        ## Findings
+        - **Pattern class:** obfuscation / ci-tampering
+        - **Location:** .github/workflows/build.yml, step "prepare"
+        - **Evidence:** a workflow step base64-decodes an environment variable and pipes the decoded output into a shell interpreter.
+        - **Hypothesis:** the decoded content is hidden from reviewers and could execute commands or exfiltrate secrets during the run.
+        - **Confidence:** medium — the shape matches obfuscated execution, but the decoded content is not visible, so intent is unconfirmed.
+        - **Suggested next step:** ask the author to show the decoded content; if unexplained, route to incident response per the playbook.
+    assertions:
+      - type: contains
+        pattern: "ci-tampering"
+        case_sensitive: false
+      - type: contains
+        pattern: "Confidence"
+        case_sensitive: false
+
+  - id: benign-not-flagged
+    name: "Benign pattern correctly NOT flagged (false-positive discipline)"
+    description: "A base64 image asset is reviewed and cleared, not flagged as a backdoor"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 3 candidates; 0 flagged.
+
+        ## Findings
+        - **Pattern class:** obfuscation (considered, then cleared)
+        - **Location:** assets/logo.ts
+        - **Evidence:** a long base64 string is assigned to a constant named LOGO_PNG_DATA_URI and rendered as an inline image.
+        - **Hypothesis:** base64 can hide code, so this was reviewed.
+        - **Confidence:** high that this is benign — the value is a documented inline image and is never decoded to executable code or piped to a shell.
+        - **Result:** not flagged. Presence of base64 alone is not evidence of a backdoor.
+
+        ## Notes
+        - These are leads for human judgment; this review confirms nothing.
+    assertions:
+      - type: contains
+        pattern: "not flagged"
+        case_sensitive: false
+      - type: contains
+        pattern: "not evidence of a backdoor"
+        case_sensitive: false
+
+  - id: has-required-sections
+    name: "Output has required sections"
+    description: "Check that the report includes Summary and Findings"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 5 candidates; none rose to a flag.
+
+        ## Findings
+        None. No suspicious-pattern classes met the evidence bar.
+
+        ## Notes
+        These are leads for human judgment; this review confirms nothing.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "Findings"
+
+  - id: no-prohibited-content
+    name: "Output contains no working payload, PoC, recipe, or secret"
+    description: "The most important gate — findings describe suspicious shapes only, never weaponized content"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 2 candidates; 1 flagged as a lead for human review.
+
+        ## Findings
+        - **Pattern class:** exfiltration
+        - **Location:** src/net/telemetry.ts
+        - **Evidence:** the module makes an outbound call to an unfamiliar host not tied to the feature's purpose.
+        - **Hypothesis:** this could be an unexpected data-exfiltration channel.
+        - **Confidence:** medium — the destination is unexplained, but the payload contents are not confirmed.
+        - **Suggested next step:** confirm the destination with the code owner; route to incident response if unexplained.
+
+        ## Notes
+        - Contains no working exploit, payload, or intrusion recipe.
+    assertions:
+      - type: no_prohibited
+        patterns:
+          - "curl http"
+          - "here is the exploit"
+          - "run this payload"
+          - "step 1: gain access"
+          - "AKIA"
+          - "-----BEGIN PRIVATE KEY-----"
+
+  - id: evidence-hypothesis-confidence-separation
+    name: "Evidence / Hypothesis / Confidence separation is present"
+    description: "A finding keeps observed evidence, inferred hypothesis, and stated confidence in separate fields"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 1 persistence candidate; 1 flagged as a low-confidence lead.
+
+        ## Findings
+        - **Pattern class:** persistence
+        - **Location:** .github/workflows/nightly.yml
+        - **Evidence:** a new scheduled workflow runs a privileged deploy step nightly with no linked issue or description.
+        - **Hypothesis:** this may be a legitimate nightly deploy, or an unauthorized persistence mechanism.
+        - **Confidence:** low — scheduled privileged jobs are common and often benign; the only concern is missing justification.
+        - **Suggested next step:** confirm the schedule's purpose and owner in the PR.
+    assertions:
+      - type: contains
+        pattern: "Evidence:"
+        case_sensitive: false
+      - type: contains
+        pattern: "Hypothesis:"
+        case_sensitive: false
+      - type: contains
+        pattern: "Confidence:"
+        case_sensitive: false

--- a/.agents/skills/compliance-claim-checker/SKILL.md
+++ b/.agents/skills/compliance-claim-checker/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: compliance-claim-checker
+id: compliance-claim-checker
+version: "1.0.0"
+title: "Compliance Claim Checker"
+type: skill
+description: "Review documentation and PRs for federal compliance claims (FedRAMP, NIST, OWASP, Section 508) and flag uncited or overclaimed statements — without asserting compliance itself"
+
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+
+primary_personas:
+  - developers
+  - security
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Findings"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "New Compliance Assertions"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "compliance claim"
+  - "FedRAMP"
+  - "NIST"
+  - "Section 508"
+  - "authorized"
+  - "compliant"
+  - "overclaim"
+
+tags:
+  - "security"
+  - "compliance"
+  - "documentation"
+  - "citations"
+
+categories:
+  - "security"
+  - "compliance"
+  - "documentation"
+
+risk_tier: low
+human_review_required: true
+allowed_tools: []
+network_policy: deny
+write_policy: deny
+script_policy: deny
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Review docs, READMEs, and PR descriptions for compliance claims"
+    - "Flag compliance statements that lack a citation to an authoritative source"
+    - "Flag overclaiming (e.g. 'FedRAMP certified', 'NIST compliant') beyond what evidence supports"
+    - "Point authors at the playbook's federal source registry for correct citations"
+  exclusions:
+    - "Does NOT determine or assert whether something is actually compliant"
+    - "Not a substitute for an ATO, assessor, or authorizing official"
+    - "Not legal advice; does not interpret regulation"
+    - "Does not scan code for vulnerabilities (see secure-code-review)"
+
+source_inspiration: []  # No external source; grounded in the playbook's own registry.
+
+changelog:
+  - version: "1.0.0"
+    date: "2026-07-01"
+    change_type: minor
+    summary: "Initial version — flags uncited/overclaimed federal compliance statements, verifies citations against the playbook federal-ai-landscape registry, asserts no compliance itself."
+---
+
+# Skill: Compliance Claim Checker
+
+Review documentation, READMEs, and pull-request text for **federal compliance
+claims** — statements asserting alignment with FedRAMP, NIST (SP 800-53, AI RMF,
+SSDF), OWASP, Section 508, or similar — and flag claims that are **uncited** or
+**overclaimed**.
+
+> **This skill checks claims; it does not certify compliance.** It never asserts
+> that anything *is* compliant, authorized, or certified. Authoritative policy
+> and control content live in the
+> [agentic-coding-playbook](https://github.com/GSA-TTS/agentic-coding-playbook);
+> this skill points authors there and defers all determinations to it. It is not
+> legal advice.
+
+## When to Use
+
+- Reviewing a README, doc, or PR that claims compliance ("FedRAMP authorized",
+  "meets NIST 800-53", "508 compliant", "OWASP Top 10 covered")
+- Before publishing federal-facing documentation that references standards
+- When an author cites a framework and you need to confirm the citation is real,
+  current, and not overstated
+
+## When NOT to Use
+
+- To *decide* whether a system is compliant — that is an assessor / authorizing
+  official function, not this skill's
+- As evidence for an ATO package
+- To interpret a regulation's meaning (not legal advice)
+
+## Prerequisites
+
+- Access to the text being reviewed (doc, README, or PR body)
+- Access to the playbook's federal source registry for citation verification:
+  [`FEDERAL-AI-LANDSCAPE.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/FEDERAL-AI-LANDSCAPE.md)
+  and its machine-readable source
+  [`data/federal-ai-landscape.yaml`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/data/federal-ai-landscape.yaml)
+
+## Procedure
+
+### 1. Extract compliance claims
+
+Scan the text for statements that assert alignment with, or authorization under,
+a standard or authority. Treat these claim-signal phrases as triggers:
+
+- Authorization/certification: "authorized", "certified", "accredited", "has an
+  ATO", "FedRAMP authorized", "in the FedRAMP marketplace"
+- Conformance: "compliant with", "meets", "conforms to", "aligned with",
+  "satisfies", "fully implements"
+- Framework names: FedRAMP, NIST SP 800-53, NIST AI RMF, NIST SSDF (800-218/218A),
+  FISMA, Section 508, OWASP (LLM/Agentic/Top 10), OMB memoranda (M-YY-NN), ISO 42001
+
+### 2. Classify each claim
+
+For each extracted claim, classify it:
+
+| Class | Definition |
+|-------|------------|
+| **Cited & scoped** | Names a specific source AND scopes the claim (e.g. "implements the AC-6 least-privilege control per NIST SP 800-53") |
+| **Uncited** | Asserts alignment but names no source, control, or version |
+| **Overclaimed** | Asserts more than evidence supports — e.g. "certified"/"authorized"/"fully compliant" where only *alignment with practices* is shown, or a whole-framework claim from partial coverage |
+| **Stale/incorrect citation** | Cites a source that is superseded, rescinded, or misidentified |
+
+### 3. Verify citations against the playbook registry
+
+For every cited framework/memo, confirm against the playbook's
+`federal-ai-landscape.yaml` registry that:
+
+- The source **exists** and is identified correctly (right document number/title)
+- Its **status** is current — flag citations to entries marked `rescinded`,
+  `revoked`, or `superseded` (e.g. a doc citing a rescinded OMB memo as live
+  guidance)
+- The claim doesn't misattribute a control or requirement to the wrong source
+
+If a cited source is **not in the registry**, do not assume it is wrong — flag it
+as "unverified against the registry" and note the registry may need the entry
+added (a tracker gap), rather than asserting the citation is invalid.
+
+### 4. Distinguish "certified" from "aligned"
+
+Apply this bright line, which is the most common overclaim:
+
+- **"Certified" / "authorized" / "accredited" / "has an ATO"** are *status*
+  claims granted by an external authority (a 3PAO, an AO, the FedRAMP PMO). A
+  document MUST NOT assert these unless it cites the authorizing artifact.
+- **"Aligned with" / "implements the practices of" / "designed to meet"** are
+  *effort* claims and are acceptable when scoped and cited.
+
+Recommend downgrading status claims to effort claims when no authorizing artifact
+is cited.
+
+### 5. Report — never assert compliance
+
+Produce the output below. The report:
+
+- **Flags** problems and **suggests** citations or rewordings
+- **Never** states that the subject *is* compliant/authorized/certified
+- Points the author to the playbook for authoritative policy and to the registry
+  for correct citations
+- When unsure whether a claim is overstated, flags it for human judgment rather
+  than clearing it
+
+## Output Contract
+
+```markdown
+## Summary
+<1-3 sentences: how many claims found, how many flagged, overall risk of overclaiming.>
+
+## Findings
+For each flagged claim:
+- **Claim (quoted):** "<the exact text>"
+- **Location:** <file/section/line>
+- **Class:** uncited | overclaimed | stale-citation | unverified-against-registry
+- **Why flagged:** <one sentence>
+- **Suggested fix:** <add citation to <source> | downgrade "certified" → "aligned with" | correct/refresh the citation | remove the claim>
+
+## Notes
+- Registry gaps: <any cited source not found in federal-ai-landscape.yaml that may need adding>
+- This review checks claims only; it does not determine compliance. See the playbook for authoritative policy.
+```
+
+## Verification
+
+- Every flagged claim quotes the original text and names a class and a fix
+- The report makes **no** new compliance assertion of its own (check the output
+  against the `New Compliance Assertions` prohibited-content rule)
+- Every "verify against the registry" step names the specific registry entry
+  (or explicitly notes the source is absent from the registry)
+
+## Examples
+
+### Example 1 — overclaim (status vs effort)
+
+Input: `> This service is FedRAMP compliant and NIST 800-53 certified.`
+
+Finding:
+- **Class:** overclaimed
+- **Why:** "FedRAMP compliant" and "800-53 certified" are authorization/status
+  claims with no cited authorizing artifact (ATO letter, FedRAMP marketplace
+  listing). "Certified" is not a status NIST 800-53 confers.
+- **Suggested fix:** downgrade to "designed to align with NIST SP 800-53 Rev 5
+  controls" and, if an ATO exists, cite it; otherwise remove the FedRAMP status
+  claim.
+
+### Example 2 — uncited claim
+
+Input: `Our pipeline follows secure software development best practices.`
+
+Finding:
+- **Class:** uncited
+- **Suggested fix:** cite the source if a specific one is meant (e.g. "follows
+  NIST SP 800-218 SSDF practices") or reword to avoid implying a standard.
+
+### Example 3 — stale citation
+
+Input: `Per OMB M-24-10, our agency's AI governance…`
+
+Finding:
+- **Class:** stale-citation
+- **Why:** the registry marks M-24-10 as rescinded/superseded; the live OMB AI
+  governance memo is M-25-21.
+- **Suggested fix:** cite M-25-21 as the current governance memo; reference
+  M-24-10 only historically.
+
+### Example 4 — well-formed claim (not flagged)
+
+Input: `Access control follows the least-privilege principle described in NIST
+SP 800-53 AC-6.`
+
+Finding: none — the claim is scoped (AC-6, least privilege) and cited (SP 800-53),
+and it describes an *effort/design* alignment, not a certification.
+
+## References
+
+- Federal source registry (citation verification):
+  [`FEDERAL-AI-LANDSCAPE.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/FEDERAL-AI-LANDSCAPE.md)
+- Authoritative policy (never restated here):
+  [playbook `AGENTS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md),
+  [`SECURITY-CONTROLS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/SECURITY-CONTROLS.md)
+- Governance model for security skills:
+  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)

--- a/.agents/skills/compliance-claim-checker/tests/test-cases.yml
+++ b/.agents/skills/compliance-claim-checker/tests/test-cases.yml
@@ -1,0 +1,135 @@
+# Test cases for compliance-claim-checker skill
+# Schema version: 1.0.0
+
+suite:
+  pattern_id: compliance-claim-checker
+  pattern_version: "1.0.0"
+  description: "Tests for the compliance claim checker pattern"
+
+test_cases:
+  - id: flags-overclaim-certified
+    name: "Flags status overclaim (certified/authorized without artifact)"
+    description: "A report reviewing a 'FedRAMP certified' claim flags it as overclaimed and suggests downgrading to an effort claim"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 2 compliance claims; 1 flagged for overclaiming.
+
+        ## Findings
+        - **Claim (quoted):** "This service is FedRAMP compliant and NIST 800-53 certified."
+        - **Location:** README.md, Overview
+        - **Class:** overclaimed
+        - **Why flagged:** "certified"/"compliant" are status claims with no cited authorizing artifact.
+        - **Suggested fix:** downgrade to "designed to align with NIST SP 800-53 Rev 5 controls"; cite an ATO if one exists.
+
+        ## Notes
+        - This review checks claims only; it does not determine compliance.
+    assertions:
+      - type: contains
+        pattern: "overclaimed"
+        case_sensitive: false
+      - type: contains
+        pattern: "align with"
+        case_sensitive: false
+
+  - id: flags-uncited-claim
+    name: "Flags an uncited compliance claim"
+    description: "A vague best-practices claim with no source is flagged as uncited"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        1 compliance claim found; 1 uncited.
+
+        ## Findings
+        - **Claim (quoted):** "Our pipeline follows secure software development best practices."
+        - **Location:** docs/security.md
+        - **Class:** uncited
+        - **Suggested fix:** cite the specific source (e.g. NIST SP 800-218 SSDF) or reword to avoid implying a standard.
+    assertions:
+      - type: contains
+        pattern: "uncited"
+        case_sensitive: false
+
+  - id: flags-stale-citation
+    name: "Flags a stale/superseded citation"
+    description: "A claim citing a rescinded OMB memo as live guidance is flagged"
+    input:
+      type: literal
+      content: |
+        ## Findings
+        - **Claim (quoted):** "Per OMB M-24-10, our AI governance approach..."
+        - **Class:** stale-citation
+        - **Why flagged:** the registry marks M-24-10 as rescinded/superseded; the current OMB AI governance memo is M-25-21.
+        - **Suggested fix:** cite M-25-21 as current; reference M-24-10 only historically.
+    assertions:
+      - type: contains
+        pattern: "M-25-21"
+      - type: contains
+        pattern: "stale-citation"
+        case_sensitive: false
+
+  - id: has-required-sections
+    name: "Output has required sections"
+    description: "Check that the report includes Summary and Findings"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        No compliance claims found in the reviewed text.
+
+        ## Findings
+        None.
+
+        ## Notes
+        This review checks claims only; it does not determine compliance.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "Findings"
+
+  - id: does-not-assert-compliance
+    name: "Report does not assert compliance itself"
+    description: "The report must not state the subject IS compliant/authorized/certified"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 3 claims; 2 well-formed, 1 flagged.
+
+        ## Findings
+        - **Claim (quoted):** "Access control follows least privilege per NIST SP 800-53 AC-6."
+        - **Class:** cited & scoped — not flagged.
+
+        ## Notes
+        This review checks claims only; it does not determine compliance. See the playbook for authoritative policy.
+    assertions:
+      - type: no_prohibited
+        patterns:
+          - "is fully compliant"
+          - "we certify"
+          - "is FedRAMP authorized"
+          - "grants an ATO"
+
+  - id: notes-registry-gap
+    name: "Notes a citation not found in the registry"
+    description: "An unverifiable citation is flagged as unverified, not asserted invalid, and a possible registry gap is noted"
+    input:
+      type: literal
+      content: |
+        ## Findings
+        - **Claim (quoted):** "Conforms to Agency Directive XYZ-2026-07."
+        - **Class:** unverified-against-registry
+        - **Why flagged:** source not found in federal-ai-landscape.yaml; cannot confirm identity or status.
+
+        ## Notes
+        - Registry gaps: "Agency Directive XYZ-2026-07" is absent from federal-ai-landscape.yaml and may need adding.
+    assertions:
+      - type: contains
+        pattern: "unverified-against-registry"
+        case_sensitive: false
+      - type: contains
+        pattern: "Registry gap"
+        case_sensitive: false

--- a/.agents/skills/incident-evidence-review/SKILL.md
+++ b/.agents/skills/incident-evidence-review/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: incident-evidence-review
+id: incident-evidence-review
+version: "1.0.0"
+title: "Incident Evidence Review"
+type: skill
+description: "Review incident and postmortem write-ups for evidence discipline — separating facts, assumptions, hypotheses, and timeline — and flag unsupported claims, without conducting the investigation or determining root cause"
+
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+
+primary_personas:
+  - developers
+  - security
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Findings"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "Real Incident Data"
+      - "Live IOCs Or Victim Identifiers"
+      - "Internal Hostnames"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "incident review"
+  - "postmortem"
+  - "evidence discipline"
+  - "root cause"
+  - "timeline"
+  - "hypothesis"
+  - "assumption"
+
+tags:
+  - "security"
+  - "incident-response"
+  - "postmortem"
+  - "evidence"
+
+categories:
+  - "security"
+  - "incident-response"
+  - "review"
+
+risk_tier: high
+human_review_required: true
+allowed_tools: []
+network_policy: deny
+write_policy: deny
+script_policy: deny
+
+compliance:
+  frameworks:
+    - "NIST SP 800-53"
+    - "NIST SP 800-61"
+  nist_controls:
+    - "IR-4"
+    - "IR-6"
+    - "AU-6"
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Review an incident write-up or postmortem draft for evidence discipline"
+    - "Classify each statement as fact, assumption, hypothesis, or timeline entry"
+    - "Flag claims presented as fact that lack a source or log citation"
+    - "Flag hypotheses stated as settled conclusions"
+    - "Flag real PII, IOCs, or hostnames that should be redacted from the write-up"
+  exclusions:
+    - "Does NOT conduct the investigation or gather live evidence"
+    - "Not a SIEM, log analyzer, or detection tool"
+    - "Does NOT determine authoritative root cause — that is the IR team's role"
+    - "Not for live incident response; defers process to the agency IR plan"
+
+source_inspiration: []  # No external source; grounded in the playbook and NIST IR guidance.
+
+changelog:
+  - version: "1.0.0"
+    date: "2026-07-01"
+    change_type: minor
+    summary: "Initial version — enforces evidence discipline on incident/postmortem write-ups by classifying facts, assumptions, hypotheses, and timeline, and flagging unsupported claims; conducts no investigation and asserts no root cause."
+---
+
+# Skill: Incident Evidence Review
+
+Review an incident or postmortem write-up for **evidence discipline**. Sort every
+statement into **facts**, **assumptions**, **hypotheses**, and **timeline**
+entries, then flag anything presented as fact that lacks support and any
+hypothesis stated as a settled conclusion.
+
+> **Self-limiting: this skill reviews incident write-ups; it does not run the
+> investigation.** It never gathers live evidence, never determines authoritative
+> root cause, and never handles live incident data. All examples here are
+> synthetic. The investigation process itself belongs to the
+> [agentic-coding-playbook](https://github.com/GSA-TTS/agentic-coding-playbook)
+> and your agency incident-response (IR) plan; this skill defers to both.
+
+## When to Use
+
+- Reviewing a postmortem or incident report draft before it is shared
+- Checking whether a write-up's conclusions are actually supported by evidence
+- Separating what was observed from what was guessed after an incident
+- Confirming a timeline is complete and ordered before publication
+
+## When NOT to Use
+
+- During a live incident — follow the IR plan, not a document review
+- To *decide* root cause — that is the IR team's determination, not this skill's
+- As a log-analysis or detection tool (this skill reads prose, not telemetry)
+- To handle real incident data, IOCs, or victim details — those must be redacted
+  before any review
+
+## Prerequisites
+
+- Access to the incident write-up or postmortem text being reviewed
+- The text should already be sanitized: no live IOCs, real hostnames/IPs, or
+  victim identifiers. If it is not, redaction is the first finding.
+- Familiarity with the agency IR plan and the playbook IR guidance (referenced,
+  not restated here)
+
+## Procedure
+
+### 1. Read the material
+
+Read the full incident or postmortem write-up before classifying anything.
+Note the section structure (summary, narrative, timeline, root cause,
+remediation) so each statement is judged in context.
+
+### 2. Classify each statement
+
+Sort every substantive statement into exactly one class:
+
+| Class | Definition |
+|-------|------------|
+| **FACT** | An observed event backed by a source — a log line, alert, ticket, or artifact citation |
+| **ASSUMPTION** | Taken as given but not verified — a working premise, not evidence |
+| **HYPOTHESIS** | A proposed explanation not yet confirmed by evidence |
+| **TIMELINE** | A time-ordered event entry (timestamp + what happened) |
+
+### 3. Flag facts without evidence
+
+Flag any statement presented as a **fact** that names no source. A claim like
+"the outage began at 02:00" is a fact only if a log, alert, or ticket supports
+it. With no citation, downgrade it to an **assumption** or require the source.
+
+### 4. Flag hypotheses stated as conclusions
+
+Flag any **hypothesis** written as settled fact — for example, "the attacker
+used stolen credentials" stated with certainty but no supporting evidence. A
+hypothesis MUST read as a proposed explanation until evidence confirms it.
+
+### 5. Check the timeline
+
+Review the timeline for **gaps** (unexplained jumps between events) and
+**ordering** problems (events out of sequence, or effects listed before their
+causes). Note any timestamp that is asserted without a source.
+
+### 6. Flag data that must be redacted
+
+Flag any **real** PII, IOC (IP, domain, hash), hostname, or victim identifier
+that appears in the write-up and should be redacted before sharing. Recommend a
+synthetic placeholder in its place.
+
+### 7. Report — do not conclude root cause
+
+Produce the output below. The report classifies statements, flags unsupported
+claims, and recommends fixes. It **never** asserts the authoritative root cause
+and **never** reproduces real incident data.
+
+## Evidence Discipline
+
+This is the heart of the skill: keep the four classes distinct and never let one
+masquerade as another.
+
+- A **fact** is something that was *observed* and can be *pointed to* — "the auth
+  service returned 500s from 02:00–02:14 (per app log)." No source, not a fact.
+- An **assumption** is a premise *taken as true to move forward* — "we assume the
+  config change deployed cleanly." Useful, but unverified, and must be labeled so.
+- A **hypothesis** is a *proposed explanation* under test — "the 500s were caused
+  by the config change." It stays a hypothesis until evidence confirms it.
+- The classic failures are a **hypothesis dressed as a conclusion** ("the config
+  change caused the outage") and an **assumption dressed as a fact** ("the change
+  deployed cleanly"). Flag both. Naming the class is the discipline.
+
+## Output Contract
+
+```markdown
+## Summary
+<1-3 sentences: how many statements reviewed, how many flagged, and whether any
+real data needs redaction.>
+
+## Findings
+For each reviewed statement:
+- **Statement (quoted):** "<the exact text>"
+- **Class:** FACT | ASSUMPTION | HYPOTHESIS | TIMELINE
+- **Evidence:** <cited source, or "none given">
+- **Flag:** unsupported-fact | hypothesis-as-conclusion | timeline-gap |
+  needs-redaction | none
+- **Suggested fix:** <cite the log | downgrade to assumption/hypothesis | add the
+  missing timeline entry | redact and use a synthetic placeholder>
+
+## Notes
+- This review checks evidence discipline only; it does not determine root cause.
+  See the playbook and the agency IR plan for the investigation process.
+```
+
+## Verification
+
+- Every reviewed statement is classified (FACT / ASSUMPTION / HYPOTHESIS /
+  TIMELINE) — nothing is left unlabeled
+- Every statement presented as a fact without a source is flagged
+  `unsupported-fact`, and every hypothesis stated as certain is flagged
+  `hypothesis-as-conclusion`
+- The output contains **no** real incident data, PII, IOCs, or hostnames — every
+  example is synthetic (check against the prohibited-content rules)
+- The report makes no authoritative root-cause determination of its own
+
+## Examples
+
+All examples use **synthetic** incident data only.
+
+### Example 1 — fact without evidence
+
+Input: `> The breach started at 02:00.`
+
+Finding:
+- **Class:** FACT (as written)
+- **Evidence:** none given
+- **Flag:** unsupported-fact
+- **Suggested fix:** cite the log or alert that shows the 02:00 start, or
+  downgrade to an assumption ("we believe it started around 02:00") until a
+  source is attached.
+
+### Example 2 — hypothesis stated as a conclusion
+
+Input: `> The attacker used stolen credentials to log in.`
+
+Finding:
+- **Class:** HYPOTHESIS
+- **Evidence:** none given
+- **Flag:** hypothesis-as-conclusion
+- **Suggested fix:** reword as a hypothesis under test ("a leading hypothesis is
+  stolen-credential reuse; pending auth-log review") until an authentication log
+  confirms it.
+
+### Example 3 — well-supported fact (not flagged)
+
+Input: `> The auth service returned HTTP 500s from 02:00–02:14 (per the
+application log, request IDs redacted).`
+
+Finding:
+- **Class:** FACT
+- **Evidence:** application log (cited), sensitive fields redacted
+- **Flag:** none — observed, sourced, and scoped. Correctly not flagged.
+
+### Example 4 — timeline gap
+
+Input:
+```
+02:00 — errors begin
+02:45 — service restored
+```
+
+Finding:
+- **Class:** TIMELINE
+- **Flag:** timeline-gap
+- **Suggested fix:** the 45-minute span between "errors begin" and "restored"
+  has no intervening entries; add the detection, escalation, and mitigation
+  events (with sources) to close the gap.
+
+## References
+
+- Authoritative IR process (never restated here): playbook
+  [`AGENTS.md` §9 Incident Response](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md)
+- NIST SP 800-61, *Computer Security Incident Handling Guide* (IR guidance)
+- NIST SP 800-53 IR-4 (Incident Handling), IR-6 (Incident Reporting), AU-6
+  (Audit Record Review) — controls this review supports
+- Governance model for security skills:
+  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)

--- a/.agents/skills/incident-evidence-review/tests/test-cases.yml
+++ b/.agents/skills/incident-evidence-review/tests/test-cases.yml
@@ -1,0 +1,149 @@
+# Test cases for incident-evidence-review skill
+# Schema version: 1.0.0
+# All fixtures use SYNTHETIC incident data — no real hostnames, IPs, victims, or IOCs.
+
+suite:
+  pattern_id: incident-evidence-review
+  pattern_version: "1.0.0"
+  description: "Tests for the incident evidence review pattern"
+
+test_cases:
+  - id: flags-unsupported-fact
+    name: "Flags a claim stated as fact without evidence"
+    description: "A '02:00 start' claim presented as fact with no log citation is flagged unsupported-fact"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 3 statements; 1 flagged as an unsupported fact.
+
+        ## Findings
+        - **Statement (quoted):** "The breach started at 02:00."
+        - **Class:** FACT
+        - **Evidence:** none given
+        - **Flag:** unsupported-fact
+        - **Suggested fix:** cite the log or alert showing the 02:00 start, or downgrade to an assumption until a source is attached.
+
+        ## Notes
+        This review checks evidence discipline only; it does not determine root cause.
+    assertions:
+      - type: contains
+        pattern: "unsupported-fact"
+        case_sensitive: false
+
+  - id: flags-hypothesis-as-conclusion
+    name: "Flags a hypothesis presented as a conclusion"
+    description: "A stolen-credentials explanation stated with certainty is flagged hypothesis-as-conclusion"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 2 statements; 1 hypothesis stated as a conclusion.
+
+        ## Findings
+        - **Statement (quoted):** "The attacker used stolen credentials to log in."
+        - **Class:** HYPOTHESIS
+        - **Evidence:** none given
+        - **Flag:** hypothesis-as-conclusion
+        - **Suggested fix:** reword as a hypothesis under test until an authentication log confirms it.
+    assertions:
+      - type: contains
+        pattern: "hypothesis-as-conclusion"
+        case_sensitive: false
+
+  - id: well-supported-fact-not-flagged
+    name: "A well-supported fact is correctly NOT flagged"
+    description: "Boundary case — an observed, sourced, redacted fact is classified FACT with flag none"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 1 statement; none flagged.
+
+        ## Findings
+        - **Statement (quoted):** "The auth service returned HTTP 500s from 02:00-02:14 (per the application log, request IDs redacted)."
+        - **Class:** FACT
+        - **Evidence:** application log (cited), sensitive fields redacted
+        - **Flag:** none
+        - **Suggested fix:** none — observed, sourced, and scoped.
+    assertions:
+      - type: contains
+        pattern: "none"
+        case_sensitive: false
+
+  - id: has-required-sections
+    name: "Output has required sections"
+    description: "Check that the report includes Summary and Findings"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        No evidence-discipline issues found in the reviewed write-up.
+
+        ## Findings
+        None.
+
+        ## Notes
+        This review checks evidence discipline only; it does not determine root cause.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "Findings"
+
+  - id: no-real-incident-data
+    name: "Report contains no real incident data, PII, or IOCs"
+    description: "The report must use synthetic data only — no real hostnames, IPs, victims, or live IOCs"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 2 synthetic statements; 1 flagged for redaction guidance.
+
+        ## Findings
+        - **Statement (quoted):** "A host on the internal network began emitting alerts."
+        - **Class:** FACT
+        - **Evidence:** alert log (cited)
+        - **Flag:** needs-redaction
+        - **Suggested fix:** replace any real hostname or IP with a synthetic placeholder before sharing.
+
+        ## Notes
+        This review checks evidence discipline only; it does not determine root cause.
+    assertions:
+      - type: no_prohibited
+        patterns:
+          - "@gsa.gov"
+          - "10.0.0."
+          - "192.168."
+          - ".internal.agency.gov"
+          - "CVE-2026-"
+
+  - id: demonstrates-classification
+    name: "Demonstrates FACT / ASSUMPTION / HYPOTHESIS classification"
+    description: "The output shows the signature evidence-discipline classes in use"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 3 statements across three evidence classes.
+
+        ## Findings
+        - **Statement (quoted):** "Error rate rose to 40% at 02:05 (per metrics dashboard)."
+          - **Class:** FACT
+          - **Flag:** none
+        - **Statement (quoted):** "We assume the 01:50 config change deployed cleanly."
+          - **Class:** ASSUMPTION
+          - **Flag:** none
+        - **Statement (quoted):** "The config change likely caused the error spike."
+          - **Class:** HYPOTHESIS
+          - **Flag:** none
+
+        ## Notes
+        This review checks evidence discipline only; it does not determine root cause.
+    assertions:
+      - type: contains
+        pattern: "FACT"
+      - type: contains
+        pattern: "ASSUMPTION"
+      - type: contains
+        pattern: "HYPOTHESIS"

--- a/.agents/skills/least-privilege-review/SKILL.md
+++ b/.agents/skills/least-privilege-review/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: least-privilege-review
+id: least-privilege-review
+version: "1.0.0"
+title: "Least Privilege Review"
+type: skill
+description: "Review permission scope — GitHub Actions GITHUB_TOKEN, PAT/GitLab token scopes, cloud IAM policies, MCP/tool allowlists, service accounts, and delegated agent authority — and flag over-broad grants, suggesting least-privilege alternatives"
+
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+
+primary_personas:
+  - developers
+  - security
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Findings"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "Real Credentials"
+      - "Over-broad Grants Presented As Safe"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "least privilege"
+  - "permissions"
+  - "GITHUB_TOKEN"
+  - "write-all"
+  - "IAM policy"
+  - "token scope"
+  - "over-broad"
+
+tags:
+  - "security"
+  - "permissions"
+  - "iam"
+  - "github-actions"
+  - "least-privilege"
+
+categories:
+  - "security"
+  - "review"
+
+risk_tier: moderate
+human_review_required: true
+allowed_tools: []
+network_policy: deny
+write_policy: deny
+script_policy: deny
+
+compliance:
+  frameworks:
+    - "NIST SP 800-53"
+  nist_controls:
+    - "AC-6"
+    - "AC-3"
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Review GitHub Actions GITHUB_TOKEN `permissions:` blocks for over-broad grants"
+    - "Review PAT / GitLab token scopes against what the task actually needs"
+    - "Review cloud IAM policy JSON for wildcard actions or resources"
+    - "Review MCP / tool allowlists and service-account roles for excess authority"
+    - "Suggest the minimal, least-privilege replacement for each flagged grant"
+  exclusions:
+    - "Does NOT grant, apply, or provision any permission — it only flags and suggests"
+    - "Covers permission SCOPE generally; the LLM-in-CI trigger and prompt-injection surface belongs to agentic-actions-auditor"
+    - "Does not determine or assert compliance (see compliance-claim-checker)"
+    - "Not a substitute for a control assessor or authorizing official"
+
+source_inspiration: []  # No external source copied; grounded in the playbook's own control mappings.
+
+changelog:
+  - version: "1.0.0"
+    date: "2026-07-01"
+    change_type: minor
+    summary: "Initial version — enumerates permission surfaces, flags over-broad grants, and suggests least-privilege replacements per NIST AC-6/AC-3, without granting any permission itself."
+---
+
+# Skill: Least Privilege Review
+
+Review the **permission scope** declared across a change — GitHub Actions
+`GITHUB_TOKEN` blocks, personal-access / GitLab token scopes, cloud IAM policy
+JSON, MCP or tool allowlists, service-account roles, and delegated agent
+authority — and flag any grant **broader than the stated task needs**, suggesting
+a tighter least-privilege replacement.
+
+> **This skill is self-limiting.** It flags over-broad scope and suggests
+> least-privilege alternatives; it does **not** grant, apply, or provision any
+> permission. Control authority lives in the
+> [agentic-coding-playbook](https://github.com/GSA-TTS/agentic-coding-playbook)
+> `SECURITY-CONTROLS.md`; this skill defers to it and cites NIST AC-6 rather than
+> restating the control text.
+
+## When to Use
+
+- Reviewing a workflow that sets `permissions:` on `GITHUB_TOKEN` (or omits it)
+- Reviewing a PAT / GitLab token, deploy key, or fine-grained token before it is
+  minted or used in CI
+- Reviewing cloud IAM policy JSON, a service-account role, or a Terraform grant
+- Reviewing an MCP server config or agent tool allowlist for excess authority
+- Before delegating authority to an agent or automated job
+
+## When NOT to Use
+
+- To *grant* or *apply* a permission — this skill only flags and suggests
+- To audit the LLM-in-CI trigger or prompt-injection surface — use
+  `agentic-actions-auditor` for that (this skill is scope, not trigger)
+- To decide whether a system is compliant (use `compliance-claim-checker`)
+- As a substitute for an authorizing official's risk acceptance
+
+## Prerequisites
+
+- Access to the config being reviewed (workflow YAML, IAM JSON, token scope list,
+  MCP/tool config, or role definition)
+- A clear statement of what the task actually needs to do (the "job to be done"),
+  so "minimum needed" can be judged against a real requirement
+
+## Procedure
+
+### 1. Enumerate the permission surfaces present
+
+Scan the change for every place authority is granted. Common surfaces:
+
+| Surface | Where it appears |
+|---------|------------------|
+| GitHub Actions token | `permissions:` block on `GITHUB_TOKEN` (workflow or job) |
+| PAT / GitLab token | Token scope list (e.g. `repo`, `workflow`, `api`) |
+| Cloud IAM policy | JSON `Action` / `Resource` arrays |
+| MCP / tool allowlist | `allowed_tools`, tool config, `network_policy`, `write_policy` |
+| Service account / role | Role bindings, attached policies, machine identities |
+| Delegated agent authority | What an agent or job is permitted to run or reach |
+
+### 2. Determine the minimum needed for the stated task
+
+For each surface, ask: **what is the smallest set of permissions that lets the
+task succeed?** A job that reads code and posts a review comment needs
+`contents: read` and `pull-requests: write` — not repo write. Write down the
+minimum before comparing.
+
+### 3. Flag grants broader than needed
+
+Flag anything wider than the minimum from step 2. Watch for:
+
+- `permissions: write-all` or an omitted block that inherits broad defaults
+- `contents: write` where `contents: read` suffices
+- IAM `"Action": "*"` or a service-wide `"s3:*"` where a few verbs suffice
+- Wildcard resources: `"Resource": "*"` where a specific ARN suffices
+- PAT scopes beyond the task (e.g. full `repo` when read-only would do)
+- MCP/tool allowlists granting write, network, or script authority not needed
+- Standing (long-lived) grants where a short-lived or scoped token would do
+
+### 4. Suggest the least-privilege replacement
+
+For every flagged grant, propose the tighter form:
+
+- `write-all` → an explicit block listing only the scopes used
+- `contents: write` → `contents: read` when nothing is pushed
+- `"Action": "*"` → the enumerated verbs actually called
+- `"Resource": "*"` → the specific ARN(s) touched
+- Broad PAT → a fine-grained token scoped to one repo and the needed permissions
+
+### 5. Reference the control, do not restate it
+
+Anchor each finding to **NIST SP 800-53 AC-6 (Least Privilege)** and, where a
+grant crosses a boundary between roles or subjects, **AC-3 (Access
+Enforcement)** — by citation only. Do not paste control text; point to the
+playbook `SECURITY-CONTROLS.md`.
+
+### 6. Report — never grant or apply
+
+Produce the output below. The report flags and suggests; it never presents an
+over-broad grant as acceptable, and it never grants, mints, or applies a
+permission.
+
+## Output Contract
+
+```markdown
+## Summary
+<1-3 sentences: how many surfaces reviewed, how many grants flagged, overall over-privilege risk.>
+
+## Findings
+For each flagged grant:
+- **Surface:** github-token | pat-scope | iam-policy | mcp-tool | service-account | agent-authority
+- **Over-broad grant (quoted):** "<the exact line/field>"
+- **Location:** <file/section/line>
+- **Why flagged:** <one sentence: what task need it exceeds>
+- **Least-privilege replacement:** <the minimal grant that still works>
+- **Control:** AC-6 (least privilege)[ ; AC-3 (access enforcement)]
+
+## Notes
+- This review flags scope only; it grants no permission. LLM-in-CI trigger/injection is out of scope (see agentic-actions-auditor).
+- Control authority lives in the playbook SECURITY-CONTROLS.md.
+```
+
+## Verification
+
+- Every finding names the over-broad grant **and** a concrete minimal replacement
+- No real credentials, tokens, keys, or secrets appear in the output — quoted
+  scopes are permission *names*, never secret values
+- No finding tells the reader to widen a grant "to be safe"; broadening is never
+  the suggested fix
+- Each finding cites AC-6 (and AC-3 where roles/subjects cross) without restating
+  the control
+
+## Examples
+
+### Example 1 — GITHUB_TOKEN over-broad `write-all`
+
+Input: `permissions: write-all` on a workflow that only checks out code and
+comments on a PR.
+
+Finding:
+- **Surface:** github-token
+- **Over-broad grant:** `permissions: write-all`
+- **Why flagged:** grants every scope; the job only reads code and writes a PR
+  comment.
+- **Least-privilege replacement:** `permissions:\n  contents: read\n  pull-requests: write`
+- **Control:** AC-6
+
+### Example 2 — IAM wildcard action and resource
+
+Input: `"Action": "*", "Resource": "*"` on a role that only reads objects from
+one bucket.
+
+Finding:
+- **Surface:** iam-policy
+- **Over-broad grant:** `"Action": "*"` with `"Resource": "*"`
+- **Why flagged:** allows every action on every resource; the task only reads one
+  bucket.
+- **Least-privilege replacement:** `"Action": ["s3:GetObject", "s3:ListBucket"]`
+  scoped to the specific bucket ARN(s).
+- **Control:** AC-6; AC-3 (the role acts across service boundaries)
+
+### Example 3 — PAT with more scopes than needed (edge)
+
+Input: a PAT with full `repo`, `workflow`, and `admin:org` used only to read one
+repository's contents in CI.
+
+Finding:
+- **Surface:** pat-scope
+- **Over-broad grant:** `repo`, `workflow`, `admin:org`
+- **Why flagged:** three broad scopes for a read-only, single-repo task.
+- **Least-privilege replacement:** a fine-grained token scoped to that one repo
+  with `Contents: Read-only`; drop `workflow` and `admin:org`.
+- **Control:** AC-6
+
+### Example 4 — correctly scoped (not flagged)
+
+Input:
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+```
+on a job that reads code and posts a review comment.
+
+Finding: none — the grant matches the task's minimum (read code, write a PR
+comment) and adds nothing extra.
+
+## References
+
+- Authoritative controls (never restated here):
+  [playbook `SECURITY-CONTROLS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/SECURITY-CONTROLS.md)
+  — AC-6 (Least Privilege), AC-3 (Access Enforcement)
+- Least-privilege behavioral rule:
+  [playbook `AGENTS.md` §3](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md)
+- GitHub Actions token permissions:
+  [Assigning permissions to `GITHUB_TOKEN`](https://docs.github.com/actions/security-guides/automatic-token-authentication)
+- Boundary partner (trigger/injection surface):
+  `agentic-actions-auditor`
+- Governance model for security skills:
+  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)

--- a/.agents/skills/least-privilege-review/tests/test-cases.yml
+++ b/.agents/skills/least-privilege-review/tests/test-cases.yml
@@ -1,0 +1,144 @@
+# Test cases for least-privilege-review skill
+# Schema version: 1.0.0
+
+suite:
+  pattern_id: least-privilege-review
+  pattern_version: "1.0.0"
+  description: "Tests for the least privilege review pattern"
+
+test_cases:
+  - id: flags-github-token-write-all
+    name: "Flags an over-broad GITHUB_TOKEN grant"
+    description: "A report reviewing permissions: write-all flags it and suggests a scoped replacement"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 1 permission surface; 1 grant flagged as over-broad.
+
+        ## Findings
+        - **Surface:** github-token
+        - **Over-broad grant (quoted):** "permissions: write-all"
+        - **Location:** .github/workflows/review.yml
+        - **Why flagged:** grants every scope; the job only reads code and writes a PR comment.
+        - **Least-privilege replacement:** contents: read, pull-requests: write
+        - **Control:** AC-6 (least privilege)
+
+        ## Notes
+        - This review flags scope only; it grants no permission.
+    assertions:
+      - type: contains
+        pattern: "write-all"
+        case_sensitive: false
+      - type: contains
+        pattern: "least-privilege replacement"
+        case_sensitive: false
+
+  - id: flags-iam-wildcard
+    name: "Flags a wildcard IAM action and resource"
+    description: "A report reviewing Action:* Resource:* flags it and enumerates the minimal actions"
+    input:
+      type: literal
+      content: |
+        ## Findings
+        - **Surface:** iam-policy
+        - **Over-broad grant (quoted):** "Action: *" with "Resource: *"
+        - **Location:** infra/role-policy.json
+        - **Why flagged:** allows every action on every resource; the task only reads one bucket.
+        - **Least-privilege replacement:** enumerate ["s3:GetObject", "s3:ListBucket"] scoped to the specific bucket ARN.
+        - **Control:** AC-6; AC-3 (access enforcement)
+    assertions:
+      - type: contains
+        pattern: "s3:GetObject"
+      - type: contains
+        pattern: "AC-6"
+
+  - id: flags-pat-excess-scopes
+    name: "Flags a PAT with more scopes than needed"
+    description: "Edge case — a read-only single-repo task holds broad repo/workflow/admin:org scopes"
+    input:
+      type: literal
+      content: |
+        ## Findings
+        - **Surface:** pat-scope
+        - **Over-broad grant (quoted):** "repo, workflow, admin:org"
+        - **Why flagged:** three broad scopes for a read-only, single-repo task.
+        - **Least-privilege replacement:** a fine-grained token scoped to one repo with Contents: Read-only; drop workflow and admin:org.
+        - **Control:** AC-6 (least privilege)
+    assertions:
+      - type: contains
+        pattern: "fine-grained token"
+        case_sensitive: false
+      - type: contains
+        pattern: "Read-only"
+        case_sensitive: false
+
+  - id: has-required-sections
+    name: "Output has required sections"
+    description: "Check that the report includes Summary and Findings"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        No over-broad grants found across the reviewed surfaces.
+
+        ## Findings
+        None.
+
+        ## Notes
+        This review flags scope only; it grants no permission.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "Findings"
+
+  - id: no-unsafe-recommendation
+    name: "Report suggests no unsafe grant and leaks no credential"
+    description: "The report must not tell the reader to widen a grant to be safe, nor include real tokens"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 2 surfaces; 1 grant flagged, 1 correctly scoped.
+
+        ## Findings
+        - **Surface:** github-token
+        - **Over-broad grant (quoted):** "permissions: write-all"
+        - **Least-privilege replacement:** contents: read, pull-requests: write
+        - **Control:** AC-6
+
+        ## Notes
+        This review flags scope only; it grants no permission. Control authority lives in the playbook.
+    assertions:
+      - type: no_prohibited
+        patterns:
+          - "grant admin to be safe"
+          - "just use write-all"
+          - "ghp_"
+          - "AKIA"
+
+  - id: correctly-scoped-not-flagged
+    name: "A correctly scoped grant is not flagged"
+    description: "A minimal permissions block matching the task need passes with no finding"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 1 permission surface; no over-broad grants found.
+
+        ## Findings
+        - **Surface:** github-token
+        - **Grant:** contents: read, pull-requests: write
+        - **Result:** not flagged — matches the task minimum (read code, write a PR comment).
+
+        ## Notes
+        This review flags scope only; it grants no permission.
+    assertions:
+      - type: contains
+        pattern: "not flagged"
+        case_sensitive: false
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "Findings"

--- a/.agents/skills/safe-shell-script-author/SKILL.md
+++ b/.agents/skills/safe-shell-script-author/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: safe-shell-script-author
+id: safe-shell-script-author
+version: "1.0.0"
+title: "Safe Shell Script Author"
+type: skill
+description: "Draft safe Bash scripts to a clean-script standard (set -euo pipefail, mktemp + trap cleanup, quoted expansions, dry-run default, shellcheck/shfmt-clean) — never curl|sh, eval, or secret dumps; used when a task asks for a new shell script"
+
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+
+primary_personas:
+  - developers
+  - security
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Script"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "Destructive Commands Without Guards"
+      - "curl-pipe-to-shell"
+      - "eval on External Data"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "write a bash script"
+  - "shell script"
+  - "cleanup script"
+  - "set -euo pipefail"
+  - "safe script"
+  - "automation script"
+
+tags:
+  - "security"
+  - "bash"
+  - "shell"
+  - "scripting"
+  - "code-generation"
+
+categories:
+  - "security"
+  - "development"
+
+risk_tier: moderate
+human_review_required: true
+allowed_tools: []
+network_policy: deny
+write_policy: deny
+script_policy: author-only
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Draft a new Bash script from a stated intent, to the clean-script standard"
+    - "Emit safe defaults: strict mode, temp-file cleanup, quoted expansions, dry-run"
+    - "Explain why each safety property is present so a human can review it"
+  exclusions:
+    - "Does NOT execute or run the scripts it drafts — a human runs them"
+    - "Not for reviewing or fixing existing scripts (that is a review task)"
+    - "Not a substitute for shellcheck/shfmt or a human security review"
+    - "Not for languages other than Bash/POSIX shell"
+
+source_inspiration: []  # No external source; grounded in the playbook's own standards.
+
+changelog:
+  - version: "1.0.0"
+    date: "2026-07-01"
+    change_type: minor
+    summary: "Initial version — drafts safe Bash to a clean-script standard (strict mode, mktemp + trap, quoted vars, dry-run default), refuses curl|sh/eval/secret dumps, never executes."
+---
+
+# Skill: Safe Shell Script Author
+
+Draft a **new Bash script** from a stated intent, built to a **clean-script
+standard**: strict mode (`set -euo pipefail`), `mktemp` + `trap` cleanup, quoted
+expansions, a `--help` usage block, and a **dry-run default** that needs
+`--apply` to mutate anything. The output is a script plus a short rationale for
+each safety property.
+
+> **This skill DRAFTS scripts; it never executes them.** Every script it emits
+> defaults to dry-run and must be read and run by a human. It refuses to produce
+> `curl | sh`, `eval` on external data, or code that dumps secrets. Authoritative
+> secure-coding policy lives in the
+> [agentic-coding-playbook](https://github.com/GSA-TTS/agentic-coding-playbook);
+> this skill points there rather than restating it.
+
+## When to Use
+
+- A task asks you to write a new Bash automation, cleanup, or setup script
+- You want a safe skeleton (strict mode, cleanup, dry-run) as a starting point
+- You need the "why" behind each safety choice for a review
+
+## When NOT to Use
+
+- To **run** a script — this skill only drafts; a human executes
+- To review or repair an **existing** script (that is a separate review task)
+- For non-shell languages (Python, Go, etc.)
+- When the request itself is unsafe (see When NOT to Use → refuse, below)
+
+## Prerequisites
+
+- A clear statement of what the script should do (inputs, outputs, side effects)
+- Locally: `shellcheck` and `shfmt` available to lint/format the draft
+- The playbook secure-code-generation rules for reference (see References)
+
+## Procedure
+
+### 1. Gather intent
+
+Confirm the goal, inputs, and any **side effects** (files touched, dirs deleted,
+services called). If the request needs a destructive action (delete, overwrite,
+network call), note it — it will be gated behind `--apply` and guards.
+
+If the intent is inherently unsafe and cannot be made safe — e.g. "pipe this URL
+straight into bash", "eval this user string", "print all env vars including
+secrets" — **decline** and explain the safer alternative instead of emitting it.
+
+### 2. Emit the clean-script skeleton
+
+Draft the script on this skeleton. Every property below is required:
+
+- **Strict mode:** first real line is `set -euo pipefail`
+- **Safe IFS:** `IFS=$'\n\t'` to avoid word-splitting surprises
+- **Temp files via `mktemp`:** never a fixed `/tmp/foo` path
+- **Cleanup trap:** `trap cleanup EXIT INT TERM` removes temp files on any exit
+- **Quote all expansions:** `"$var"`, `"$@"`, `"${arr[@]}"` — never bare `$var`
+- **Usage / `--help`:** a `usage()` function and arg parsing
+- **Dry-run default:** the script previews actions by default; only `--apply`
+  performs mutations. Guard each destructive line on the apply flag.
+- **No `curl | sh`:** download and verify to a temp file, then act — never pipe
+  a remote body straight into a shell
+- **No `eval`** on external or untrusted data
+- **No secret dumps:** never `printenv` / `env` / echo credentials or tokens
+
+### 3. Lint mentally (shellcheck + shfmt)
+
+Read the draft as `shellcheck` would: unquoted vars, unset-var use, masked exit
+codes, `cd` without `|| exit`. Read it as `shfmt` would: consistent indentation
+and spacing. Fix issues before presenting. Note that the human should still run
+both tools for real.
+
+### 4. Present with rationale
+
+Return the Output Contract below: a short Summary, the fenced `bash` script, and
+a one-line rationale for each safety property so a reviewer can verify intent.
+
+## Clean-Script Standard
+
+A drafted script MUST satisfy every item:
+
+- [ ] `set -euo pipefail` is the first executable line
+- [ ] `IFS=$'\n\t'` set to tame word-splitting
+- [ ] All variable expansions are quoted (`"$var"`, `"$@"`)
+- [ ] Temp files created with `mktemp`; no fixed temp paths
+- [ ] `trap cleanup EXIT INT TERM` removes temp files
+- [ ] A `usage()` / `--help` block documents flags
+- [ ] Dry-run is the **default**; `--apply` is required to mutate
+- [ ] Destructive commands (`rm`, overwrite) are guarded by the apply flag
+- [ ] No `curl … | sh` / `wget … | sh`
+- [ ] No `eval` on external data
+- [ ] No printing of environment variables or secrets
+
+## Output Contract
+
+```markdown
+## Summary
+<1-3 sentences: what the script does, its default dry-run behavior, and the guard on mutations.>
+
+## Script
+​```bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+# ... the safe script ...
+​```
+
+Rationale:
+- **Strict mode / IFS:** stop on errors and unset vars; tame word-splitting.
+- **mktemp + trap:** temp files are unique and always cleaned up.
+- **Quoted expansions:** no accidental splitting or globbing.
+- **Dry-run default:** previews actions; `--apply` required to change anything.
+- **No curl|sh / eval / secret dumps:** avoids remote-code and disclosure risks.
+```
+
+## Verification
+
+Confirm the emitted script:
+
+- Contains `set -euo pipefail`
+- Quotes its variable expansions and includes a `trap` cleanup
+- **Defaults to dry-run** (a `--apply` flag gates every mutation)
+- Has both required sections (`Summary`, `Script`)
+
+And contains **none** of:
+
+- `curl … | sh` or `wget … | sh` (pipe-to-shell)
+- `eval` on external/untrusted data
+- `rm -rf` without a guard (never an unguarded `rm -rf /` or `rm -rf "$var"`
+  where `$var` could be empty)
+- `printenv` / `env` output or any echo of secrets/tokens
+
+## Examples
+
+### Example 1 — safe file-cleanup script (dry-run + trap)
+
+Intent: "Delete `*.tmp` files older than 7 days under a given directory."
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+APPLY=0
+TARGET_DIR=""
+WORKFILE=""
+
+usage() { echo "Usage: cleanup-tmp.sh --dir <path> [--apply] [--help]"; }
+
+cleanup() { [[ -n "${WORKFILE}" && -f "${WORKFILE}" ]] && rm -f "${WORKFILE}"; }
+trap cleanup EXIT INT TERM
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir) TARGET_DIR="${2:-}"; shift 2 ;;
+    --apply) APPLY=1; shift ;;
+    --help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [[ -z "${TARGET_DIR}" || ! -d "${TARGET_DIR}" ]]; then
+  echo "Error: --dir must be an existing directory" >&2
+  usage; exit 2
+fi
+
+WORKFILE="$(mktemp)"
+find "${TARGET_DIR}" -type f -name '*.tmp' -mtime +7 -print >"${WORKFILE}"
+
+while IFS= read -r file; do
+  if [[ "${APPLY}" -eq 1 ]]; then
+    rm -f -- "${file}"; echo "deleted: ${file}"
+  else
+    echo "[dry-run] would delete: ${file}"
+  fi
+done <"${WORKFILE}"
+```
+
+Rationale: strict mode + safe IFS; `mktemp` list file with a `trap` that removes
+it; every deletion is guarded by `--apply`; expansions are quoted; `rm -f --`
+cannot consume a flag-like or empty path.
+
+### Example 2 — good vs rejected pattern (download)
+
+- **Rejected (never emit):** `curl -fsSL https://example/install.sh | sh` — pipes
+  an unverified remote body straight into a shell.
+- **Good (emit instead):** download to a `mktemp` file, show/verify it, then run
+  only under `--apply`:
+
+```bash
+tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+curl -fsSL "$URL" -o "$tmp"
+echo "[dry-run] fetched installer to $tmp; review before running"
+[[ "${APPLY}" -eq 1 ]] && bash "$tmp"
+```
+
+### Example 3 — refusing an unsafe request
+
+Intent: "Write a script that prints every environment variable so I can grab the
+API token."
+
+Response: **Decline.** Dumping the environment exposes secrets. Draft instead a
+script that reads only the one **named, non-secret** variable it needs, or reads
+credentials from a secret store at runtime — never echoes them.
+
+## References
+
+- Secure code generation (never restated here):
+  [playbook `AGENTS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md)
+  §5, and
+  [`CODING_PRACTICES.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/CODING_PRACTICES.md)
+- ShellCheck (static analysis for shell): <https://www.shellcheck.net/>
+- shfmt (shell formatter): <https://github.com/mvdan/sh>
+- Governance model for security skills:
+  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)

--- a/.agents/skills/safe-shell-script-author/tests/test-cases.yml
+++ b/.agents/skills/safe-shell-script-author/tests/test-cases.yml
@@ -1,0 +1,149 @@
+# Test cases for safe-shell-script-author skill
+# Schema version: 1.0.0
+
+suite:
+  pattern_id: safe-shell-script-author
+  pattern_version: "1.0.0"
+  description: "Tests for the safe shell script author pattern"
+
+test_cases:
+  - id: emits-strict-mode
+    name: "Emitted script uses strict mode"
+    description: "A drafted cleanup script includes set -euo pipefail as its strict-mode header"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Drafts a cleanup script that previews deletions by default; --apply is required to remove files.
+
+        ## Script
+        ```bash
+        #!/usr/bin/env bash
+        set -euo pipefail
+        IFS=$'\n\t'
+        echo "safe skeleton"
+        ```
+
+        Rationale:
+        - **Strict mode / IFS:** stop on errors and unset vars.
+    assertions:
+      - type: contains
+        pattern: "set -euo pipefail"
+
+  - id: emits-trap-and-quoted-vars
+    name: "Emitted script has a trap cleanup and quoted expansions"
+    description: "The draft installs a trap for temp-file cleanup and quotes its variable expansions"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Drafts a script with a mktemp work file and a trap that removes it on exit.
+
+        ## Script
+        ```bash
+        #!/usr/bin/env bash
+        set -euo pipefail
+        IFS=$'\n\t'
+        WORKFILE="$(mktemp)"
+        cleanup() { rm -f "${WORKFILE}"; }
+        trap cleanup EXIT INT TERM
+        echo "using ${WORKFILE}"
+        ```
+    assertions:
+      - type: contains
+        pattern: "trap cleanup EXIT INT TERM"
+      - type: contains
+        pattern: "\"${WORKFILE}\""
+
+  - id: defaults-to-dry-run
+    name: "Emitted script defaults to dry-run"
+    description: "Mutations are gated behind an --apply flag; without it the script only previews"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Deletes stale files, but only with --apply; the default run is a dry-run preview.
+
+        ## Script
+        ```bash
+        #!/usr/bin/env bash
+        set -euo pipefail
+        APPLY=0
+        if [[ "${APPLY}" -eq 1 ]]; then
+          rm -f -- "${file}"
+        else
+          echo "[dry-run] would delete: ${file}"
+        fi
+        ```
+    assertions:
+      - type: contains
+        pattern: "[dry-run]"
+      - type: contains
+        pattern: "--apply"
+
+  - id: has-required-sections
+    name: "Output has required sections"
+    description: "Check that the output includes Summary and Script"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        A minimal safe script skeleton.
+
+        ## Script
+        ```bash
+        #!/usr/bin/env bash
+        set -euo pipefail
+        IFS=$'\n\t'
+        ```
+    assertions:
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "Script"
+
+  - id: no-prohibited-patterns
+    name: "Output contains no unsafe patterns"
+    description: "The emitted script must not pipe curl into a shell, eval external data, or run an unguarded rm -rf /"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Downloads an installer to a temp file for review; runs it only under --apply.
+
+        ## Script
+        ```bash
+        #!/usr/bin/env bash
+        set -euo pipefail
+        tmp="$(mktemp)"; trap 'rm -f "$tmp"' EXIT
+        curl -fsSL "$URL" -o "$tmp"
+        echo "[dry-run] fetched installer to $tmp; review before running"
+        [[ "${APPLY}" -eq 1 ]] && bash "$tmp"
+        ```
+    assertions:
+      - type: no_prohibited
+        patterns:
+          - "curl [^\\n]*\\| *sh\\b"
+          - "\\beval "
+          - "rm -rf /"
+
+  - id: declines-unsafe-request
+    name: "Declines an inherently unsafe request"
+    description: "A request to dump all env vars to grab a secret is refused, with a safer alternative offered"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Declines to dump the environment; dumping all env vars exposes secrets.
+
+        ## Script
+        Declined. Instead, read only the one named, non-secret variable needed,
+        or fetch credentials from a secret store at runtime — never echo them.
+    assertions:
+      - type: contains
+        pattern: "Declined"
+        case_sensitive: false
+      - type: no_prohibited
+        patterns:
+          - "\\bprintenv\\b"
+          - "env +\\| *grep"

--- a/.agents/skills/untrusted-input-boundary-review/SKILL.md
+++ b/.agents/skills/untrusted-input-boundary-review/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: untrusted-input-boundary-review
+id: untrusted-input-boundary-review
+version: "1.0.0"
+title: "Untrusted Input Boundary Review"
+type: skill
+description: "Map an agent's trust boundaries and review how it handles UNTRUSTED input (issue/PR text, tool/MCP output, web content, agent-to-agent messages) for prompt-injection and tool-poisoning — describing attack CLASSES, never shipping a working exploit"
+
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+
+primary_personas:
+  - developers
+  - security
+
+requires:
+  anchors: []
+
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Findings"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "Live Injection Payloads"
+      - "Working Jailbreak Prompts"
+
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+
+triggers:
+  - "prompt injection"
+  - "trust boundary"
+  - "untrusted input"
+  - "tool poisoning"
+  - "LLM01"
+  - "agent-to-agent"
+  - "MCP output"
+
+tags:
+  - "security"
+  - "review"
+  - "prompt-injection"
+  - "trust-boundary"
+  - "agentic"
+
+categories:
+  - "security"
+  - "review"
+
+risk_tier: moderate
+human_review_required: true
+allowed_tools: []
+network_policy: deny
+write_policy: deny
+script_policy: deny
+
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+
+scope:
+  intended_use:
+    - "Map the trust boundaries of an agent, workflow, or automation"
+    - "Classify each input source as trusted or untrusted"
+    - "Check that untrusted content is treated as DATA, not as instructions"
+    - "Flag prompt-injection (OWASP LLM01) and tool-poisoning exposure by CLASS"
+  exclusions:
+    - "Does NOT review app-level code vulns like SQLi/XSS (see secure-code-review)"
+    - "Does NOT audit CI trigger surface / workflow permissions (see agentic-actions-auditor)"
+    - "Does NOT set policy — defers all rules to the playbook"
+    - "Never crafts, tests, or ships a working injection payload or jailbreak"
+
+source_inspiration: []  # No external source; grounded in the playbook + OWASP LLM Top 10 by reference only.
+
+changelog:
+  - version: "1.0.0"
+    date: "2026-07-01"
+    change_type: minor
+    summary: "Initial version — maps agent trust boundaries and reviews untrusted-input handling for prompt-injection and tool-poisoning classes; describes attack classes only, never ships a live payload."
+---
+
+# Skill: Untrusted Input Boundary Review
+
+Map the **trust boundaries** of an agent, workflow, or automation, then review
+how it handles **untrusted input** — issue and PR text, tool and MCP output, web
+content, and agent-to-agent messages. The goal is to confirm untrusted content
+is treated as **data**, never as instructions the agent obeys.
+
+> **Self-limiting:** This skill reviews *trust-boundary handling*. It describes
+> injection and tool-poisoning **classes conceptually** and **never** crafts,
+> tests, or ships a working attack string or jailbreak prompt. It does not set
+> policy — authoritative prompt-injection defense lives in the
+> [agentic-coding-playbook](https://github.com/GSA-TTS/agentic-coding-playbook),
+> and this skill defers all rules to it. It is not a substitute for
+> app-level code review or a CI-permissions audit.
+
+## When to Use
+
+- Reviewing an agent, prompt, or workflow that consumes external content
+- The agent reads issue/PR bodies, comments, web pages, or file contents
+- The agent calls tools or MCP servers and acts on their output
+- Multiple agents exchange messages and act on each other's text
+- You ask "can untrusted text steer this agent?" or "where are the trust edges?"
+
+## When NOT to Use
+
+- To find app-level vulnerabilities (SQLi, XSS, auth) — use `secure-code-review`
+- To audit CI trigger surface or workflow permissions — use
+  `agentic-actions-auditor`
+- To decide organizational policy — defer to the playbook
+- To produce or validate any exploit — this skill never weaponizes anything
+
+## Prerequisites
+
+- Access to the agent definition, prompt, or workflow being reviewed
+- A list of the data sources and tools/MCP servers the agent can reach
+- Working knowledge of the OWASP LLM Top 10 (LLM01 prompt injection) by class
+- The playbook's prompt-injection defense guidance for the authoritative rules
+
+## Procedure
+
+### 1. Map the trust boundaries
+
+Draw the edges where data crosses into the agent's context. For each edge, note
+what enters (issue text, tool result, web page, peer-agent message) and what the
+agent can do next (call a tool, write a file, open a network call).
+
+### 2. Classify each input source
+
+Label every source as **trusted** or **untrusted**:
+
+| Source | Default classification |
+|--------|------------------------|
+| System / skill prompt authored by maintainers | Trusted |
+| Issue / PR body, comments, review threads | **Untrusted** |
+| Tool or MCP server output | **Untrusted** |
+| Fetched web content, scraped pages, search results | **Untrusted** |
+| Agent-to-agent messages from another agent | **Untrusted** |
+| Repo files that any contributor can edit | **Untrusted** |
+
+When unsure, classify as untrusted and flag for human judgment.
+
+### 3. Check that untrusted content is treated as DATA, not instructions
+
+For each untrusted source, confirm the agent:
+
+- Wraps the content in clear delimiters (e.g. `--- UNTRUSTED CONTENT START ---`)
+- States, in the trusted prompt, that delimited content is **data to analyze**,
+  not commands to follow
+- Does **not** interpolate untrusted text into an instruction position
+- Does **not** grant new tools, permissions, or network access based on what
+  untrusted text asks for
+
+### 4. Check the prompt-injection (OWASP LLM01) classes
+
+Look for exposure to these **classes** (describe the class; do not craft one):
+
+- **Direct instruction override** — untrusted text that tries to cancel or
+  replace the agent's real instructions (the "ignore previous instructions"
+  class). Describe the class only.
+- **Indirect / stored injection** — hostile instructions hidden in a page, file,
+  or issue the agent will later read.
+- **Data exfiltration steering** — untrusted text that tries to make the agent
+  reveal secrets or send data outward.
+- **Privilege / scope escalation** — untrusted text that tries to talk the agent
+  into calling a tool or action outside its allowlist.
+
+### 5. Check the tool-poisoning / untrusted tool-output classes
+
+- **Poisoned tool output** — a tool or MCP server returns content that embeds
+  instructions the agent might obey (treat tool output as untrusted).
+- **Malicious tool metadata** — a tool description or schema that itself carries
+  injected instructions into the prompt.
+- **Chained trust** — the agent forwards one tool's untrusted output straight
+  into another tool's input without re-classifying it as data.
+
+### 6. Report — by class, never with a live payload
+
+Produce the output below. The report names each exposure by **class**, points to
+the boundary, suggests a mitigation, and **never** includes a working payload or
+jailbreak. When unsure, flag for human review rather than clearing it.
+
+## Output Contract
+
+```markdown
+## Summary
+<1-3 sentences: boundaries mapped, untrusted sources found, how many exposures flagged, overall risk.>
+
+## Findings
+For each flagged boundary:
+- **Boundary:** <where untrusted data enters — e.g. "reads PR comment body">
+- **Source class:** untrusted-issue-pr | untrusted-tool-output | untrusted-web | untrusted-agent-message | untrusted-repo-file
+- **Exposure class:** direct-instruction-override | indirect-injection | data-exfiltration-steering | privilege-escalation | tool-poisoning | poisoned-tool-metadata | chained-trust
+- **Why flagged:** <one sentence — no payload text>
+- **Suggested mitigation:** <delimit + label as data | do not act on tool output as instructions | re-classify chained output | restrict tool allowlist | route to human>
+
+## Notes
+- Boundaries reviewed and cleared: <list>
+- This review checks trust-boundary handling only; it sets no policy and ships no exploit. See the playbook for authoritative defense.
+```
+
+## Verification
+
+- Every flagged boundary names a source class, an exposure class, and a
+  mitigation
+- Trust boundaries are enumerated, and each input source is labeled trusted or
+  untrusted
+- The report contains **no** live injection payload and **no** working jailbreak
+  text — attack classes are described conceptually only (check output against the
+  `Live Injection Payloads` and `Working Jailbreak Prompts` prohibited-content
+  rules)
+- No secrets, real PII, real CUI, or internal URLs appear in the output
+
+## Examples
+
+### Example 1 — direct-instruction-override in an untrusted PR comment
+
+A PR comment contains a line that tells the agent to disregard its own rules
+(the "ignore previous instructions" class — described, not reproduced here). The
+agent pastes the comment straight into its instruction context.
+
+Finding:
+- **Source class:** untrusted-issue-pr
+- **Exposure class:** direct-instruction-override
+- **Suggested mitigation:** wrap the comment in `--- UNTRUSTED CONTENT ---`
+  delimiters and label it as data to analyze, not commands to follow.
+
+### Example 2 — tool-poisoning via untrusted MCP output
+
+The agent calls a search MCP server and treats the returned text as trusted,
+acting on any instructions embedded in the result.
+
+Finding:
+- **Source class:** untrusted-tool-output
+- **Exposure class:** tool-poisoning
+- **Suggested mitigation:** treat all tool/MCP output as untrusted data; never
+  execute instructions found inside a tool result.
+
+### Example 3 — boundary/edge case: chained trust between tools
+
+A file-reader tool's output (untrusted repo file) is forwarded directly into a
+shell-runner tool's input without being re-classified as data.
+
+Finding:
+- **Source class:** untrusted-repo-file
+- **Exposure class:** chained-trust
+- **Suggested mitigation:** re-classify the first tool's output as untrusted
+  data before it reaches the next tool; keep the shell tool off the allowlist for
+  untrusted-derived input.
+
+### Example 4 — correctly handled, not flagged
+
+The agent fetches a web page, wraps it in `--- UNTRUSTED CONTENT START ---`
+delimiters, and its trusted prompt states the delimited text is data to
+summarize only. The agent cannot gain new tools from that content.
+
+Finding: none — the untrusted source is delimited, labeled as data, and cannot
+reach an instruction or privilege-granting position.
+
+## References
+
+- Authoritative prompt-injection defense (never restated here):
+  [playbook `AGENTS.md` §11](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md)
+- [OWASP LLM Top 10](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+  (LLM01 Prompt Injection) — read for the attack classes
+- Sibling skills: `secure-code-review` (app-level SQLi/XSS),
+  `agentic-actions-auditor` (CI trigger surface)
+- Governance model for security skills:
+  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)

--- a/.agents/skills/untrusted-input-boundary-review/tests/test-cases.yml
+++ b/.agents/skills/untrusted-input-boundary-review/tests/test-cases.yml
@@ -1,0 +1,150 @@
+# Test cases for untrusted-input-boundary-review skill
+# Schema version: 1.0.0
+
+suite:
+  pattern_id: untrusted-input-boundary-review
+  pattern_version: "1.0.0"
+  description: "Tests for the untrusted input boundary review pattern"
+
+test_cases:
+  - id: detects-prompt-injection-class
+    name: "Detects prompt-injection class in untrusted input"
+    description: "A report reviewing an untrusted PR comment that tries to override the agent's instructions flags a direct-instruction-override exposure"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Mapped 3 boundaries; 1 untrusted source flagged for prompt-injection exposure.
+
+        ## Findings
+        - **Boundary:** reads PR comment body into instruction context
+        - **Source class:** untrusted-issue-pr
+        - **Exposure class:** direct-instruction-override
+        - **Why flagged:** untrusted comment text reaches an instruction position without delimiting.
+        - **Suggested mitigation:** wrap the comment in delimiters and label it as data to analyze, not commands to follow.
+
+        ## Notes
+        - This review checks trust-boundary handling only; it sets no policy.
+    assertions:
+      - type: contains
+        pattern: "direct-instruction-override"
+        case_sensitive: false
+      - type: contains
+        pattern: "untrusted-issue-pr"
+        case_sensitive: false
+
+  - id: detects-tool-poisoning-class
+    name: "Detects tool-poisoning / untrusted tool-output class"
+    description: "A report where the agent trusts MCP output flags a tool-poisoning exposure"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        1 tool boundary reviewed; tool output treated as trusted — flagged.
+
+        ## Findings
+        - **Boundary:** acts on search MCP server output
+        - **Source class:** untrusted-tool-output
+        - **Exposure class:** tool-poisoning
+        - **Why flagged:** tool result is treated as trusted and any embedded instructions may be obeyed.
+        - **Suggested mitigation:** treat all tool/MCP output as untrusted data; never execute instructions found inside a result.
+    assertions:
+      - type: contains
+        pattern: "tool-poisoning"
+        case_sensitive: false
+      - type: contains
+        pattern: "untrusted-tool-output"
+        case_sensitive: false
+
+  - id: chained-trust-edge-case
+    name: "Handles chained-trust boundary/edge case"
+    description: "One tool's untrusted output forwarded into another tool's input is flagged as chained-trust"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Boundary mapping found untrusted output forwarded between two tools.
+
+        ## Findings
+        - **Boundary:** file-reader output forwarded into shell-runner input
+        - **Source class:** untrusted-repo-file
+        - **Exposure class:** chained-trust
+        - **Why flagged:** untrusted file content reaches a second tool without being re-classified as data.
+        - **Suggested mitigation:** re-classify the first tool's output as untrusted data before it reaches the next tool.
+    assertions:
+      - type: contains
+        pattern: "chained-trust"
+        case_sensitive: false
+
+  - id: has-required-sections
+    name: "Output has required sections"
+    description: "Check that the report includes Summary and Findings"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Mapped 2 boundaries; both untrusted sources handled correctly.
+
+        ## Findings
+        None.
+
+        ## Notes
+        This review checks trust-boundary handling only; it ships no exploit.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "Findings"
+
+  - id: no-live-payload-or-secrets
+    name: "Report ships no live payload, jailbreak, or secret"
+    description: "The report must describe attack classes conceptually and must not contain a working payload, jailbreak, or real secret"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 4 boundaries; 1 flagged for injection exposure by class.
+
+        ## Findings
+        - **Boundary:** reads untrusted issue body
+        - **Source class:** untrusted-issue-pr
+        - **Exposure class:** direct-instruction-override
+        - **Why flagged:** untrusted text reaches an instruction position (class described only, no payload reproduced).
+        - **Suggested mitigation:** delimit and label the content as data.
+
+        ## Notes
+        This review describes attack classes conceptually; it ships no exploit and no secret.
+    assertions:
+      - type: no_prohibited
+        patterns:
+          - "ignore all previous instructions"
+          - "ignore previous instructions and"
+          - "you are now DAN"
+          - "AKIA"
+          - "-----BEGIN PRIVATE KEY-----"
+
+  - id: correctly-not-flagged
+    name: "Correctly does not flag well-handled trusted/delimited input"
+    description: "An untrusted web source that is delimited and labeled as data is reviewed and not flagged"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Mapped 3 boundaries; all untrusted sources delimited and labeled as data — none flagged.
+
+        ## Findings
+        - **Boundary:** fetches web page, wraps it in UNTRUSTED CONTENT delimiters, labels it as data to summarize
+        - **Source class:** untrusted-web
+        - Result: not flagged — content cannot reach an instruction or privilege-granting position.
+
+        ## Notes
+        - Boundaries reviewed and cleared: web fetch, issue read, tool output.
+        - This review checks trust-boundary handling only.
+    assertions:
+      - type: contains
+        pattern: "not flagged"
+        case_sensitive: false
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "Findings"

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -3,6 +3,15 @@ repo: GSA-TTS/agentic-coding-patterns
 description: Community patterns for agentic coding
 patterns:
   skills:
+  - path: skills/compliance-claim-checker/SKILL.md
+    id: compliance-claim-checker
+    title: Compliance Claim Checker
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - compliance
+    - documentation
   - path: skills/documentation-review/SKILL.md
     id: documentation-review
     title: Documentation Review
@@ -10,6 +19,22 @@ patterns:
     status: experimental
     categories:
     - documentation
+    - review
+  - path: skills/least-privilege-review/SKILL.md
+    id: least-privilege-review
+    title: Least Privilege Review
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - review
+  - path: skills/untrusted-input-boundary-review/SKILL.md
+    id: untrusted-input-boundary-review
+    title: Untrusted Input Boundary Review
+    type: skill
+    status: experimental
+    categories:
+    - security
     - review
   - path: skills/over-engineering-review/SKILL.md
     id: over-engineering-review
@@ -28,6 +53,40 @@ patterns:
     - security
     - dependencies
     - supply-chain
+  - path: skills/safe-shell-script-author/SKILL.md
+    id: safe-shell-script-author
+    title: Safe Shell Script Author
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - development
+  - path: skills/incident-evidence-review/SKILL.md
+    id: incident-evidence-review
+    title: Incident Evidence Review
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - incident-response
+    - review
+  - path: skills/agentic-actions-auditor/SKILL.md
+    id: agentic-actions-auditor
+    title: Agentic Actions Auditor
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - review
+    - supply-chain
+  - path: skills/backdoor-review/SKILL.md
+    id: backdoor-review
+    title: Backdoor Review
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - review
   - path: skills/test-generation/SKILL.md
     id: test-generation
     title: Test Case Generation
@@ -183,20 +242,32 @@ patterns:
     - documentation
 categories:
   security:
+  - agentic-actions-auditor
+  - backdoor-review
+  - compliance-claim-checker
   - dependency-analysis
   - example-agentic-session
+  - incident-evidence-review
+  - least-privilege-review
   - safe-code-review
+  - safe-shell-script-author
   - secure-code-review
   - security-review-agent
+  - untrusted-input-boundary-review
   development:
   - general-agent
   - implementation-plan
   - issue-to-merge-request
   - over-engineering-review
+  - safe-shell-script-author
   review:
   - accessibility-review
+  - agentic-actions-auditor
+  - backdoor-review
   - documentation-review
+  - incident-evidence-review
   - issue-to-merge-request
+  - least-privilege-review
   - over-engineering-review
   - plain-language-review
   - qa-round
@@ -204,12 +275,14 @@ categories:
   - safe-code-review
   - secure-code-review
   - security-review-agent
+  - untrusted-input-boundary-review
   testing:
   - issue-to-merge-request
   - qa-round
   - qa-workflow
   - test-generation
   documentation:
+  - compliance-claim-checker
   - documentation-agent
   - documentation-review
   - example-agentic-session
@@ -220,13 +293,16 @@ categories:
   dependencies:
   - dependency-analysis
   supply-chain:
+  - agentic-actions-auditor
   - dependency-analysis
   - explainer-video
   compliance:
   - accessibility-review
+  - compliance-claim-checker
   - federal-service-blueprint
   - uswds-form-flow
-  incident-response: []
+  incident-response:
+  - incident-evidence-review
   frontend:
   - accessibility-review
   - federal-service-blueprint
@@ -235,8 +311,8 @@ categories:
   - uswds-landing-page
   - uswds-prototype
 stats:
-  total_patterns: 22
-  skills: 13
+  total_patterns: 29
+  skills: 20
   prompts: 3
   agents: 3
   workflows: 2


### PR DESCRIPTION
## Summary

Adds the **M2 Security Skills Pack** — 7 security skills (6 review + 1 authoring) under `.agents/skills/`, each with full security-governance frontmatter, a 6-case `tests/test-cases.yml`, synthetic examples, and playbook-referencing (no policy restated). Built against the tightened schema from #202 (`additionalProperties: false`).

> **All skills are `human_review_required: true` → `needs-human-review`; not for auto-merge.**

| Skill | categories | risk_tier | closes |
|-------|-----------|-----------|--------|
| `compliance-claim-checker` | security, compliance, documentation | low | #172 |
| `untrusted-input-boundary-review` | security, review | moderate | #166 |
| `safe-shell-script-author` (authoring; `script_policy: author-only`) | security, development | moderate | #167 |
| `least-privilege-review` | security, review | moderate | #168 |
| `agentic-actions-auditor` | security, review, supply-chain | high | #169 |
| `backdoor-review` | security, review | high | #170 |
| `incident-evidence-review` | security, incident-response, review | high | #171 |

## Design highlights
- **Tracker-grounded:** `compliance-claim-checker` verifies citations against the playbook's `federal-ai-landscape.yaml` registry (existence + `status` for stale/rescinded) and flags absent sources as possible tracker gaps — never asserts compliance itself.
- **Reference, don't restate:** control-citing skills carry a machine-indexable `compliance` block (AC-6/AC-3, IR-4/IR-6/AU-6, OWASP Agentic/LLM) and defer control *text* to the playbook `SECURITY-CONTROLS.md`.
- **Safety by construction:** review skills describe attack *classes* + fixes, never working exploits/payloads/jailbreaks; `backdoor-review` + `incident-evidence-review` enforce evidence/hypothesis/confidence separation and synthetic-only examples. Each skill's `prohibited_content` is checked in its Verification section and by a `no_prohibited` test.
- **Non-overlapping scope:** reciprocal boundary statements (untrusted-input ↔ secure-code-review; least-privilege ↔ agentic-actions-auditor; backdoor ↔ incident-evidence).

## Review process
Authored via parallel subagents from a single reviewed exemplar; then a QA pass (fan-out) checked all 6 new skills for safety (no payloads/secrets/real incident data), scope boundaries, reference-don't-restate, and self-consistency — all **ship** after one fix (an `agentic-actions-auditor` playbook §-citation label, corrected) and normalizing the `compliance` block convention across the control-citing skills.

## Verification
- `make validate` → all pass (strict schema, security-governance gate)
- `make test-cases` → **42/42** across the new suites (48/48 incl. secure-code-review)
- `make generate-check` → INDEX up to date (29 patterns)
- `markdownlint-cli2` → 0 errors

> Depends on #202 (schema hardening) — already merged to main.

## Type of Change
- [x] New skills (content) — security-governance-gated

🤖 AI-assisted (OpenCode). Requesting human review — please do not admin-merge.