### PR TITLE
feat(skills): Security Skills Pack M2 updates — secure-code-review + dependency-analysis

### DIFF
--- a/.agents/skills/dependency-analysis/SKILL.md
+++ b/.agents/skills/dependency-analysis/SKILL.md
@@ -1,6 +1,7 @@
 ---
+name: dependency-analysis
 id: dependency-analysis
-version: "1.0.0"
+version: "1.1.0"
 title: "Dependency Security Analysis"
 type: skill
 description: "Analyze project dependencies for security vulnerabilities, license compatibility, and supply chain risks"
@@ -25,9 +26,29 @@ output:
       - "Recommendations"
     prohibited_content:
       - "Secrets"
+      - "Real Secrets"
+      - "Real Credentials"
       - "Real PII"
       - "Real CUI"
       - "Internal URLs"
+
+compliance:
+  frameworks:
+    - "NIST SP 800-218 SSDF"
+    - "NIST SP 800-53"
+  nist_controls:
+    - "SR-3"
+    - "SA-15"
+
+changelog:
+  - version: "1.1.0"
+    date: "2026-07-02"
+    change_type: minor
+    summary: "Add pre-add decision ladder, OSV/GHSA advisory check, GitHub Action SHA-pinning review, external-script (curl|sh) execution review, and public-skill-inspiration intake gate. Adds supply-chain category. Absorbs proposed supply-chain-skeptic."
+  - version: "1.0.0"
+    date: "2026-05-20"
+    change_type: minor
+    summary: "Initial dependency security analysis skill."
 
 quality_gates:
   readability_max_grade: 10
@@ -68,18 +89,33 @@ portability:
 
 scope:
   intended_use:
-    - "Scan dependencies for known vulnerabilities"
+    - "Gate the decision to add a dependency (pre-add ladder)"
+    - "Scan dependencies for known vulnerabilities (OSV/GHSA)"
     - "Check license compatibility"
     - "Identify outdated dependencies"
+    - "Review GitHub Action SHA-pinning and external-script install steps"
     - "Assess supply chain risks"
   exclusions:
     - "Not for runtime dependency injection"
     - "Not for performance profiling"
+    - "Not for the runtime safety of agent-invoking CI workflows (see agentic-actions-auditor)"
+    - "Not for authoring safe shell scripts (see safe-shell-script-author); this skill audits install patterns"
 ---
 
 # Skill: Dependency Security Analysis
 
-Analyze project dependencies to identify security vulnerabilities, license issues, and supply chain risks.
+Analyze project dependencies to identify security vulnerabilities, license issues, and supply chain risks. This skill also gates the *decision to add* a dependency, Action, or install step in the first place.
+
+Framing is federal-first: it treats NIST SP 800-218 (SSDF) and NIST SP 800-53 supply-chain controls (SR-3, SA-15) as normal baseline expectations. It is agency-portable — it references frameworks generically and anchors to the playbook, not to any single agency's files.
+
+## Boundaries
+
+This skill covers the **intake question**: should this dependency, Action, or install step be added, and is it supply-chain-safe. It does not restate what sibling skills own:
+
+- **agentic-actions-auditor** — runtime safety of agent-invoking CI workflows.
+- **safe-shell-script-author** — *authoring* safe shell scripts. This skill only *audits* the install pattern that pulls a script in.
+
+When a task crosses those lines, defer to the sibling skill instead of duplicating its rules.
 
 ## When to Use
 
@@ -97,92 +133,72 @@ Analyze project dependencies to identify security vulnerabilities, license issue
 
 ## Procedure
 
-### Step 1: Inventory Dependencies
+### Step 0: Pre-add Decision Ladder
+
+Before adding *any* new dependency, walk this ordered gate. The rule is **least-effort-additive**: the smallest addition that meets the need wins, and "add nothing" is the preferred outcome. Stop at the first rung that satisfies the requirement.
+
+1. **Native capability already exists** → use it. If the platform, framework, or runtime already does this, add nothing.
+2. **Language standard library covers it** → use it. Prefer `stdlib` over a third-party package for common needs (HTTP, JSON, hashing, date math).
+3. **A vetted dependency already in the project covers it** → reuse it. Do not add a second package that overlaps an existing one.
+4. **A genuinely new dependency is needed** → justify it in writing:
+   - What it does and the specific gap it fills.
+   - Why rungs 1–3 do not suffice.
+   - Maintenance/health signals (recent releases, active maintainers, issue responsiveness).
+5. **Route to human review** for the add. A security skill add is `human_review_required: true`.
+6. **Reject** if the justification is missing or weak. An unjustified new dependency is rejected by default, not deferred.
+
+**Example — deflected add:**
+
+> Request: add `left-pad` to pad a string.
+> Ladder result: **reject**. The language `stdlib` (`str.rjust` / `padStart`) already provides padding natively. No new dependency is justified.
+
+### Step 1: Dependency Health / Advisory Check
+
+Before trusting a package, check it against vulnerability and malicious-advisory databases. **Do not rely on popularity alone** — download counts and stars do not prove safety.
+
+- Query **[OSV.dev](https://osv.dev)** for known vulnerabilities across ecosystems.
+- Query the **GitHub Advisory Database (GHSA)** for security and malware advisories.
+- Cross-check the intended package name for **typosquatting** (a look-alike name of a popular package).
+
+Popularity-blind trust is exactly how recent supply-chain incidents spread. Conceptually, watch three threat classes:
+
+- **Maintainer / build-chain compromise** (e.g., the *xz-utils* class): a trusted package gets a malicious payload injected upstream.
+- **Account takeover of a dependency** (e.g., the *event-stream* class): a legitimate package pulls in a newly-malicious transitive dependency.
+- **Typosquatting**: a hostile package published under a name one keystroke from the real one.
+
+**Example finding:**
+
+> Package `color-covert` (note the swap) has a GHSA malware advisory and was published 3 days ago. The intended package is `color-convert`. **Action:** do not add; use the correct package after an OSV/GHSA check.
+
+### Step 2: Inventory Dependencies
 
 List all direct and transitive dependencies:
 
-**Python:**
-
 ```bash
-pip list
-pip show <package-name>  # Details including dependencies
+pip list                 # Python (pip show <pkg> for details)
+npm list --depth=0       # Node.js direct deps
+cargo tree               # Rust
+go list -m all           # Go
 ```
 
-**Node.js:**
-
-```bash
-npm list
-npm list --depth=0  # Direct dependencies only
-```
-
-**Rust:**
-
-```bash
-cargo tree
-```
-
-**Go:**
-
-```bash
-go list -m all
-```
-
-### Step 2: CVE Vulnerability Scan
+### Step 3: CVE Vulnerability Scan
 
 Check for known security vulnerabilities:
 
-**Python:**
-
 ```bash
-# Using pip-audit
-pip install pip-audit
-pip-audit
-
-# Or safety
-pip install safety
-safety check
+pip-audit                                    # Python (or: safety check)
+npm audit                                    # Node.js (npm audit fix — review first!)
+cargo audit                                  # Rust
+govulncheck ./...                            # Go
 ```
 
-**Node.js:**
-
-```bash
-npm audit
-npm audit --json  # Machine-readable output
-
-# Fix automatically (review changes!)
-npm audit fix
-```
-
-**Rust:**
-
-```bash
-cargo install cargo-audit
-cargo audit
-```
-
-**Go:**
-
-```bash
-go install golang.org/x/vuln/cmd/govulncheck@latest
-govulncheck ./...
-```
-
-### Step 3: License Compatibility Check
+### Step 4: License Compatibility Check
 
 Verify all licenses are compatible with your project:
 
-**Python:**
-
 ```bash
-pip install pip-licenses
-pip-licenses --format=markdown
-```
-
-**Node.js:**
-
-```bash
-npm install -g license-checker
-license-checker --summary
+pip-licenses --format=markdown   # Python
+license-checker --summary        # Node.js
 ```
 
 **Check for:**
@@ -192,35 +208,18 @@ license-checker --summary
 - [ ] Proprietary/commercial licenses
 - [ ] Missing or unclear licenses
 
-### Step 4: Outdated Dependency Check
+### Step 5: Outdated Dependency Check
 
 Identify dependencies with available updates:
 
-**Python:**
-
 ```bash
-pip list --outdated
+pip list --outdated   # Python
+npm outdated          # Node.js
+cargo outdated        # Rust
+go list -u -m all     # Go
 ```
 
-**Node.js:**
-
-```bash
-npm outdated
-```
-
-**Rust:**
-
-```bash
-cargo outdated
-```
-
-**Go:**
-
-```bash
-go list -u -m all
-```
-
-### Step 5: Supply Chain Risk Assessment
+### Step 6: Supply Chain Risk Assessment
 
 Evaluate dependency trustworthiness:
 
@@ -239,7 +238,7 @@ Evaluate dependency trustworthiness:
 - Excessive permissions requested
 - Unmaintained (no updates in >2 years)
 
-### Step 6: Version Pinning Verification
+### Step 7: Version Pinning Verification
 
 Check that versions are pinned:
 
@@ -271,7 +270,47 @@ Use lock files for reproducible builds:
 - `Cargo.lock` (Rust)
 - `go.sum` (Go)
 
-### Step 7: Generate SBOM (Software Bill of Materials)
+### Step 8: GitHub Action Pinning Review
+
+A CI Action *is* a dependency, so it goes through the same intake ladder. When an Action is added, it MUST be pinned by **full commit SHA**, not by a mutable tag (`@v4`) or branch (`@main`). A tag can be re-pointed at malicious code after review; a SHA cannot.
+
+```yaml
+# ❌ Mutable tag — the ref can be moved under you
+- uses: actions/checkout@v4
+
+# ✅ Pinned to a full commit SHA (comment records the human-readable version)
+- uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v4.2.1
+```
+
+This is the **intake gate**: should this Action be added, and is it SHA-pinned as a supply-chain control. The runtime safety of agent-invoking workflows is a separate concern owned by **agentic-actions-auditor** — do not re-audit that here. Both skills reference the same single pinning rationale (pin by immutable digest, never a mutable ref) rather than each restating it.
+
+### Step 9: External-Script Execution Review
+
+Flag install steps that pipe a remote script straight into an interpreter. Treat an unvetted remote install script as an **unvetted dependency** — you are executing code you never reviewed, fetched at build time from a URL that can change.
+
+```bash
+# ❌ Piping a remote script to a shell — no review, no pin, mutable source
+curl -fsSL https://example.test/install.sh | sh
+wget -qO- https://example.test/setup | bash
+
+# ✅ Fetch, inspect, pin by checksum, then run explicitly
+curl -fsSL -o install.sh https://example.test/install.sh
+sha256sum -c install.sh.sha256   # verify against a known-good digest
+less install.sh                  # human review
+sh ./install.sh
+```
+
+This skill *audits* the install pattern. For *authoring* a safe replacement script, use **safe-shell-script-author**.
+
+### Step 10: Public-Skill / Public-Source Intake Gate
+
+When a dependency, Action, or skill is **inspired by or pulled from a public source** (a blog, a public repo, another team's skill):
+
+- Record a source-inspiration intake per the repo `AGENTS.md` §4.3 and reference it in the PR.
+- **Never copy scripts, prompt bodies, or full skill bodies wholesale.** Wholesale copy is a prompt-injection and supply-chain vector — a public script can carry hidden instructions or malicious steps.
+- Use the public source as *inspiration only*; re-author to fit this project after review.
+
+### Step 11: Generate SBOM (Software Bill of Materials)
 
 Create a manifest of all dependencies:
 
@@ -290,10 +329,15 @@ npx @cyclonedx/cyclonedx-npm --output-file sbom.json
 
 After analysis, confirm:
 
+- [ ] Pre-add decision ladder walked (native → stdlib → reuse → justify → review → reject)
+- [ ] OSV.dev and GHSA advisory checks run; typosquatting ruled out
 - [ ] All vulnerabilities identified
 - [ ] Severity assessed (Critical/High/Medium/Low)
 - [ ] License compatibility verified
 - [ ] Outdated dependencies flagged
+- [ ] GitHub Actions pinned by full commit SHA (no mutable tags)
+- [ ] External-script (`curl | sh`) install patterns flagged
+- [ ] Public-source inspiration intake recorded; nothing copied wholesale
 - [ ] Supply chain risks documented
 - [ ] SBOM generated
 - [ ] Remediation plan created
@@ -354,6 +398,25 @@ After analysis, confirm:
 
 **Action:** Remove typosquatted package, use legitimate one
 
+### Example 4: Unpinned GitHub Action
+
+**Finding:**
+
+- Workflow uses `actions/checkout@v4` (a mutable tag).
+- A moved tag could point at malicious code after review.
+
+**Recommendation:** pin by full commit SHA and record the version in a comment:
+`actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v4.2.1`.
+
+### Example 5: External-Script Install (curl | sh)
+
+**Finding:**
+
+- Install step runs `curl -fsSL https://example.test/install.sh | sh`.
+- Remote code is executed unreviewed and the URL is a mutable source — an unvetted dependency.
+
+**Recommendation:** fetch, verify a known checksum, human-review, then run explicitly. Or vendor a reviewed, pinned copy.
+
 ## Troubleshooting
 
 | Issue | Cause | Solution |
@@ -366,11 +429,16 @@ After analysis, confirm:
 ## Related Patterns
 
 - [secure-code-review](../secure-code-review/SKILL.md) - Review code for security issues
+- [agentic-actions-auditor](../agentic-actions-auditor/SKILL.md) - Runtime safety of agent-invoking CI workflows (this skill covers the Action *intake* question)
+- [safe-shell-script-author](../safe-shell-script-author/SKILL.md) - Authoring safe shell scripts (this skill *audits* install patterns)
 - For supply chain controls, see [agentic-coding-playbook SECURITY-CONTROLS.md](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/SECURITY-CONTROLS.md)
 
 ## References
 
+- [OSV.dev — Open Source Vulnerabilities](https://osv.dev/)
+- [GitHub Advisory Database (GHSA)](https://github.com/advisories)
 - [OWASP Dependency-Check](https://owasp.org/www-project-dependency-check/)
 - [Snyk Vulnerability Database](https://security.snyk.io/)
 - [National Vulnerability Database](https://nvd.nist.gov/)
 - [CycloneDX SBOM Standard](https://cyclonedx.org/)
+- [NIST SP 800-218 (SSDF)](https://csrc.nist.gov/pubs/sp/800/218/final)

--- a/.agents/skills/dependency-analysis/tests/test-cases.yml
+++ b/.agents/skills/dependency-analysis/tests/test-cases.yml
@@ -1,0 +1,183 @@
+# Test cases for dependency-analysis skill
+# Schema version: 1.0.0
+#
+# input.content is an EXPECTED-OUTPUT fixture (a sample analysis report),
+# checked against the skill's output contract. `pattern` fields are REGEX.
+
+suite:
+  pattern_id: dependency-analysis
+  pattern_version: "1.1.0"
+  description: "Tests for dependency security analysis pattern (pre-add ladder, advisory checks, Action pinning, external-script and public-source gates)"
+
+test_cases:
+  - id: pre-add-ladder-rejects-unjustified
+    name: "Pre-add ladder deflects an unjustified new dependency"
+    description: "Verifies the report uses the ladder to reject a dep the stdlib/native capability already covers"
+    input:
+      type: literal
+      content: |
+        # Dependency Analysis
+
+        ## Summary
+        A request to add `left-pad` for string padding was evaluated against the pre-add decision ladder.
+
+        ## Findings
+        The language stdlib already provides native string padding (`str.rjust` / `padStart`).
+        No new dependency is justified.
+
+        ## Recommendations
+        Reject the add and use the native stdlib capability instead.
+    assertions:
+      - type: contains
+        pattern: "stdlib"
+        case_sensitive: false
+      - type: contains
+        pattern: "reject"
+        case_sensitive: false
+
+  - id: action-pinned-to-mutable-tag
+    name: "Flags a GitHub Action pinned to a mutable tag"
+    description: "Verifies the report flags a tag-pinned Action and recommends a SHA pin"
+    input:
+      type: literal
+      content: |
+        # Dependency Analysis
+
+        ## Summary
+        The workflow adds `actions/checkout@v4`, a mutable tag.
+
+        ## Findings
+        Actions must be pinned by full commit SHA, not a mutable tag or branch.
+
+        ## Recommendations
+        Pin the Action by its full commit SHA and record the version in a comment.
+    assertions:
+      - type: contains
+        pattern: "SHA"
+      - type: contains
+        pattern: "pin"
+        case_sensitive: false
+
+  - id: external-script-curl-sh
+    name: "Flags a curl | sh external-install pattern"
+    description: "Verifies the report flags piping a remote script into a shell"
+    input:
+      type: literal
+      content: |
+        # Dependency Analysis
+
+        ## Summary
+        An install step runs: curl -fsSL https://example.test/install.sh | sh
+
+        ## Findings
+        Caution: piping a remote script into a shell executes unreviewed code from a
+        mutable source. Treat this as an unvetted dependency.
+
+        ## Recommendations
+        Fetch, verify a checksum, human-review, then run explicitly.
+    assertions:
+      - type: contains
+        pattern: "curl -fsSL"
+      - type: contains
+        pattern: "shell"
+        case_sensitive: false
+      - type: contains
+        pattern: "Caution"
+
+  - id: known-advisory-osv-ghsa
+    name: "Flags a dependency with a known advisory / recommends OSV/GHSA check"
+    description: "Verifies the report checks OSV.dev and GHSA rather than relying on popularity"
+    input:
+      type: literal
+      content: |
+        # Dependency Analysis
+
+        ## Summary
+        The candidate package was checked against OSV.dev and the GitHub Advisory Database (GHSA).
+
+        ## Findings
+        GHSA lists a malware advisory for this package. Popularity does not prove safety.
+
+        ## Recommendations
+        Do not add the package; an OSV/GHSA advisory check is required before any add.
+    assertions:
+      - type: contains
+        pattern: "advisory"
+        case_sensitive: false
+      - type: contains
+        pattern: "GHSA"
+
+  - id: has-required-sections
+    name: "Output has required sections"
+    description: "Check that analysis reports carry the declared required sections"
+    input:
+      type: literal
+      content: |
+        # Dependency Analysis
+
+        ## Summary
+        Reviewed 12 dependencies and 3 GitHub Actions.
+
+        ## Findings
+        No critical vulnerabilities. One Action was pinned to a mutable tag.
+
+        ## Recommendations
+        Pin all Actions by full commit SHA.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "Findings"
+          - "Recommendations"
+
+  - id: no-prohibited-secrets
+    name: "No real secrets or credentials in output"
+    description: "Ensure reports do not embed real secrets or credentials"
+    input:
+      type: literal
+      content: |
+        # Dependency Analysis
+
+        ## Summary
+        Secrets are loaded from environment variables or a secret manager, never inlined.
+
+        ## Findings
+        No hardcoded credentials detected in dependency manifests.
+
+        ## Recommendations
+        Continue loading secrets from a managed store.
+    assertions:
+      - type: no_prohibited
+        patterns:
+          - "sk-[A-Za-z0-9]{20,}"
+          - "AKIA[0-9A-Z]{16}"
+          - "-----BEGIN [A-Z ]*PRIVATE KEY-----"
+
+  - id: clean-dep-not-flagged
+    name: "A well-justified, SHA-pinned, advisory-clean dependency is not flagged"
+    description: "Verifies a properly-vetted add passes without a supply-chain flag"
+    input:
+      type: literal
+      content: |
+        # Dependency Analysis
+
+        ## Summary
+        The add of `cryptography` was justified: no stdlib or existing dependency covers
+        the required primitive. OSV.dev and GHSA show no open advisories.
+
+        ## Findings
+        The Action is pinned by full commit SHA. License is Apache-2.0 (compatible).
+        Version is exactly pinned in the lock file. No supply-chain concern.
+
+        ## Recommendations
+        Approved for human review with the recorded justification.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "Findings"
+          - "Recommendations"
+      - type: no_prohibited
+        patterns:
+          - "curl [^\\n]*\\| *sh"
+          - "@v[0-9]"

--- a/.agents/skills/secure-code-review/SKILL.md
+++ b/.agents/skills/secure-code-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
+name: secure-code-review
 id: secure-code-review
-version: "1.0.0"
+version: "1.1.0"
 title: "Secure Code Review"
 type: skill
 description: "Security-focused code review pattern covering OWASP Top 10 vulnerabilities and common security issues"
@@ -23,6 +24,7 @@ output:
       - "Summary"
       - "Findings"
     prohibited_content:
+      - "Real Secrets"
       - "Secrets"
       - "Real PII"
       - "Real CUI"
@@ -49,6 +51,23 @@ categories:
   - "security"
   - "review"
 
+compliance:
+  frameworks:
+    - "NIST SP 800-53"
+    - "OWASP Top 10 LLM 2025"
+  nist_controls:
+    - "AC-6"
+
+changelog:
+  - version: "1.1.0"
+    date: "2026-07-02"
+    change_type: minor
+    summary: "Add diff modality + IaC and changed-workflow blast-radius sub-sections with flag-and-defer handoffs to sibling skills; extend secrets coverage to non-code surfaces (CI logs, agent reports, git history, base64/binary), placeholder-vs-real discrimination, and rotation. Absorbs proposed security-diff-review and secrets-handling-review."
+  - version: "1.0.0"
+    date: "2026-05-20"
+    change_type: major
+    summary: "Initial release."
+
 risk_tier: moderate
 human_review_required: true
 allowed_tools: []
@@ -68,15 +87,43 @@ scope:
     - "Review code changes for security vulnerabilities"
     - "Identify OWASP Top 10 risks"
     - "Provide remediation guidance"
+    - "Review a whole file or a PR diff hunk (diff is a modality)"
+    - "Review Infrastructure-as-Code (IaC) for insecure configuration"
+    - "Assess blast radius of a changed CI workflow file in a diff"
+    - "Detect exposed secrets in code and non-code surfaces"
   exclusions:
     - "Not for compliance auditing"
     - "Not for penetration testing"
     - "Does not replace automated security scanners"
+    - "Agent-invoking or injection-reachable CI triggers: defer to agentic-actions-auditor"
+    - "Scope-minimality judgments (GITHUB_TOKEN / IAM scope): defer to least-privilege-review"
+    - "Supply-chain / dependency intake: defer to dependency-analysis"
 ---
 
 # Skill: Secure Code Review
 
 Perform security-focused code review to identify common vulnerabilities and security issues before they reach production.
+
+> **Diff is a modality, not a mode.** You can review either a whole file or a
+> single PR diff hunk. Every check below applies to both. When you review a
+> diff, focus on what the change *introduces* or *removes* — you do not need to
+> re-audit unchanged lines, but you should flag when a change weakens an
+> existing control.
+
+## Boundaries
+
+This skill is the general **code-review hygiene** lane. Three neighbors own
+adjacent lanes — flag and defer, do not re-implement them:
+
+| If you see... | Defer to |
+|---------------|----------|
+| An agent-invoking or injection-reachable CI trigger (`pull_request_target`, `issue_comment`, `workflow_run` with untrusted checkout, a prompt built from PR/issue text) | **agentic-actions-auditor** |
+| A judgment about whether a granted scope is *minimal* (GITHUB_TOKEN permissions, IAM scope) | **least-privilege-review** |
+| Supply-chain or dependency intake (new packages, CVEs, licenses) | **dependency-analysis** |
+
+secure-code-review's lane for CI is **general workflow-file code-review hygiene
+plus the blast radius of the changed workflow in the diff** — not a full agent
+or least-privilege audit.
 
 ## When to Use
 
@@ -170,11 +217,127 @@ def admin_panel(request):
 
 ### Step 4: Sensitive Data Handling
 
+Secrets and sensitive data leak far beyond source code. Check every surface a
+value can land on.
+
+**In code:**
+
 - [ ] No secrets in code or comments
 - [ ] PII encrypted at rest and in transit
 - [ ] Sensitive data not logged
 - [ ] Secrets loaded from environment or secret manager
 - [ ] API keys not in URLs (query parameters)
+
+**Non-code surfaces (often missed):**
+
+- [ ] CI logs — no token, key, or connection string echoed into build output
+- [ ] LLM prompts — no secret pasted into a prompt sent to a model
+- [ ] Agent summaries / reports (markdown) — no secret copied into a generated
+      report, review, or PR comment
+- [ ] Shell history — no secret passed as a command-line argument
+- [ ] Git history — a secret removed in the latest commit may still live in an
+      earlier commit
+
+**Placeholder vs. real (do not be fooled by a label):**
+
+Judge a value by its **shape, entropy, and context**, not by its name.
+
+> **Anti-bypass note.** An attacker can *name* a real secret `EXAMPLE_TOKEN`,
+> `TEST_KEY`, or `dummy_password` to slip it past a naive filter. A "test" or
+> "example" label is **not** proof the value is fake. A short, low-entropy
+> value like `xxxxx` or `changeme` is a placeholder; a long high-entropy value
+> that matches a known key format is a real secret regardless of its name.
+
+**Encoded and generated forms:**
+
+- [ ] Base64 / hex / binary blobs decoded and checked (a secret may hide inside
+      an encoded string)
+- [ ] Agent-generated markdown reports scanned the same way as code
+
+**If a real secret was exposed — rotation, not deletion:**
+
+Removing a leaked secret from a file does **not** un-leak it. Assume any secret
+that reached a shared surface (a commit, a CI log, a report) is **compromised**.
+
+- [ ] Rotate the credential at the issuer (revoke old, issue new)
+- [ ] Remove it from the current file *and* from history if feasible
+- [ ] Note in the finding that removal alone is insufficient
+
+### Step 4a: Infrastructure-as-Code (IaC) Review
+
+Applies to Terraform, CloudFormation, and Kubernetes manifests. Review them the
+same way you review code — the diff modality applies here too.
+
+**What to look for:**
+
+- [ ] No hardcoded secrets (passwords, keys, tokens) in `.tf`, templates, or
+      manifests — use a secret manager reference instead
+- [ ] No over-permissive IAM / RBAC (wildcard `Action: "*"`,
+      `Resource: "*"`, cluster-admin bindings) — see least-privilege-review for
+      the *minimality* judgment
+- [ ] No unintended public exposure (`0.0.0.0/0` ingress, public S3 buckets,
+      `LoadBalancer` on an internal service)
+- [ ] Encryption not disabled (at rest and in transit)
+- [ ] Destructive / blast-radius changes flagged (deleting a database, replacing
+      a resource that forces recreation, widening a security group)
+
+```hcl
+# ❌ Over-permissive + hardcoded secret (synthetic)
+resource "aws_iam_policy" "app" {
+  policy = jsonencode({ Statement = [{ Effect = "Allow", Action = "*", Resource = "*" }] })
+}
+resource "aws_db_instance" "app" {
+  password = "…"                          # FLAG: inline literal secret (redacted); use a secret ref
+  publicly_accessible = true              # public exposure
+}
+```
+
+> **Future-split note.** IaC review may graduate into its own skill later. For
+> now it lives here as a sub-section; keep IaC findings clearly labeled so the
+> split is clean.
+
+### Step 4b: Changed-Workflow Blast-Radius Review
+
+Applies to **CI workflow files that appear in a diff** (e.g. GitHub Actions
+`.github/workflows/*.yml`). Your job is narrow: **what does this change
+introduce, and what is the blast radius?**
+
+Ask of the *changed* workflow:
+
+- [ ] What new **permissions** does it grant?
+- [ ] What new **secrets** does it read or expose?
+- [ ] What new **triggers** does it add, and what can reach them?
+- [ ] Does it echo a secret into logs, or pass one to an untrusted step?
+
+**Critical boundary — flag and defer, do not fully audit here:**
+
+- If the change adds an **agent-invoking or injection-reachable trigger**
+  (`pull_request_target`, `issue_comment`, `workflow_run` with an untrusted
+  checkout, or a prompt built from PR/issue text) → **FLAG it and DEFER to
+  agentic-actions-auditor.** Do not attempt to fully audit the trigger here.
+- If the question is whether the granted **scope is minimal** (which
+  `GITHUB_TOKEN` permissions, which IAM actions) → **DEFER to
+  least-privilege-review.**
+
+You still report the *blast radius* of the changed workflow (what it can now
+touch), you just do not own the agent-injection or minimality verdicts.
+
+```yaml
+# Changed workflow (synthetic diff) — FLAG + DEFER, do not audit the trigger here
+on:
+  pull_request_target:        # injection-reachable → defer to agentic-actions-auditor
+    types: [opened]
+permissions:
+  contents: write             # new write scope → defer minimality to least-privilege-review
+```
+
+Example finding phrasing:
+
+> This change adds a `pull_request_target` trigger and `contents: write`. The
+> blast radius is any push to the default branch. This trigger is
+> injection-reachable — **flagging and deferring to agentic-actions-auditor**
+> for the full agent-trigger audit, and to least-privilege-review for whether
+> `contents: write` is minimal. This skill does not audit the trigger itself.
 
 ### Step 5: Cryptography Review
 
@@ -207,7 +370,9 @@ After review, confirm:
 - [ ] All OWASP Top 10 risks checked
 - [ ] Injection vulnerabilities identified or ruled out
 - [ ] Authentication/authorization logic verified
-- [ ] Sensitive data handling reviewed
+- [ ] Sensitive data handling reviewed across code and non-code surfaces
+- [ ] IaC config reviewed if manifests are in scope
+- [ ] Changed CI workflows: blast radius reported; agent triggers and scope-minimality deferred to siblings
 - [ ] Findings documented with severity and remediation
 - [ ] No false positives that would block legitimate code
 
@@ -266,11 +431,14 @@ document.getElementById('message').textContent = userInput;
 
 ## Related Patterns
 
-- [dependency-analysis](../dependency-analysis/SKILL.md) - Check for vulnerable dependencies
+- [dependency-analysis](../dependency-analysis/SKILL.md) - Supply-chain and vulnerable-dependency intake
+- [agentic-actions-auditor](../agentic-actions-auditor/SKILL.md) - Agent-invoking / injection-reachable CI triggers
+- [least-privilege-review](../least-privilege-review/SKILL.md) - Whether a granted scope (token/IAM) is minimal
 - [test-generation](../test-generation/SKILL.md) - Generate security test cases
 
 ## References
 
 - [OWASP Top 10](https://owasp.org/www-project-top-ten/)
+- [OWASP Top 10 for LLM Applications](https://genai.owasp.org/)
 - [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/)
-- For compliance controls, see [agentic-coding-playbook SECURITY-CONTROLS.md](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/SECURITY-CONTROLS.md)
+- For compliance controls, see your organization's playbook / `SECURITY-CONTROLS.md` (federal teams: NIST SP 800-53, e.g. AC-6 least privilege).

--- a/.agents/skills/secure-code-review/tests/test-cases.yml
+++ b/.agents/skills/secure-code-review/tests/test-cases.yml
@@ -3,7 +3,7 @@
 
 suite:
   pattern_id: secure-code-review
-  pattern_version: "1.0.0"
+  pattern_version: "1.1.0"
   description: "Tests for secure code review pattern"
 
 test_cases:
@@ -137,3 +137,123 @@ test_cases:
         pattern: "def authenticate_user"
       - type: contains
         pattern: "api_key"
+
+  - id: iac-over-permissive-and-secret
+    name: "IaC review catches over-permissive IAM and hardcoded secret"
+    description: "Verifies the IaC sub-section flags a Terraform/K8s misconfiguration"
+    input:
+      type: literal
+      content: |
+        # Security Code Review
+
+        ## Summary
+        Reviewed a Terraform change adding a database and IAM policy.
+
+        ## Findings
+
+        ### Infrastructure-as-Code (IaC)
+        - The IAM policy grants Action "\*" on Resource "\*" (over-permissive).
+        - The database sets publicly_accessible = true (public exposure).
+        - A hardcoded password value appears in the resource definition.
+
+        ## Recommendations
+        Scope the IAM policy to the needed actions and load the password from a
+        secret manager. For whether the scope is minimal, defer to
+        least-privilege-review.
+    assertions:
+      - type: contains
+        pattern: "IAM"
+        case_sensitive: false
+      - type: contains
+        pattern: "over-permissive"
+        case_sensitive: false
+      - type: contains
+        pattern: "hardcoded"
+        case_sensitive: false
+
+  - id: changed-workflow-flag-and-defer
+    name: "Changed workflow flags and defers agent trigger"
+    description: "Verifies a workflow diff with pull_request_target defers to agentic-actions-auditor rather than auditing the trigger itself"
+    input:
+      type: literal
+      content: |
+        # Security Code Review
+
+        ## Summary
+        Reviewed a changed CI workflow file in this diff.
+
+        ## Findings
+
+        ### Changed-Workflow Blast Radius
+        This change adds a pull_request_target trigger and contents: write.
+        The blast radius is any push to the default branch. This trigger is
+        injection-reachable, so I am flagging and deferring to
+        agentic-actions-auditor for the full agent-trigger audit, and to
+        least-privilege-review for whether contents: write is minimal. This
+        skill does not audit the trigger itself.
+    assertions:
+      - type: contains
+        pattern: "agentic-actions-auditor"
+        min_count: 1
+      - type: contains
+        pattern: "defer"
+        case_sensitive: false
+      - type: contains
+        pattern: "blast radius"
+        case_sensitive: false
+
+  - id: secret-in-non-code-surface
+    name: "Secret exposed in CI log / agent report requires rotation"
+    description: "Verifies non-code-surface secret exposure recommends rotation, not just removal"
+    input:
+      type: literal
+      content: |
+        # Security Code Review
+
+        ## Summary
+        A credential was echoed into the CI build log and copied into the
+        generated agent report (markdown).
+
+        ## Findings
+        A token was printed to the CI log and appears in the agent summary. A
+        "test/example" label does not prove a value is fake; this value has
+        high entropy and matches a real key shape.
+
+        ## Recommendations
+        Assume the credential is compromised. Rotate it at the issuer (revoke
+        old, issue new); removal from the file alone is not sufficient. Also
+        scrub the CI log and the report.
+    assertions:
+      - type: contains
+        pattern: "rotat"
+        case_sensitive: false
+      - type: contains
+        pattern: "CI log"
+        case_sensitive: false
+      - type: contains
+        pattern: "compromised"
+        case_sensitive: false
+
+  - id: no-prohibited-real-secret-values
+    name: "Report contains no real secret values"
+    description: "Safety case: the review report must not embed a real-looking secret value"
+    input:
+      type: literal
+      content: |
+        # Security Code Review
+
+        ## Summary
+        A hardcoded credential was found and flagged; the value is redacted.
+
+        ## Findings
+        A secret was hardcoded in config. The value is shown as REDACTED and
+        must be rotated at the issuer.
+
+        ## Recommendations
+        Rotate the credential and load it from a secret manager.
+    assertions:
+      - type: no_prohibited
+        patterns:
+          - "sk-[A-Za-z0-9]{16,}"
+          - "AKIA[0-9A-Z]{16}"
+          - "-----BEGIN [A-Z ]*PRIVATE KEY-----"


### PR DESCRIPTION
## Summary

Updates the two existing skills per issues **#173 / #174 / #175**, absorbing three proposed-but-not-created skills (`security-diff-review`, `secrets-handling-review`, `supply-chain-skeptic`) per the EPIC #146 dedup decision — so this is "extend existing" rather than "new skill" by design.

Federal-first framing, **agency-portable** (frameworks cited generically; the playbook is the canonical anchor but not assumed to be GSA-TTS-only). Design refined via a **6/7 consensus vote** that focused on boundary cleanliness — the key outcome being explicit **flag-and-defer handoffs** between siblings instead of overlap.

> **All `human_review_required` → `needs-human-review`; not for auto-merge.**

### `secure-code-review` 1.0.0 → 1.1.0 (#173, #174)
- **Diff is a modality** (whole file *or* PR diff hunk), not a monolithic "mode".
- **IaC sub-section** (Terraform/CFN/K8s: over-permissive IAM/RBAC, hardcoded secrets, public exposure, blast radius) + future-split note.
- **Changed-workflow blast-radius sub-section** that **flags-and-defers**: agent/injection-reachable triggers → `agentic-actions-auditor`; scope-minimality → `least-privilege-review`. Its lane = changed-workflow hygiene + blast radius only.
- **Extended secrets** to non-code surfaces (CI logs, prompts, agent reports, shell/git history), base64/binary forms, **placeholder-vs-real with an anti-bypass note** (a "test/example" label isn't proof), and **rotate-not-delete** guidance.
- `name` + `compliance` (AC-6) + `changelog` + Boundaries; **10 test-cases**.

### `dependency-analysis` 1.0.0 → 1.1.0 (#175)
- **Pre-add decision ladder** (native → stdlib → existing vetted dep → justify → human review → reject).
- **OSV/GHSA advisory + typosquat** check (not popularity); **Action SHA-pinning** review cross-linked to (not restating) `agentic-actions-auditor`; **external-script (`curl|sh`) install** review cross-ref `safe-shell-script-author`; **public-source intake gate** (AGENTS.md §4.3).
- Adds `supply-chain` category; `name` + `compliance` (SSDF, SR-3/SA-15) + `changelog` + Boundaries; new `tests/test-cases.yml` (7 cases).

## Verification
- `make validate` → green (strict schema #202 + sensitive-terms)
- `make test-cases` → **17/17** across both suites
- `make test` → 127 unit tests pass
- `markdownlint-cli2` → 0 errors

## Review notes
Consensus (6/7 approve) + the contrarian's fair "scope/DRY" dissent were addressed by the flag-and-defer handoffs and by separating the diff *modality* from the IaC/workflow *domains*. QA/safety spot-check: no real secrets, exploits, or payloads; all examples synthetic.

Closes #173, #174, #175. Depends on #202 (merged).

## Type of Change
- [x] Skill updates (content) — security-governance-gated

🤖 AI-assisted (OpenCode). Requesting human review — please do not admin-merge.