### PR TITLE
feat(test): security-skill fixtures + runner assertions (M3 #156/#157/#158)

### DIFF
--- a/.agents/skills/fixtures/README.md
+++ b/.agents/skills/fixtures/README.md
@@ -1,0 +1,50 @@
+# Security-Skill Fixture Catalog
+
+Safe, **defanged** known-bad and known-good inputs for exercising the security
+skills' `tests/test-cases.yml`. Every fixture here is **synthetic** — no real
+secrets, PII, CUI, working exploit payloads, live IOCs, or internal hostnames.
+Prohibited patterns appear only as **clearly-labeled anti-patterns** so the
+unsafe-shell scanner and the sensitive-terms scan both pass.
+
+## Layout
+
+```text
+fixtures/
+├── known-bad/    # inputs a security skill SHOULD flag (defanged)
+└── known-good/   # inputs a security skill should NOT flag
+```
+
+## How fixtures are used
+
+A skill's `tests/test-cases.yml` references a fixture with an `input.type:
+file_path` and asserts the skill's behavior with the security assertions added
+in issue #157:
+
+- `flags_finding` — the (expected-output) report must contain ALL listed literal
+  signals (the finding class + the fix). Proves the skill catches a known-bad.
+- `no_false_positive` — the report must contain NONE of the listed finding
+  signals. Proves the skill does not over-report on a known-good.
+- `no_prohibited` with `literal: true` — literal-substring match (issue #203),
+  so shell strings like `curl | sh` are not misread as regex.
+
+> These fixtures are the **inputs** a skill reviews. The skill's *report* is what
+> a test-case asserts against; see `docs/security-skill-validation.md` for the
+> end-to-end example.
+
+## Safety rules for fixtures
+
+- Placeholder secrets only, and shaped so they can't be mistaken for real:
+  `AKIA_EXAMPLE_NOT_A_REAL_KEY`, `ghp_EXAMPLE_ONLY`, `password = "…"`.
+- Real prohibited shell (e.g. `curl … | sh`) appears only in a
+  ` ```bash anti-pattern ` fence or with a `# anti-pattern` marker.
+- Synthetic hostnames use `.example` / `.test`; synthetic IPs use `192.0.2.0/24`
+  (RFC 5737 TEST-NET).
+- No live IOCs, no real incident data, no working exploit code.
+
+## Catalog
+
+| Fixture | Kind | Demonstrates |
+|---------|------|--------------|
+| `known-bad/workflow-overbroad-permissions.md` | bad | over-broad `permissions: write-all` in a CI workflow |
+| `known-bad/dependency-unpinned-action.md` | bad | GitHub Action pinned to a mutable tag, not a SHA |
+| `known-good/workflow-least-privilege.md` | good | a correctly scoped, SHA-pinned workflow |

--- a/.agents/skills/fixtures/known-bad/dependency-unpinned-action.md
+++ b/.agents/skills/fixtures/known-bad/dependency-unpinned-action.md
@@ -1,0 +1,26 @@
+# Known-bad fixture: unpinned GitHub Action
+
+> **Synthetic** — for exercising `dependency-analysis` (Action SHA-pinning) /
+> `agentic-actions-auditor`. Demonstrates an Action pinned to a mutable tag.
+
+```yaml
+name: release
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      # ANTI-PATTERN: mutable tag, not a commit SHA — the tag can be re-pointed.
+      - uses: some-org/publish-action@v3
+      - run: echo "publishing"
+```
+
+What a review should flag: `some-org/publish-action@v3` is pinned to a mutable
+tag; pin to a full commit SHA (with the version in a trailing comment) so the
+resolved code cannot change under the tag.

--- a/.agents/skills/fixtures/known-bad/workflow-overbroad-permissions.md
+++ b/.agents/skills/fixtures/known-bad/workflow-overbroad-permissions.md
@@ -1,0 +1,23 @@
+# Known-bad fixture: over-broad CI workflow permissions
+
+> **Synthetic** — for exercising `least-privilege-review` / `agentic-actions-auditor`.
+> Not a real workflow. Demonstrates an over-broad `GITHUB_TOKEN` grant.
+
+```yaml
+name: build
+on: [push]
+
+# ANTI-PATTERN: repository-wide write granted to every job.
+permissions: write-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make build
+```
+
+What a review should flag: `permissions: write-all` grants far more than a build
+needs; scope to the minimum (e.g. `contents: read`). This is a least-privilege
+finding, not an agent-injection one.

--- a/.agents/skills/fixtures/known-good/workflow-least-privilege.md
+++ b/.agents/skills/fixtures/known-good/workflow-least-privilege.md
@@ -1,0 +1,29 @@
+# Known-good fixture: least-privilege, SHA-pinned workflow
+
+> **Synthetic** — the "should NOT be flagged" counterpart for
+> `least-privilege-review` / `agentic-actions-auditor` / `dependency-analysis`.
+
+```yaml
+name: build
+on:
+  pull_request:
+    branches: [main]
+
+# Minimal scope: read-only token is all a build needs.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Pinned to a full commit SHA (version in the trailing comment).
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - run: make build
+```
+
+Why this is clean: read-only token (least privilege), a safe `pull_request`
+trigger (not `pull_request_target`), a SHA-pinned action, and
+`persist-credentials: false`. A review should raise no finding.

--- a/.agents/skills/least-privilege-review/tests/test-cases.yml
+++ b/.agents/skills/least-privilege-review/tests/test-cases.yml
@@ -142,3 +142,44 @@ test_cases:
         sections:
           - "Summary"
           - "Findings"
+
+  - id: flags-finding-assertion-demo
+    name: "flags_finding: report catches the over-broad grant (fixture-style)"
+    description: "Exercises the #157 flags_finding assertion — the report names the finding and the fix"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Reviewed 1 workflow; 1 least-privilege finding.
+
+        ## Findings
+        - **Grant:** permissions: write-all
+        - **Why flagged:** grants more than the build needs.
+        - **Fix:** scope to contents: read.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "Findings"
+      - type: flags_finding
+        patterns:
+          - "write-all"
+          - "contents: read"
+
+  - id: no-false-positive-assertion-demo
+    name: "no_false_positive: clean workflow is not over-reported (fixture-style)"
+    description: "Exercises the #157 no_false_positive assertion — no finding signals on a known-good input"
+    input:
+      type: literal
+      content: |
+        ## Summary
+        No least-privilege findings. Token is read-only and the action is SHA-pinned.
+
+        ## Findings
+        None.
+    assertions:
+      - type: no_false_positive
+        patterns:
+          - "write-all"
+          - "severity: high"
+          - "over-broad"

--- a/docs/security-skill-validation.md
+++ b/docs/security-skill-validation.md
@@ -1,0 +1,106 @@
+# Security-Skill Validation — Worked Examples
+
+> How the pieces fit: a **fixture** (a defanged known-bad or known-good input) is
+> fed to a security skill, and the skill's **report** is asserted against the
+> skill's output contract using the test-runner assertions. This doc shows the
+> end-to-end pattern for authors adding or reviewing security skills.
+
+## The pieces
+
+| Piece | Where | Role |
+|-------|-------|------|
+| Fixture | [`.agents/skills/fixtures/`](../.agents/skills/fixtures/) | The *input* the skill reviews (synthetic, defanged) |
+| Skill | `.agents/skills/<skill>/SKILL.md` | Produces a review *report* |
+| Test-case | `.agents/skills/<skill>/tests/test-cases.yml` | Asserts the report meets the contract |
+| Runner | `scripts/run_test_cases.py` (`make test-cases`) | Executes the assertions |
+| Standard | [`clean-script-standard.md`](clean-script-standard.md) | Prohibited shell patterns (enforced by `scripts/scan_unsafe_shell.py`) |
+
+> A test-case's `input.content` is an **expected-output fixture** — a sample of
+> the report the skill should produce — checked against the contract. It is not
+> fed *to* the skill at runtime; these tests validate the *shape and safety* of
+> conformant output, not a live model call.
+
+## Assertion types for security skills
+
+Added in issue #157 (plus the `literal` option from #203):
+
+- **`flags_finding`** — the report must contain ALL listed literal signals (the
+  finding class + the recommended fix). Proves the skill catches a known-bad.
+- **`no_false_positive`** — the report must contain NONE of the listed
+  finding-signal literals. Proves the skill does not over-report on a known-good.
+- **`no_prohibited`** with **`literal: true`** — literal-substring match, so a
+  shell string like `curl | sh` is not misread as a regex alternation.
+- Existing: `contains`, `not_contains`, `has_sections`, `has_pattern`,
+  `no_prohibited` (regex default), `readability_max`.
+
+## Example 1 — assert a skill FLAGS a known-bad input
+
+A `least-privilege-review` test-case, using a fixture that shows an over-broad
+`GITHUB_TOKEN` grant:
+
+```yaml
+- id: flags-overbroad-token
+  name: "Flags a write-all GITHUB_TOKEN grant"
+  input:
+    type: literal
+    content: |
+      ## Summary
+      Reviewed 1 workflow; 1 least-privilege finding.
+
+      ## Findings
+      - **Grant:** permissions: write-all
+      - **Why flagged:** grants more than the build needs.
+      - **Fix:** scope to contents: read.
+  assertions:
+    - type: has_sections
+      sections: ["Summary", "Findings"]
+    - type: flags_finding
+      patterns: ["write-all", "contents: read"]
+```
+
+## Example 2 — assert a skill does NOT over-report on a known-good input
+
+```yaml
+- id: clean-workflow-not-flagged
+  name: "A least-privilege, SHA-pinned workflow is not flagged"
+  input:
+    type: literal
+    content: |
+      ## Summary
+      No least-privilege findings. Token is read-only, action SHA-pinned.
+
+      ## Findings
+      None.
+  assertions:
+    - type: no_false_positive
+      patterns: ["FAIL", "flagged", "severity: high", "write-all"]
+```
+
+## Example 3 — literal `no_prohibited` (safety, #203)
+
+Assert the skill's own output never emits a live pipe-to-shell, without the regex
+footgun:
+
+```yaml
+- type: no_prohibited
+  literal: true
+  patterns:
+    - "| sh"
+    - "eval $"
+```
+
+## Running
+
+```bash
+make test-cases        # all suites
+python scripts/run_test_cases.py .agents/skills/<skill>/tests/test-cases.yml
+```
+
+## Authoring checklist
+
+- [ ] Fixtures are synthetic and defanged (see fixtures/README.md safety rules).
+- [ ] Each security skill has a `flags_finding` case (catches a known-bad) and a
+      `no_false_positive` case (clean on a known-good).
+- [ ] A `no_prohibited` safety case (prefer `literal: true` for shell strings)
+      proves the skill's own report ships no live payload/secret.
+- [ ] `make test-cases`, `make validate`, and `make scan-shell` all pass.

--- a/scripts/run_test_cases.py
+++ b/scripts/run_test_cases.py
@@ -174,7 +174,7 @@ def run_assertion_has_pattern(output: str, patterns: list[str], minimum_count: i
     )
 
 
-def run_assertion_no_prohibited(output: str, patterns: list[str]) -> tuple[bool, str | None]:
+def run_assertion_no_prohibited(output: str, patterns: list[str], literal: bool = False) -> tuple[bool, str | None]:
     """
     Run 'no_prohibited' assertion.
 
@@ -182,20 +182,76 @@ def run_assertion_no_prohibited(output: str, patterns: list[str]) -> tuple[bool,
 
     Args:
         output: The output text to check
-        patterns: List of prohibited patterns
+        patterns: List of prohibited patterns (regex by default)
+        literal: When True, match patterns as literal substrings instead of
+            regex. Prevents shell/CI strings like ``curl | sh`` being read as the
+            regex alternation ``curl `` | `` sh`` (issue #203). Default False for
+            backward compatibility with existing regex-based test-cases.
 
     Returns:
         (passed, error_message)
     """
     found_patterns = []
     for pattern in patterns:
-        if re.search(pattern, output):
+        hit = pattern in output if literal else re.search(pattern, output) is not None
+        if hit:
             found_patterns.append(pattern)
 
     if not found_patterns:
         return True, None
 
     return False, f"Found prohibited patterns: {', '.join(found_patterns)}"
+
+
+def run_assertion_flags_finding(
+    output: str, patterns: list[str], case_sensitive: bool = False
+) -> tuple[bool, str | None]:
+    """
+    Run 'flags_finding' assertion (security-skill support, issue #157).
+
+    Asserts a skill's report FLAGS a known-bad fixture: EVERY listed literal
+    pattern (e.g. the finding class + the recommended fix) must appear. Use to
+    verify the skill correctly detects a known-bad input.
+
+    Args:
+        output: The skill's report (expected-output fixture)
+        patterns: Literal substrings that must ALL be present
+        case_sensitive: Whether matching is case-sensitive (default False)
+
+    Returns:
+        (passed, error_message)
+    """
+    hay = output if case_sensitive else output.lower()
+    missing = [p for p in patterns if (p if case_sensitive else p.lower()) not in hay]
+    if not missing:
+        return True, None
+    return False, f"Expected the report to flag (all present): missing {missing}"
+
+
+def run_assertion_no_false_positive(
+    output: str, patterns: list[str], case_sensitive: bool = False
+) -> tuple[bool, str | None]:
+    """
+    Run 'no_false_positive' assertion (security-skill support, issue #157).
+
+    Asserts a skill's report does NOT raise a finding on a known-GOOD fixture:
+    NONE of the listed finding-signal literal patterns (e.g. "FAIL", "flagged",
+    a severity marker) may appear. Use to verify the skill does not over-report
+    on safe input.
+
+    Args:
+        output: The skill's report (expected-output fixture)
+        patterns: Finding-signal literal substrings that must NOT be present
+        case_sensitive: Whether matching is case-sensitive (default False)
+
+    Returns:
+        (passed, error_message)
+    """
+    hay = output if case_sensitive else output.lower()
+    present = [p for p in patterns if (p if case_sensitive else p.lower()) in hay]
+    if not present:
+        return True, None
+    return False, f"False-positive signals present on a known-good input: {present}"
 
 
 def run_assertion_readability_max(output: str, max_grade: float) -> tuple[bool, str | None]:
@@ -274,7 +330,6 @@ def run_assertion(assertion: dict[str, Any], output: str) -> tuple[bool, str | N
             assertion.get("min_count", 1),
             assertion.get("case_sensitive", True),
         )
-
     elif assertion_type == "not_contains":
         return run_assertion_not_contains(output, assertion["pattern"], assertion.get("case_sensitive", True))
 
@@ -285,7 +340,25 @@ def run_assertion(assertion: dict[str, Any], output: str) -> tuple[bool, str | N
         return run_assertion_has_pattern(output, assertion["patterns"], assertion.get("minimum_count", 1))
 
     elif assertion_type == "no_prohibited":
-        return run_assertion_no_prohibited(output, assertion["patterns"])
+        return run_assertion_no_prohibited(
+            output,
+            assertion["patterns"],
+            assertion.get("literal", False),
+        )
+
+    elif assertion_type == "flags_finding":
+        return run_assertion_flags_finding(
+            output,
+            assertion["patterns"],
+            assertion.get("case_sensitive", False),
+        )
+
+    elif assertion_type == "no_false_positive":
+        return run_assertion_no_false_positive(
+            output,
+            assertion["patterns"],
+            assertion.get("case_sensitive", False),
+        )
 
     elif assertion_type == "readability_max":
         return run_assertion_readability_max(output, assertion.get("max_grade", 12))

--- a/scripts/tests/test_run_test_cases.py
+++ b/scripts/tests/test_run_test_cases.py
@@ -16,13 +16,60 @@ from run_test_cases import (
     load_test_cases,
     run_assertion,
     run_assertion_contains,
+    run_assertion_flags_finding,
     run_assertion_has_pattern,
     run_assertion_has_sections,
+    run_assertion_no_false_positive,
     run_assertion_no_prohibited,
     run_assertion_not_contains,
     run_test_case,
     run_test_suite,
 )
+
+
+class TestSecurityAssertions:
+    """issue #157 (security-skill assertions) + #203 (literal no_prohibited)."""
+
+    def test_no_prohibited_regex_default_backward_compatible(self):
+        # Default regex behavior unchanged: 'a|b' matches 'a'.
+        passed, _ = run_assertion_no_prohibited("just a here", ["a|b"])
+        assert passed is False
+
+    def test_no_prohibited_literal_avoids_regex_footgun(self):
+        # #203: 'curl | sh' as a literal must NOT match a safe 'curl -o f'
+        # (regex would match via the ' sh'/'curl ' alternation branches).
+        passed, _ = run_assertion_no_prohibited("curl -fsSL -o f url", ["curl | sh"], literal=True)
+        assert passed is True
+        # ...but it DOES match the real literal substring 'curl | sh'.
+        passed2, _ = run_assertion_no_prohibited("run: curl x.sh | sh here", ["| sh"], literal=True)
+        assert passed2 is False
+
+    def test_flags_finding_all_present(self):
+        report = "## Findings\n- Class: overclaimed\n- Fix: add citation\n"
+        passed, _ = run_assertion_flags_finding(report, ["overclaimed", "add citation"])
+        assert passed is True
+
+    def test_flags_finding_missing_one_fails(self):
+        report = "## Findings\n- Class: overclaimed\n"
+        passed, msg = run_assertion_flags_finding(report, ["overclaimed", "add citation"])
+        assert passed is False
+        assert "add citation" in msg
+
+    def test_no_false_positive_clean_report_passes(self):
+        report = "## Summary\nNo issues found. The workflow is least-privilege.\n"
+        passed, _ = run_assertion_no_false_positive(report, ["FAIL", "flagged", "severity: high"])
+        assert passed is True
+
+    def test_no_false_positive_detects_overreport(self):
+        report = "## Findings\n- severity: high — flagged\n"
+        passed, msg = run_assertion_no_false_positive(report, ["flagged", "severity: high"])
+        assert passed is False
+        assert "flagged" in msg or "severity: high" in msg
+
+    def test_dispatch_new_assertion_types(self):
+        assert run_assertion({"type": "flags_finding", "patterns": ["x"]}, "x here")[0] is True
+        assert run_assertion({"type": "no_false_positive", "patterns": ["x"]}, "clean")[0] is True
+        assert run_assertion({"type": "no_prohibited", "patterns": ["a | b"], "literal": True}, "a -o b")[0] is True
 
 
 class TestLoadTestCases:


### PR DESCRIPTION
## Summary

M3 PR C — the test-harness layer for security skills. Adds fixtures, two new runner assertion types, and a validation-examples doc. Closes **#156, #157, #158**; also fixes the regex footgun from **#203** (backward-compatibly).

## Runner (#157) — backward-compatible
- **`flags_finding`** — assert a report contains ALL listed literal signals (finding class + fix). Proves a skill catches a known-bad.
- **`no_false_positive`** — assert a report contains NONE of the listed finding signals. Proves a skill doesn't over-report on a known-good.
- **`no_prohibited`** gains an opt-in **`literal: true`** (#203): shell strings like `curl | sh` match literally instead of as a regex alternation. **Default stays regex — no existing test-case changes behavior.**

## Fixtures (#156)
`.agents/skills/fixtures/` — synthetic, **defanged** known-bad (over-broad workflow permissions; unpinned Action) and known-good (least-privilege SHA-pinned workflow) inputs. Prohibited patterns appear only in ` ```bash anti-pattern ` fences / `# anti-pattern` markers; secrets are obvious placeholders; RFC-5737 IPs / `.example` hosts. **gitleaks-clean** (verified against the files), sensitive-terms scan passes.

## Examples (#158)
`docs/security-skill-validation.md` walks the fixture → skill → report → assertion flow end-to-end, documents the new assertions, and gives an authoring checklist. Demonstrated live in `least-privilege-review`'s test-cases (added a `flags_finding` + a `no_false_positive` case).

## Verification
- `make validate` → green
- `make test-cases` → **51/51** across 9 suites
- `pytest` → 134 (run_test_cases suite 42, incl. new security-assertion + literal-#203 tests)
- `ruff` + `markdownlint` clean

## Type of Change
- [x] Test tooling + fixtures + docs

🤖 AI-assisted (OpenCode). Requesting human review.