### PR TITLE
fix(ci): suppress low adhoc-packages zizmor findings in frontend-skills-qa

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# zizmor configuration
+# https://docs.zizmor.sh/configuration/
+#
+# Suppress low-severity `adhoc-packages` findings for the frontend-skills-qa
+# workflow. These are `npm install -g <pkg>@<pinned-version>` steps in the
+# advisory-only HTML/accessibility jobs. The versions ARE pinned, the jobs are
+# path-filtered + non-blocking (they never fail the build), and installing a
+# global CLI for a throwaway CI job is the intended use — so the ad-hoc-install
+# finding is accepted here. Reassess if frontend-skills-qa is reworked (#193).
+rules:
+  adhoc-packages:
+    ignore:
+      - frontend-skills-qa.yml


### PR DESCRIPTION
## Summary

The **Actions Security (zizmor)** required check has been **failing on `main`** (exit 12) — this blocks every workflow-touching PR, including the M3 scanner PR #210. It is **not** caused by any recent PR; it's a pre-existing repo-hygiene failure.

The two findings are `low`-severity `adhoc-packages` in `frontend-skills-qa.yml` (the advisory HTML/a11y jobs' `npm install -g <pkg>@<pinned-version>` steps).

## Fix

Add `.github/zizmor.yml` (auto-discovered by the zizmor action — no `--config` needed) that ignores `adhoc-packages` for `frontend-skills-qa.yml`. Rationale: the versions are pinned, the jobs are path-filtered + non-blocking (they `exit 0` / advisory-only), and installing a global CLI for a throwaway CI job is the intended use. Reassess if frontend-skills-qa is reworked (#193).

## Verification (zizmor v1.26.1, online)
- **Before** (config removed): `2 findings ... exit 12`
- **After** (config auto-discovered): `No findings to report. Good job! (2 ignored)` / exit 0
- `make validate` still green.

## Why standalone
Kept separate from the M3 PRs (#209/#210/#212) — it fixes a pre-existing `main` failure in a workflow those PRs don't own, and unblocks the required check for all of them.

## Type of Change
- [x] CI fix (repo hygiene)

🤖 AI-assisted (OpenCode).