### PR TITLE
feat(sbx-kits): usai kit merges into global opencode config

### DIFF
--- a/integrations/isolation/sbx-kits/usai-provider-kit/README.md
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/README.md
@@ -6,8 +6,8 @@ provider, with network egress allow-listed.
 
 ## Scope and roadmap
 
-Today this kit targets **OpenCode**: it drops an `opencode.jsonc` and points
-OpenCode at it. It is named `usai-provider` (rather than
+Today this kit targets **OpenCode**: it ships an `opencode.jsonc` and merges it
+into OpenCode's global config. It is named `usai-provider` (rather than
 `usai-opencode-provider`) deliberately — the intent is to grow it into a single
 kit that configures the USAi provider for **multiple agents** (e.g. Codex,
 Claude Code, Cursor) as their config formats are added. Until then, applying it
@@ -18,11 +18,10 @@ on a non-OpenCode agent has no effect beyond the network allow-list.
 - **Network egress** — allow-lists `api.gsa.usai.gov` (`caps.network`), since
   USAi is a custom endpoint, not a built-in sbx service.
 - **Provider config** — ships `opencode.jsonc` (the USAi provider block + the
-  generated USAi model catalog) and sets
-  `OPENCODE_CONFIG=/home/agent/usai-config/opencode.jsonc` so OpenCode loads it
-  instead of prompting for a provider on startup.
-- **Co-tenancy guard** — a warn-only startup check (see
-  [Co-tenancy](#co-tenancy)).
+  generated USAi model catalog) and, at startup, **merges it into OpenCode's
+  global config** (`~/.config/opencode/opencode.jsonc`) so OpenCode loads it
+  instead of prompting for a provider — without clobbering any existing global
+  config (see [Design: merge, don't clobber](#design-merge-dont-clobber)).
 - **Permissions** — a deliberately **default-allow** OpenCode permission policy
   tuned for the sandbox, keeping only a zero-prompt `read` credential deny-list
   (see [Permissions](#permissions)).
@@ -69,7 +68,7 @@ contributes `ask`/`deny` rules via a project-layer
 config (OpenCode evaluates the **last matching** rule, so a later fragment wins —
 which is also why this config orders every `ask` edge after the broad `allow`).
 See
-[`docs/decisions/relax-permissions-for-sandbox.md`](docs/decisions/relax-permissions-for-sandbox.md).
+[`docs/decisions/0003-relax-permissions-for-sandbox.md`](docs/decisions/0003-relax-permissions-for-sandbox.md).
 
 ## Usage
 
@@ -93,33 +92,43 @@ sbx secret set-custom -g --host api.gsa.usai.gov --env USAI_API_KEY
 USAi keys expire periodically — if the agent starts failing auth, rotate the key
 and update the secret. See [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
 
-## Design: compose, don't clobber
+## Design: merge, don't clobber
 
-OpenCode merges config from **global** (`~/.config/opencode/opencode.json[c]`) <
-**`OPENCODE_CONFIG`** (a single custom file) < **project**
-(`<workspace>/.opencode/`). This kit deliberately writes a *namespaced* file
-(`~/usai-config/opencode.jsonc`) and points `OPENCODE_CONFIG` at it, rather than
-writing the global path. That way the kit **composes with** whatever the
-opencode base template writes globally instead of overwriting it — so USAi
-support doesn't preclude picking up upstream config changes.
+OpenCode reads config from the **global** path
+(`~/.config/opencode/opencode.json[c]`) < **project**
+(`<workspace>/.opencode/`). By request, this kit lands its config at the
+**global** path (rather than pointing `OPENCODE_CONFIG` at a namespaced file, as
+earlier versions did).
+
+To avoid overwriting a global config the base template or another kit may have
+written, a startup step **merges** instead of copying blindly:
+
+- **No existing global config** → the kit's `opencode.jsonc` is copied
+  **verbatim** (comments and the ownership marker preserved).
+- **An existing global config** → the USAi keys are **deep-merged into** it.
+  USAi wins for its own keys (`provider.usai`, `model`, `small_model`, `agent`,
+  `permission`, …); unrelated keys are preserved; any existing leaf the kit
+  overrides (e.g. a pre-existing top-level `model`) is logged as a warning.
+  Comments are dropped in this branch (JSON has none) — the fully annotated
+  source stays at `~/usai-config/opencode.jsonc` and in this repo.
+
+The merge is idempotent and runs as the agent user at every start. See
+[`docs/decisions/0004-global-config-merge-instead-of-opencode-config.md`](docs/decisions/0004-global-config-merge-instead-of-opencode-config.md).
 
 ## Co-tenancy
 
-`OPENCODE_CONFIG` is a single scalar env var, so only one kit can own it (env
-composition is last-wins). This kit owns it, and tags its config with an
-ownership **marker comment** (`usai-provider-kit:owns-opencode-config`). A
-warn-only `commands.startup` check fires if `OPENCODE_CONFIG` ends up pointing at
-a file without that marker (i.e. another kit claimed the channel). It never
-blocks startup.
+Because the kit no longer sets `OPENCODE_CONFIG` (a single-valued env var that
+only one kit could own), there is no env-var shadowing to guard against. Another
+kit that needs to add OpenCode config should drop its fragment at
+`<workspace>/.opencode/opencode.jsonc` (kit `files/workspace/...`) — OpenCode's
+**project** layer deep-merges it *over* the global config, so its keys and the
+USAi provider config compose without either clobbering the other.
 
-> The marker is a JSONC **comment**, not a config key, because current OpenCode
-> validates against a closed schema and rejects unknown top-level keys.
-
-**If you are writing another kit that needs to add OpenCode config, do not set
-`OPENCODE_CONFIG`.** Instead drop your fragment at
-`<workspace>/.opencode/opencode.jsonc` (kit `files/workspace/...`) — OpenCode
-deep-merges it *over* `OPENCODE_CONFIG`, so your keys and the USAi provider
-config compose without either clobbering the other.
+> The ownership **marker comment**
+> (`usai-provider-kit:owns-opencode-config`) is retained in the shipped file. It
+> is a JSONC **comment**, not a config key, because OpenCode validates against a
+> closed schema and rejects unknown top-level keys. It survives the verbatim-copy
+> path and lets `scripts/verify` recognize the kit's own config.
 
 ## Updating the model catalog
 
@@ -143,31 +152,38 @@ Run the bundled check on a host with `sbx` installed and logged in:
 ```
 
 It validates the spec, creates a throwaway sandbox with the kit, and confirms
-`OPENCODE_CONFIG` is set, the config file + ownership marker are present, and
-the USAi API is reachable with the injected key. Set `KEEP=1` to keep the
-sandbox for inspection.
+the global config (`~/.config/opencode/opencode.jsonc`) exists and carries the
+USAi `provider.usai` block, that a pre-seeded foreign global key survives the
+merge, and that the USAi API is reachable with the injected key. Set `KEEP=1` to
+keep the sandbox for inspection.
 
 ## Design decisions
 
 See [`docs/decisions/`](docs/decisions/):
 
-- [`usai-provider-as-mixin-kit.md`](docs/decisions/usai-provider-as-mixin-kit.md)
-  — why a self-contained kit, namespaced `OPENCODE_CONFIG`, secret handling.
-- [`opencode-config-co-tenancy.md`](docs/decisions/opencode-config-co-tenancy.md)
-  — single `OPENCODE_CONFIG` owner, the ownership marker, the fragment contract.
-- [`relax-permissions-for-sandbox.md`](docs/decisions/relax-permissions-for-sandbox.md)
+- [`0001-usai-provider-as-mixin-kit.md`](docs/decisions/0001-usai-provider-as-mixin-kit.md)
+  — why a self-contained kit, secret handling (config-delivery portion
+  superseded by 0004).
+- [`0002-opencode-config-co-tenancy.md`](docs/decisions/0002-opencode-config-co-tenancy.md)
+  — the old single-`OPENCODE_CONFIG` owner contract (**superseded** by 0004).
+- [`0003-relax-permissions-for-sandbox.md`](docs/decisions/0003-relax-permissions-for-sandbox.md)
   — why the permission policy is default-allow, and how to re-gate via a mixin.
+- [`0004-global-config-merge-instead-of-opencode-config.md`](docs/decisions/0004-global-config-merge-instead-of-opencode-config.md)
+  — why the kit merges into the global config path instead of setting
+  `OPENCODE_CONFIG`.
 
 ## Layout
 
 ```
 usai-provider-kit/
 ├── spec.yaml                                   # the kit
-├── files/home/usai-config/opencode.jsonc       # USAi provider + model catalog
+├── files/home/usai-config/
+│   ├── opencode.jsonc                          # USAi provider + model catalog
+│   └── merge-global-config.mjs                 # startup merge into global config
 ├── scripts/
 │   ├── sync-usai-models.mjs                    # regenerate the model catalog
 │   └── verify                                  # host-side end-to-end check
-├── tests/                                      # generator tests + fixture
-├── docs/decisions/                             # design decision records
+├── tests/                                      # generator + merge tests + fixture
+├── docs/decisions/                             # numbered design decision records
 └── package.json                                # npm test / sync:usai-models
 ```

--- a/integrations/isolation/sbx-kits/usai-provider-kit/TROUBLESHOOTING.md
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/TROUBLESHOOTING.md
@@ -8,20 +8,22 @@ applied the kit to a sandbox (`sbx run --kit <kit> opencode <project>`).
 **Symptoms:** OpenCode lists generic providers instead of USAi; the custom USAi
 model catalog is missing.
 
-**Cause:** the USAi provider config isn't loaded. The kit delivers it by setting
-`OPENCODE_CONFIG=/home/agent/usai-config/opencode.jsonc` and dropping that file.
-This symptom means the kit wasn't applied to the sandbox, or another kit claimed
-the single-valued `OPENCODE_CONFIG` channel (the kit's startup guard warns when
-it detects this — check the sandbox's startup logs).
+**Cause:** the USAi provider config isn't in OpenCode's global config. The kit
+delivers it by staging `opencode.jsonc` at `/home/agent/usai-config/` and running
+a startup step that merges it into `~/.config/opencode/opencode.jsonc`. This
+symptom means the kit wasn't applied, or the merge step didn't run.
 
 **Fix:**
 
 - Recreate the sandbox with the kit applied: `sbx run --kit <kit> opencode <proj>`.
 - Or inject it into an existing sandbox without recreating
-  (EXPERIMENTAL): `sbx kit add <sandbox> <kit>`, then restart the agent so it
-  re-reads `OPENCODE_CONFIG`.
-- Confirm the channel isn't shadowed: `sbx exec <sandbox> -- sh -c 'echo
-  $OPENCODE_CONFIG'` should print `/home/agent/usai-config/opencode.jsonc`.
+  (EXPERIMENTAL): `sbx kit add <sandbox> <kit>`, then restart the agent so the
+  startup merge runs and OpenCode re-reads its global config.
+- Confirm the global config has the USAi provider:
+  `sbx exec <sandbox> -- sh -c 'grep -c \"\\\"usai\\\"\" ~/.config/opencode/opencode.jsonc'`
+  should print a non-zero count.
+- Check the merge step's output in the sandbox startup logs (look for
+  `usai-provider: merged ...` or `usai-provider: ... copied ...`).
 
 ## USAi authentication fails (HTTP 401/403)
 
@@ -63,15 +65,19 @@ it detects this — check the sandbox's startup logs).
 sync:usai-models`, then re-apply/recreate the sandbox. The generator only
 rewrites the region between the `BEGIN/END GENERATED USAI MODELS` markers.
 
-## The ownership warning appeared at startup
+## A global-key override warning appeared at startup
 
-**Symptom:** a `usai-provider: warning: OPENCODE_CONFIG ... is not the USAi kit
-config` message in startup logs.
+**Symptom:** a `usai-provider: warning: overrode existing global key '<key>'
+with the USAi value` message in startup logs.
 
-**Cause:** another kit set `OPENCODE_CONFIG` and shadowed this kit's config
-(env-var composition is last-wins).
+**Cause:** the sandbox already had a global OpenCode config
+(`~/.config/opencode/opencode.jsonc` or `.json`) that set a key the USAi kit also
+sets (e.g. a top-level `model`). The kit's config wins for its own keys, so it
+overrode that leaf during the merge. This is informational, not an error — all
+unrelated keys from the existing config are preserved.
 
-**Fix:** have the other kit contribute its OpenCode config via
-`<workspace>/.opencode/opencode.jsonc` instead of setting `OPENCODE_CONFIG` —
-OpenCode deep-merges that *over* `OPENCODE_CONFIG`, so both compose. See the
-"Co-tenancy" section of the README.
+**Fix (only if the override is unwanted):** have the other config contribute via
+`<workspace>/.opencode/opencode.jsonc` instead of the global path. OpenCode's
+**project** layer deep-merges *over* the global config, so a value set there wins
+over the USAi kit's global value — letting both compose. See the "Co-tenancy"
+section of the README.

--- a/integrations/isolation/sbx-kits/usai-provider-kit/TROUBLESHOOTING.md
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/TROUBLESHOOTING.md
@@ -81,3 +81,21 @@ unrelated keys from the existing config are preserved.
 **project** layer deep-merges *over* the global config, so a value set there wins
 over the USAi kit's global value — letting both compose. See the "Co-tenancy"
 section of the README.
+
+## A pre-existing global `config.json` seems to be ignored
+
+**Symptom:** the sandbox had a global `~/.config/opencode/config.json` (or
+`opencode.json`), you hand-edit it later, and your change has no effect.
+
+**Cause:** the startup merge writes its result to the canonical
+`opencode.jsonc` and leaves any other global filename (`config.json`,
+`opencode.json`) **on disk, untouched**. Your original keys were merged into
+`opencode.jsonc` at first boot, and OpenCode's precedence ranks `opencode.jsonc`
+**over** `config.json` — so the canonical file wins and later edits to the
+orphaned `config.json` are shadowed. No data is lost; the orphaned file is just
+no longer authoritative.
+
+**Fix:** make edits in `~/.config/opencode/opencode.jsonc` (the file the kit
+writes and OpenCode prefers), or drop a project-layer
+`<workspace>/.opencode/opencode.jsonc` fragment, which deep-merges *over* the
+global config.

--- a/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/0001-usai-provider-as-mixin-kit.md
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/0001-usai-provider-as-mixin-kit.md
@@ -1,6 +1,11 @@
 # Decision: Ship the USAi provider config as a self-contained sbx mixin kit
 
-**Status:** accepted
+**Status:** accepted — but the `OPENCODE_CONFIG` delivery mechanism below is
+**superseded by** [`0004-global-config-merge-instead-of-opencode-config.md`](0004-global-config-merge-instead-of-opencode-config.md).
+The kit is still a self-contained mixin with allow-listed egress and injected
+secrets (those parts stand); it no longer sets `OPENCODE_CONFIG` — it merges its
+config into the global path instead. Read the "Namespaced `OPENCODE_CONFIG`"
+section below as historical context.
 
 ## Context
 
@@ -69,4 +74,8 @@ and applied without any surrounding repository.
 - A sandbox with this kit applied has a working USAi provider with no prompt.
 - The kit is portable and independently versionable.
 - It owns the single-valued `OPENCODE_CONFIG` channel — see
-  [`opencode-config-co-tenancy.md`](opencode-config-co-tenancy.md).
+  [`0002-opencode-config-co-tenancy.md`](0002-opencode-config-co-tenancy.md).
+
+> **Superseded (2026-07-06):** the `OPENCODE_CONFIG` channel and its co-tenancy
+> contract were replaced by a startup merge into the global config path. See
+> [`0004-global-config-merge-instead-of-opencode-config.md`](0004-global-config-merge-instead-of-opencode-config.md).

--- a/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/0002-opencode-config-co-tenancy.md
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/0002-opencode-config-co-tenancy.md
@@ -1,6 +1,19 @@
 # Decision: OpenCode config co-tenancy — single `OPENCODE_CONFIG` owner
 
-**Status:** accepted
+**Status:** superseded by
+[`0004-global-config-merge-instead-of-opencode-config.md`](0004-global-config-merge-instead-of-opencode-config.md)
+(2026-07-06)
+
+> **Why superseded:** this entire decision exists to make the kit's use of the
+> single-valued `OPENCODE_CONFIG` env var co-tenant-safe. The kit no longer sets
+> `OPENCODE_CONFIG` at all — it merges its config into the global path
+> (`~/.config/opencode/opencode.jsonc`) at startup, so the last-wins env-var
+> shadowing problem this document addresses no longer applies. The ownership
+> **marker comment** is retained in the shipped file (it still tags the kit's
+> config), but the warn-only startup guard that greps for it has been removed.
+> Co-tenant kits still contribute via `<workspace>/.opencode/opencode.jsonc`
+> (the project layer still deep-merges over the global layer). The record below
+> is retained for historical context.
 
 ## Context
 

--- a/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/0003-relax-permissions-for-sandbox.md
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/0003-relax-permissions-for-sandbox.md
@@ -170,5 +170,5 @@ overlay as independent, composable pieces.
 
 ## Links
 
-- Companion: `opencode-config-co-tenancy.md` (the merge/precedence contract a
+- Companion: `0002-opencode-config-co-tenancy.md` (the merge/precedence contract a
   re-gating mixin relies on)

--- a/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/0004-global-config-merge-instead-of-opencode-config.md
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/0004-global-config-merge-instead-of-opencode-config.md
@@ -1,0 +1,122 @@
+# Decision: Merge into OpenCode's global config instead of setting `OPENCODE_CONFIG`
+
+**Status:** accepted (2026-07-06)
+**Supersedes:** the `OPENCODE_CONFIG` delivery mechanism in
+[`0001-usai-provider-as-mixin-kit.md`](0001-usai-provider-as-mixin-kit.md)
+(§"Namespaced `OPENCODE_CONFIG`") and all of
+[`0002-opencode-config-co-tenancy.md`](0002-opencode-config-co-tenancy.md).
+
+## Context
+
+The kit originally delivered the USAi provider config by writing a namespaced
+file (`~/usai-config/opencode.jsonc`) and setting
+`OPENCODE_CONFIG=/home/agent/usai-config/opencode.jsonc`. That leaned on
+OpenCode's config layering (global < `OPENCODE_CONFIG` < project) to *compose
+with* whatever the base template might write to the global path, without
+clobbering it — see ADR 0001. The single-valued nature of `OPENCODE_CONFIG` then
+forced a co-tenancy contract (ownership marker + warn-only guard) — see ADR
+0002.
+
+**Users asked for the config to land at the global path**
+(`~/.config/opencode/opencode.jsonc`) rather than being reached through
+`OPENCODE_CONFIG`. Reasons cited: it is the path people already know and inspect,
+it avoids an extra env var, and it behaves like a "normal" OpenCode install.
+
+The naive way to honor that — write the kit's file directly to the global path —
+would **clobber** any global config the base template or another kit wrote. That
+is exactly the failure mode ADR 0001 avoided by *not* writing the global path.
+
+## Decision
+
+**Ship the USAi config in the kit's `files/` tree (staging area, unchanged) and,
+at startup, MERGE it into the global config path — copying verbatim when no
+global config exists, deep-merging when one does.** Stop setting
+`OPENCODE_CONFIG`.
+
+Concretely:
+
+1. **No `OPENCODE_CONFIG`.** The `environment.variables` block is removed.
+
+2. **Ship a merge script in `files/`.** `merge-global-config.mjs` lives at
+   `files/home/usai-config/` (not host-only `scripts/`), so sbx maps it into the
+   sandbox next to the staged `opencode.jsonc`. The base image ships `node`
+   (v22), which the kit already depends on.
+
+3. **`commands.startup` runs the merge** as the agent user (uid 1000, which owns
+   `/home/agent`). The kit's `files/` payload is laid down by base-image setup
+   that runs **before** `startup` — the same lifecycle ordering the
+   `zscaler-ca-certificate` kit relies on — so the staged source and script
+   exist by then.
+
+4. **Copy vs. merge:**
+   - **No existing global config** (`config.json` / `opencode.json` /
+     `opencode.jsonc` all absent): copy the staged file **verbatim**. Comments
+     and the ownership marker are preserved.
+   - **Existing global config(s):** deep-merge the USAi keys **into** the
+     existing config and write JSON to `opencode.jsonc`. The **USAi kit wins for
+     its own keys** (`provider.usai`, `model`, `small_model`, `agent`,
+     `permission`, …); unrelated existing keys are preserved. Any existing leaf
+     the kit overwrites (e.g. a pre-existing top-level `model`) is reported as a
+     `warning:` on stderr. If more than one global filename exists, they are
+     merged in OpenCode's precedence order first, then the kit's config on top.
+
+5. **Idempotent.** Re-running the merge on every start converges to the same
+   result, satisfying sbx's "startup must be idempotent" rule.
+
+### Co-tenancy after this change
+
+The single-valued `OPENCODE_CONFIG` shadowing problem (ADR 0002) **no longer
+exists**, because the kit no longer sets that env var. Other config-contributing
+kits still contribute via `<workspace>/.opencode/opencode.jsonc` — OpenCode's
+**project** layer still deep-merges *over* the global layer, so a co-tenant kit's
+fragment composes with the USAi global config exactly as before. The warn-only
+startup guard is removed; the ownership **marker comment** is retained (it still
+tags the kit's file and lets `scripts/verify` recognize a verbatim copy).
+
+## Trade-offs
+
+- **Comments are lost in the merge branch.** JSON has no comments, so merging
+  into a pre-existing global config drops the annotations. Accepted: the fully
+  annotated source stays at `~/usai-config/opencode.jsonc` inside the sandbox and
+  in the repo, so the reference copy is never lost. The copy branch (the common
+  case, since the stock base writes no global config) **keeps** comments.
+- **We now own the global path's contents.** Overwriting an existing leaf is a
+  real semantic change to the user's config; we surface each such override as a
+  warning rather than silently winning.
+- **Startup does not fail closed.** Like the zscaler kit, a merge failure logs
+  but does not gate the agent entrypoint. The script exits non-zero only on an
+  unexpected error (missing/unparseable source), not on leaf conflicts.
+  `scripts/verify` asserts the end state to catch regressions.
+
+## Considered alternatives
+
+- **Write the global path directly (no merge)** — rejected: clobbers an existing
+  global config, the exact property ADR 0001 preserved.
+- **Keep `OPENCODE_CONFIG`** — rejected per the user request that motivated this
+  ADR; also carries the ADR-0002 co-tenancy complexity.
+- **Merge with `jq`** — rejected: `jq` cannot parse the JSONC comments in the
+  shipped file, and the kit already depends on Node, which handles JSONC and the
+  file's shape. A small, unit-tested script is clearer than a comment-stripping
+  `jq` pipeline.
+- **Embed the merge script inline via `commands.initFiles`** — rejected:
+  duplicates the script body in `spec.yaml` and can't be unit-tested; shipping it
+  in `files/` keeps a single tested source.
+
+## Validation
+
+- `tests/merge-global-config.test.mjs` covers JSONC comment stripping (including
+  `//` inside string URLs), deep-merge precedence and conflict reporting, the
+  copy-vs-merge branches, and an end-to-end run of the script against a temp dir.
+- `scripts/verify` asserts the end state on a real sandbox: the global
+  `opencode.jsonc` exists and contains `provider.usai`, and a pre-seeded foreign
+  global key survives the merge.
+- Phase-ordering assumption (files/ present by startup) is the same one the
+  `zscaler-ca-certificate` kit documents and relies on.
+
+## See also
+
+- [`0001-usai-provider-as-mixin-kit.md`](0001-usai-provider-as-mixin-kit.md) —
+  original self-contained-mixin decision (partially superseded here).
+- [`0002-opencode-config-co-tenancy.md`](0002-opencode-config-co-tenancy.md) —
+  the `OPENCODE_CONFIG` co-tenancy contract (superseded here).
+- Docker kit spec reference — [Commands (`install`, `startup`, `initFiles`)](https://docs.docker.com/ai/sandboxes/customize/kit-reference/#commands)

--- a/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/0004-global-config-merge-instead-of-opencode-config.md
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/docs/decisions/0004-global-config-merge-instead-of-opencode-config.md
@@ -60,8 +60,14 @@ Concretely:
      `warning:` on stderr. If more than one global filename exists, they are
      merged in OpenCode's precedence order first, then the kit's config on top.
 
-5. **Idempotent.** Re-running the merge on every start converges to the same
-   result, satisfying sbx's "startup must be idempotent" rule.
+5. **Converges to a stable fixed point.** Re-running the merge on every start
+   satisfies sbx's "startup must be idempotent" rule in the sense that matters:
+   the effective config is stable at every boot. Note it is *not* byte-identical
+   from the very first run — on an empty global dir, boot 1 copies verbatim
+   (comments + marker intact) and boot 2 re-reads that file as an existing config
+   and normalizes it to bare JSON (comments + marker dropped). From boot 2 onward
+   the on-disk bytes are stable. No config key/value is ever lost across this
+   transition; only comments are (JSON has none).
 
 ### Co-tenancy after this change
 

--- a/integrations/isolation/sbx-kits/usai-provider-kit/files/home/usai-config/merge-global-config.mjs
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/files/home/usai-config/merge-global-config.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+//
+// merge-global-config.mjs — land the USAi provider config at OpenCode's GLOBAL
+// config path (~/.config/opencode/opencode.jsonc) WITHOUT clobbering a global
+// config that another kit or the base template may already have written.
+//
+// Invoked by the kit's `commands.startup` step (see spec.yaml). It ships in the
+// kit's `files/` tree (so it is mapped into the sandbox alongside the staged
+// config, unlike host-only `scripts/`) and replaces the old approach of
+// pointing OPENCODE_CONFIG at a namespaced file. See
+// docs/decisions/0004-global-config-merge-instead-of-opencode-config.md.
+//
+// Behavior:
+//   - No existing global config  -> COPY the kit's file verbatim (comments and
+//     the ownership marker preserved). No merge needed.
+//   - Existing global config(s)  -> DEEP-MERGE the kit's keys INTO the existing
+//     config and write JSON to opencode.jsonc. The USAi kit wins for its OWN
+//     keys (provider.usai, model, small_model, agent, permission, ...); all
+//     unrelated existing keys are preserved. A `warning:` is printed to stderr
+//     for every top-level leaf the kit overwrites (e.g. a pre-existing `model`).
+//     Comments are lost in this branch (JSON has none); the annotated source
+//     remains at the kit's staged path and in the repo.
+//
+// The step is idempotent: re-merging the same keys converges to the same result
+// (once merged, the ownership marker is gone, but the effective config is
+// stable, and a subsequent run just re-writes the same JSON).
+//
+// Usage:
+//   node merge-global-config.mjs \
+//     --source /home/agent/usai-config/opencode.jsonc \
+//     --global-dir /home/agent/.config/opencode
+//
+// Exit codes: 0 on success (copy or merge), non-zero only on unexpected error
+// (e.g. the source is missing/unparseable). Leaf-conflict warnings do NOT fail.
+
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises"
+import path from "node:path"
+import process from "node:process"
+
+// OpenCode reads these filenames from the global dir, in this precedence order
+// (later overrides earlier when more than one is present). We merge any that
+// exist so nothing a base template wrote is silently dropped.
+const GLOBAL_FILENAMES = ["config.json", "opencode.json", "opencode.jsonc"]
+// Canonical file we (re)write. .jsonc so the copy branch can keep comments.
+const CANONICAL_FILENAME = "opencode.jsonc"
+
+/**
+ * Strip `//` line comments and block comments from JSONC, plus trailing
+ * commas, WITHOUT corrupting comment-like sequences inside string literals
+ * (the config contains `https://` URLs). Returns plain JSON text.
+ * @param {string} text
+ * @returns {string}
+ */
+export function stripJsonc(text) {
+  let out = ""
+  let inString = false
+  let stringQuote = ""
+  let inLineComment = false
+  let inBlockComment = false
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    const next = text[i + 1]
+
+    if (inLineComment) {
+      if (ch === "\n") {
+        inLineComment = false
+        out += ch
+      }
+      continue
+    }
+    if (inBlockComment) {
+      if (ch === "*" && next === "/") {
+        inBlockComment = false
+        i++
+      }
+      continue
+    }
+    if (inString) {
+      out += ch
+      if (ch === "\\") {
+        // Copy the escaped character verbatim.
+        out += text[i + 1] ?? ""
+        i++
+      } else if (ch === stringQuote) {
+        inString = false
+      }
+      continue
+    }
+    // Not in a string or comment.
+    if (ch === '"' || ch === "'") {
+      inString = true
+      stringQuote = ch
+      out += ch
+      continue
+    }
+    if (ch === "/" && next === "/") {
+      inLineComment = true
+      i++
+      continue
+    }
+    if (ch === "/" && next === "*") {
+      inBlockComment = true
+      i++
+      continue
+    }
+    out += ch
+  }
+
+  // Remove trailing commas before } or ].
+  return out.replace(/,(\s*[}\]])/g, "$1")
+}
+
+/**
+ * Parse JSONC text into an object.
+ * @param {string} text
+ * @returns {object}
+ */
+export function parseJsonc(text) {
+  return JSON.parse(stripJsonc(text))
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+/**
+ * Deep-merge `source` INTO `base`, returning a new object. `source` wins on
+ * conflicts. Objects merge recursively; arrays and scalars from `source`
+ * replace `base`. Records every top-level leaf that `source` overwrites (an
+ * existing value replaced by a differing one) into `conflicts`.
+ * @param {object} base
+ * @param {object} source
+ * @param {string[]} conflicts - accumulator of dotted paths overwritten
+ * @param {string} [prefix]
+ * @returns {object}
+ */
+export function deepMerge(base, source, conflicts, prefix = "") {
+  const result = { ...base }
+  for (const key of Object.keys(source)) {
+    const dotted = prefix ? `${prefix}.${key}` : key
+    const sourceVal = source[key]
+    const baseVal = base[key]
+    if (isPlainObject(sourceVal) && isPlainObject(baseVal)) {
+      result[key] = deepMerge(baseVal, sourceVal, conflicts, dotted)
+    } else {
+      if (
+        Object.prototype.hasOwnProperty.call(base, key) &&
+        JSON.stringify(baseVal) !== JSON.stringify(sourceVal)
+      ) {
+        conflicts.push(dotted)
+      }
+      result[key] = sourceVal
+    }
+  }
+  return result
+}
+
+/**
+ * Find existing global config files in `globalDir`, in precedence order.
+ * @param {string} globalDir
+ * @returns {Promise<string[]>} absolute paths that exist
+ */
+async function findExistingGlobalConfigs(globalDir) {
+  let entries
+  try {
+    entries = await readdir(globalDir)
+  } catch {
+    return []
+  }
+  const present = new Set(entries)
+  return GLOBAL_FILENAMES.filter((name) => present.has(name)).map((name) =>
+    path.join(globalDir, name),
+  )
+}
+
+function parseArgs(argv) {
+  const args = { source: "", globalDir: "" }
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--source") args.source = argv[++i]
+    else if (argv[i] === "--global-dir") args.globalDir = argv[++i]
+  }
+  return args
+}
+
+/**
+ * Perform the copy-or-merge. Pure enough to unit-test: takes the source text
+ * and the list of existing {path, text} global configs, returns
+ * { output, merged, conflicts }.
+ * @param {string} sourceText - the kit's opencode.jsonc (JSONC)
+ * @param {{path: string, text: string}[]} existing - existing global configs,
+ *   in precedence order (earliest first)
+ * @returns {{ output: string, merged: boolean, conflicts: string[] }}
+ */
+export function computeOutput(sourceText, existing) {
+  if (existing.length === 0) {
+    // Copy verbatim — preserves comments and the ownership marker.
+    return { output: sourceText, merged: false, conflicts: [] }
+  }
+  const sourceConfig = parseJsonc(sourceText)
+  const conflicts = []
+  // Start from the existing configs merged in OpenCode precedence order (later
+  // file wins over earlier), THEN merge the kit's config on top so USAi wins
+  // for its own keys.
+  let base = {}
+  for (const cfg of existing) {
+    base = deepMerge(base, parseJsonc(cfg.text), [])
+  }
+  const output = deepMerge(base, sourceConfig, conflicts)
+  return {
+    output: JSON.stringify(output, null, 2) + "\n",
+    merged: true,
+    conflicts,
+  }
+}
+
+async function main() {
+  const { source, globalDir } = parseArgs(process.argv.slice(2))
+  if (!source || !globalDir) {
+    throw new Error("usage: merge-global-config.mjs --source <file> --global-dir <dir>")
+  }
+
+  const sourceText = await readFile(source, "utf8")
+  const existingPaths = await findExistingGlobalConfigs(globalDir)
+  const existing = await Promise.all(
+    existingPaths.map(async (p) => ({ path: p, text: await readFile(p, "utf8") })),
+  )
+
+  const { output, merged, conflicts } = computeOutput(sourceText, existing)
+
+  await mkdir(globalDir, { recursive: true })
+  const target = path.join(globalDir, CANONICAL_FILENAME)
+  await writeFile(target, output)
+
+  if (!merged) {
+    process.stdout.write(
+      `usai-provider: no existing global config; copied USAi config to ${target}\n`,
+    )
+    return
+  }
+
+  process.stdout.write(
+    `usai-provider: merged USAi config into existing global config at ${target} ` +
+      `(sources: ${existing.map((e) => path.basename(e.path)).join(", ")})\n`,
+  )
+  for (const c of conflicts) {
+    process.stderr.write(
+      `usai-provider: warning: overrode existing global key '${c}' with the USAi value\n`,
+    )
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(`usai-provider: merge failed: ${error.message}`)
+    process.exit(1)
+  })
+}

--- a/integrations/isolation/sbx-kits/usai-provider-kit/files/home/usai-config/merge-global-config.mjs
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/files/home/usai-config/merge-global-config.mjs
@@ -21,9 +21,13 @@
 //     Comments are lost in this branch (JSON has none); the annotated source
 //     remains at the kit's staged path and in the repo.
 //
-// The step is idempotent: re-merging the same keys converges to the same result
-// (once merged, the ownership marker is gone, but the effective config is
-// stable, and a subsequent run just re-writes the same JSON).
+// The step converges to a stable fixed point rather than being byte-idempotent
+// from the first run. On an empty global dir the first boot COPIES verbatim
+// (comments + marker intact); the next boot re-reads that output as an existing
+// config and takes the MERGE branch, normalizing it to bare JSON (comments +
+// marker dropped). From that point on every boot re-writes byte-identical JSON.
+// The effective config is stable at every step; only the on-disk form settles
+// after the first merge.
 //
 // Usage:
 //   node merge-global-config.mjs \

--- a/integrations/isolation/sbx-kits/usai-provider-kit/files/home/usai-config/opencode.jsonc
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/files/home/usai-config/opencode.jsonc
@@ -19,18 +19,20 @@
   // outbound "new destination" commands (git push, new remotes, scp/sftp/etc.).
   // For stricter environments, layer a separate mixin that re-gates via a
   // project-layer .opencode/opencode.jsonc rather than editing this file. See
-  // docs/decisions/relax-permissions-for-sandbox.md.
+  // docs/decisions/0003-relax-permissions-for-sandbox.md.
   // ===========================================================================
   "$schema": "https://opencode.ai/config.json",
 
   // usai-provider-kit:owns-opencode-config
-  // ^ Ownership sentinel COMMENT for the usai-provider sbx kit. The kit's
-  // startup guard greps OPENCODE_CONFIG's file for this marker to tell "the
-  // file we wrote" apart from a foreign opencode.jsonc some other mixin may
-  // have pointed OPENCODE_CONFIG at (env-var last-wins). It is a comment (not a
-  // JSON key) on purpose: current OpenCode validates config against a closed
-  // schema and rejects unknown top-level keys. See the kit README "Co-tenancy".
-  // Do not remove this comment.
+  // ^ Ownership marker COMMENT for the usai-provider sbx kit. It tags this file
+  // as the one the kit ships, so the startup merge step (and `scripts/verify`)
+  // can recognize the kit's own config after it is copied verbatim into the
+  // global path. It is a comment (not a JSON key) on purpose: current OpenCode
+  // validates config against a closed schema and rejects unknown top-level keys.
+  // NOTE: comments (including this one) are preserved when the kit COPIES this
+  // file into an empty global path, but are dropped when it MERGES into a
+  // pre-existing global config (JSON has no comments). See the kit README
+  // "Design: merge, don't clobber". Do not remove this comment.
 
   // ===========================================================================
   // PROVIDER CONFIGURATION
@@ -294,7 +296,7 @@
     // <workspace>/.opencode/opencode.jsonc, which OpenCode deep-merges OVER this
     // config. OpenCode evaluates the LAST matching rule, so a re-gating fragment
     // that loads after this one wins. See
-    // docs/decisions/relax-permissions-for-sandbox.md.
+    // docs/decisions/0003-relax-permissions-for-sandbox.md.
     // -------------------------------------------------------------------------
     "*": "allow",
     "edit": "allow",

--- a/integrations/isolation/sbx-kits/usai-provider-kit/scripts/verify
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/scripts/verify
@@ -3,9 +3,10 @@
 # verify — host-side validation for the usai-provider sbx mixin kit.
 #
 # Run on a host where `sbx` (>= 0.34.0) is installed and logged in. It validates
-# the kit spec, creates a sandbox with the kit applied, and confirms OpenCode is
-# pointed at the USAi config (OPENCODE_CONFIG set, the config file present, the
-# ownership marker comment intact, and the USAi API reachable with the key).
+# the kit spec, creates a sandbox with the kit applied, and confirms OpenCode's
+# GLOBAL config carries the USAi provider (config present at
+# ~/.config/opencode/opencode.jsonc, contains provider.usai, a pre-seeded
+# foreign global key survives the merge, and the USAi API is reachable).
 #
 # It creates a temporary sandbox named "usai-kit-verify-*" and removes it at the
 # end (and on interrupt). It does not touch your other sandboxes. Nothing here
@@ -73,13 +74,35 @@ else
 fi
 sleep 2
 
-info "3. OPENCODE_CONFIG points at the kit config"
-cfg="$(in_sbx 'printf "%s" "${OPENCODE_CONFIG:-}"')"
-echo "  OPENCODE_CONFIG=${cfg:-<unset>}"
-[ -n "$cfg" ] && ok "OPENCODE_CONFIG is set" || bad "OPENCODE_CONFIG is unset"
-[ "$(in_sbx "test -f \"$cfg\" && echo yes")" = "yes" ] && ok "config file present at \$OPENCODE_CONFIG" || bad "config file missing"
-[ "$(in_sbx "grep -q 'usai-provider-kit:owns-opencode-config' \"$cfg\" 2>/dev/null && echo yes")" = "yes" ] \
-  && ok "ownership marker present" || bad "ownership marker missing"
+info "3. USAi provider config landed in the global OpenCode config"
+glob="/home/agent/.config/opencode/opencode.jsonc"
+[ "$(in_sbx "test -f \"$glob\" && echo yes")" = "yes" ] \
+  && ok "global config present at $glob" || bad "global config missing at $glob"
+# The merged/copied global config must carry the USAi provider block. (In the
+# common case — no pre-existing global config — this is a verbatim copy that
+# also keeps the ownership marker; we don't require the marker here since a
+# merge into a foreign config drops comments.)
+[ "$(in_sbx "grep -q '\"usai\"' \"$glob\" 2>/dev/null && echo yes")" = "yes" ] \
+  && ok "global config contains the USAi provider" || bad "USAi provider missing from global config"
+
+info "3b. Merge preserves a pre-existing global key (does not clobber)"
+# Seed a foreign global config, then re-run the kit's merge script and confirm
+# the foreign key survives alongside the USAi provider.
+merge_check="$(in_sbx '
+  set -e
+  d="$HOME/.config/opencode"
+  mkdir -p "$d"
+  printf "%s" "{\"theme\":\"usai-verify-probe\"}" > "$d/opencode.jsonc"
+  node "$HOME/usai-config/merge-global-config.mjs" \
+    --source "$HOME/usai-config/opencode.jsonc" \
+    --global-dir "$d" >/dev/null 2>&1
+  if grep -q "usai-verify-probe" "$d/opencode.jsonc" && grep -q "\"usai\"" "$d/opencode.jsonc"; then
+    echo ok
+  fi
+')"
+[ "$merge_check" = "ok" ] \
+  && ok "foreign global key preserved and USAi merged in" \
+  || bad "merge clobbered the foreign key or dropped the USAi provider"
 
 info "4. USAi API reachable from the sandbox (uses injected key)"
 status="$(in_sbx "curl -sS -o /dev/null -w '%{http_code}' -H \"Authorization: Bearer \$USAI_API_KEY\" $USAI_MODELS_URL")"

--- a/integrations/isolation/sbx-kits/usai-provider-kit/spec.yaml
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/spec.yaml
@@ -10,16 +10,19 @@
 #
 # What it does, declaratively:
 #   - caps.network: allow egress to the USAi endpoint (default-deny networks).
-#   - environment: set OPENCODE_CONFIG so OpenCode loads the namespaced USAi
-#     config below instead of prompting for a provider on startup.
-#   - files/: drop the USAi opencode.jsonc at ~/usai-config/opencode.jsonc.
-#   - commands.startup: warn-only co-tenancy guard (see README "Co-tenancy").
+#   - files/: drop the USAi opencode.jsonc AND the merge script at
+#     ~/usai-config/ (staging area; not the path OpenCode reads).
+#   - commands.startup: merge the staged USAi config INTO OpenCode's global
+#     config path (~/.config/opencode/opencode.jsonc) without clobbering an
+#     existing global config (see README "Design: merge, don't clobber").
 #
-# Design: we deliberately do NOT write the global config path
-# (~/.config/opencode/opencode.json). Pointing OPENCODE_CONFIG at a namespaced
-# path lets this kit COMPOSE with (rather than clobber) whatever the opencode
-# template/kit writes to the global path — OpenCode merges global < custom
-# (OPENCODE_CONFIG) < project. See README.md.
+# Design: OpenCode reads config from the GLOBAL path
+# (~/.config/opencode/opencode.json[c]) < project (<workspace>/.opencode/). By
+# popular request this kit now lands its config at the GLOBAL path rather than
+# pointing OPENCODE_CONFIG at a namespaced file. To keep the old
+# "compose, don't clobber" property, a startup step MERGES the kit's config into
+# any pre-existing global config instead of overwriting it. See
+# docs/decisions/0004-global-config-merge-instead-of-opencode-config.md.
 #
 # Secret: the USAi API key is NOT in this kit. opencode.jsonc reads it from the
 # injected USAI_API_KEY env var; supply it once with
@@ -31,10 +34,10 @@ name: usai-provider
 displayName: USAi Provider (OpenCode)
 description: >
   Configures the agent to use the GSA USAi OpenAI-compatible endpoint as its
-  model provider, with egress allow-listed. Targets OpenCode today: drops a
-  namespaced opencode.jsonc and points OpenCode at it via OPENCODE_CONFIG so it
-  composes with, rather than clobbers, any global config the opencode template
-  or kit writes.
+  model provider, with egress allow-listed. Targets OpenCode today: ships a
+  USAi opencode.jsonc and merges it into OpenCode's global config path at
+  startup, composing with (rather than clobbering) any global config the
+  opencode template or another kit wrote.
 
 caps:
   network:
@@ -43,50 +46,31 @@ caps:
       # built-in sbx service, so the kit must allow-list it explicitly.
       - api.gsa.usai.gov
 
-environment:
-  variables:
-    # Absolute path — v2 spec forbids "~"; the sbx agent home is /home/agent.
-    # OpenCode loads this file between the global and project configs.
-    OPENCODE_CONFIG: /home/agent/usai-config/opencode.jsonc
-
 commands:
-  # Warn-only co-tenancy guard. OPENCODE_CONFIG is a single scalar env var;
-  # if another mixin also sets it, sbx env composition is last-wins and one
-  # kit silently shadows the other. We can't prevent that from inside a kit,
-  # but we can detect it and fail loud instead of silent: check that the file
-  # OPENCODE_CONFIG resolves to is the one we wrote (identified by the
-  # "usai-provider-kit:owns-opencode-config" marker COMMENT — OpenCode rejects
-  # unknown JSON keys, so the sentinel is a comment, not a key). If not, warn
-  # with guidance. This never blocks startup. Future config-contributing kits
-  # should instead drop a fragment at <workspace>/.opencode/opencode.jsonc,
-  # which OpenCode deep-merges over OPENCODE_CONFIG — see README "Co-tenancy".
+  # Merge the staged USAi config into OpenCode's GLOBAL config path, without
+  # clobbering an existing global config. Runs at every start as the agent user
+  # (uid 1000, which owns /home/agent). The kit's files/ payload is laid down by
+  # the base-image setup that runs BEFORE startup (same lifecycle the
+  # zscaler-ca-certificate kit relies on), so the staged source + script exist
+  # here. The merge script:
+  #   - copies the staged file verbatim (comments preserved) if no global config
+  #     exists yet; or
+  #   - deep-merges the USAi keys INTO an existing global config (USAi wins for
+  #     its own keys; unrelated keys preserved; warns on any leaf it overrides).
+  # It is idempotent: re-merging the same keys converges to the same result.
+  # A non-zero exit only happens on an unexpected error (missing/unparseable
+  # source); leaf-conflict warnings do NOT fail startup.
   startup:
-    - description: Warn if OPENCODE_CONFIG was claimed by another kit
+    - description: Merge USAi provider config into the global OpenCode config
       user: "1000"
-      # StartupCommand.command is argv ([]string), not a shell string, so we
-      # invoke a shell explicitly. The script body is the third argv element.
+      # StartupCommand.command is argv ([]string), not a shell string.
       command:
-        - sh
-        - -c
-        - |
-          cfg="${OPENCODE_CONFIG:-}"
-          ours="/home/agent/usai-config/opencode.jsonc"
-          marker="usai-provider-kit:owns-opencode-config"
-          if [ -z "$cfg" ]; then
-            echo "usai-provider: warning: OPENCODE_CONFIG is unset after kit apply; USAi provider config may not load." >&2
-            exit 0
-          fi
-          if [ ! -f "$cfg" ]; then
-            echo "usai-provider: warning: OPENCODE_CONFIG points at '$cfg', which does not exist; USAi provider config may not load." >&2
-            exit 0
-          fi
-          if ! grep -q "$marker" "$cfg" 2>/dev/null; then
-            echo "usai-provider: warning: OPENCODE_CONFIG ('$cfg') is not the USAi kit config" >&2
-            echo "  (no ownership marker). Another kit likely set OPENCODE_CONFIG and shadowed ours" >&2
-            echo "  at '$ours'. OPENCODE_CONFIG is single-valued; only one kit can own it. Have the" >&2
-            echo "  other kit contribute via <workspace>/.opencode/opencode.jsonc instead (OpenCode" >&2
-            echo "  merges it). See README 'Co-tenancy'." >&2
-          fi
+        - node
+        - /home/agent/usai-config/merge-global-config.mjs
+        - --source
+        - /home/agent/usai-config/opencode.jsonc
+        - --global-dir
+        - /home/agent/.config/opencode
 
-# files/home/usai-config/opencode.jsonc maps to
-# /home/agent/usai-config/opencode.jsonc automatically — no explicit listing.
+# files/home/usai-config/{opencode.jsonc,merge-global-config.mjs} map to
+# /home/agent/usai-config/... automatically — no explicit listing.

--- a/integrations/isolation/sbx-kits/usai-provider-kit/tests/merge-global-config.test.mjs
+++ b/integrations/isolation/sbx-kits/usai-provider-kit/tests/merge-global-config.test.mjs
@@ -1,0 +1,150 @@
+import test from "node:test"
+import assert from "node:assert/strict"
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+
+import {
+  stripJsonc,
+  parseJsonc,
+  deepMerge,
+  computeOutput,
+} from "../files/home/usai-config/merge-global-config.mjs"
+
+const execFileAsync = promisify(execFile)
+const scriptPath = fileURLToPath(
+  new URL("../files/home/usai-config/merge-global-config.mjs", import.meta.url),
+)
+const kitConfigPath = fileURLToPath(
+  new URL("../files/home/usai-config/opencode.jsonc", import.meta.url),
+)
+
+test("stripJsonc removes line and block comments but preserves URLs in strings", () => {
+  const input = `{
+    // a line comment
+    "url": "https://api.example.gov/v1", /* trailing block */
+    "n": 1, // another
+  }`
+  const parsed = JSON.parse(stripJsonc(input))
+  assert.equal(parsed.url, "https://api.example.gov/v1")
+  assert.equal(parsed.n, 1)
+})
+
+test("stripJsonc does not strip // sequences inside string values", () => {
+  const parsed = parseJsonc('{"a": "x // not a comment", "b": "/* also not */"}')
+  assert.equal(parsed.a, "x // not a comment")
+  assert.equal(parsed.b, "/* also not */")
+})
+
+test("parseJsonc parses the shipped kit config", async () => {
+  const text = await readFile(kitConfigPath, "utf8")
+  const cfg = parseJsonc(text)
+  assert.ok(cfg.provider?.usai, "provider.usai present")
+  assert.match(cfg.model, /^usai\//)
+})
+
+test("deepMerge: source wins, unrelated keys preserved, conflicts recorded", () => {
+  const base = { model: "openai/gpt-4", theme: "dark", provider: { foo: { npm: "x" } } }
+  const source = { model: "usai/claude", provider: { usai: { npm: "y" } } }
+  const conflicts = []
+  const merged = deepMerge(base, source, conflicts)
+
+  assert.equal(merged.model, "usai/claude") // source wins
+  assert.equal(merged.theme, "dark") // unrelated preserved
+  assert.equal(merged.provider.foo.npm, "x") // existing provider preserved
+  assert.equal(merged.provider.usai.npm, "y") // kit provider added
+  assert.deepEqual(conflicts, ["model"]) // only the real overwrite
+})
+
+test("deepMerge: identical leaf is not reported as a conflict", () => {
+  const conflicts = []
+  deepMerge({ model: "usai/x" }, { model: "usai/x" }, conflicts)
+  assert.deepEqual(conflicts, [])
+})
+
+test("computeOutput: no existing config copies verbatim (comments preserved)", async () => {
+  const sourceText = await readFile(kitConfigPath, "utf8")
+  const { output, merged, conflicts } = computeOutput(sourceText, [])
+  assert.equal(merged, false)
+  assert.equal(output, sourceText)
+  assert.deepEqual(conflicts, [])
+  assert.match(output, /usai-provider-kit:owns-opencode-config/)
+})
+
+test("computeOutput: existing config merges, USAi provider survives, foreign key kept", async () => {
+  const sourceText = await readFile(kitConfigPath, "utf8")
+  const existing = [
+    { path: "/g/opencode.jsonc", text: '{"theme": "gruvbox", "keybinds": {"leader": "ctrl+x"}}' },
+  ]
+  const { output, merged, conflicts } = computeOutput(sourceText, existing)
+  assert.equal(merged, true)
+  const parsed = JSON.parse(output)
+  assert.equal(parsed.theme, "gruvbox") // foreign key preserved
+  assert.equal(parsed.keybinds.leader, "ctrl+x")
+  assert.ok(parsed.provider.usai, "USAi provider merged in")
+  assert.match(parsed.model, /^usai\//)
+  assert.deepEqual(conflicts, []) // no overlapping leaves
+  // Merge branch emits JSON — comments dropped.
+  assert.doesNotMatch(output, /owns-opencode-config/)
+})
+
+test("computeOutput: conflicting top-level model is overridden and reported", async () => {
+  const sourceText = await readFile(kitConfigPath, "utf8")
+  const existing = [{ path: "/g/opencode.json", text: '{"model": "openai/gpt-4o"}' }]
+  const { output, conflicts } = computeOutput(sourceText, existing)
+  const parsed = JSON.parse(output)
+  assert.match(parsed.model, /^usai\//)
+  assert.ok(conflicts.includes("model"))
+})
+
+test("computeOutput: multiple existing files merge in precedence order", async () => {
+  const sourceText = '{"model": "usai/x"}'
+  const existing = [
+    { path: "/g/config.json", text: '{"theme": "a", "shared": "from-config"}' },
+    { path: "/g/opencode.json", text: '{"shared": "from-opencode"}' },
+  ]
+  const { output } = computeOutput(sourceText, existing)
+  const parsed = JSON.parse(output)
+  assert.equal(parsed.theme, "a")
+  assert.equal(parsed.shared, "from-opencode") // later global file wins over earlier
+  assert.equal(parsed.model, "usai/x") // kit wins overall
+})
+
+// End-to-end: run the script against a temp dir.
+test("script copies when global dir is empty", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "usai-merge-copy-"))
+  const globalDir = path.join(dir, ".config", "opencode")
+  await execFileAsync("node", [
+    scriptPath,
+    "--source",
+    kitConfigPath,
+    "--global-dir",
+    globalDir,
+  ])
+  const written = await readFile(path.join(globalDir, "opencode.jsonc"), "utf8")
+  assert.match(written, /owns-opencode-config/) // verbatim copy keeps marker
+})
+
+test("script merges when a global config already exists", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "usai-merge-merge-"))
+  const globalDir = path.join(dir, ".config", "opencode")
+  await mkdir(globalDir, { recursive: true })
+  await writeFile(path.join(globalDir, "opencode.jsonc"), '{"theme": "solarized"}')
+
+  const { stderr } = await execFileAsync("node", [
+    scriptPath,
+    "--source",
+    kitConfigPath,
+    "--global-dir",
+    globalDir,
+  ])
+  const written = await readFile(path.join(globalDir, "opencode.jsonc"), "utf8")
+  const parsed = JSON.parse(written)
+  assert.equal(parsed.theme, "solarized")
+  assert.ok(parsed.provider.usai)
+  // theme did not conflict, so no warning expected.
+  assert.doesNotMatch(stderr, /warning/)
+})


### PR DESCRIPTION
Lands the USAi kit's `opencode.jsonc` at OpenCode's global config path instead of
via `OPENCODE_CONFIG`, per user request. A startup step merges into any existing
global config rather than clobbering it (verbatim copy when none exists).

Verified: `npm test` (41 pass), `scripts/verify` against a live sbx sandbox, and
`validate_repo.py`. AI-assisted (OpenCode), reviewed by the submitter.
