### PR TITLE
chore(sbx-kits): bump playbook-kit to playbook v0.14.0

### DIFF
--- a/integrations/isolation/sbx-kits/playbook-kit/spec.yaml
+++ b/integrations/isolation/sbx-kits/playbook-kit/spec.yaml
@@ -68,8 +68,8 @@ environment:
     # cloned HEAD equals PLAYBOOK_SHA and refuses to link on mismatch. (Signed-tag
     # verification is a possible future hardening, tracked separately on the
     # playbook repo; it needs the playbook to sign its releases.)
-    PLAYBOOK_REF: "v0.12.1"
-    PLAYBOOK_SHA: "79cb496da9be67c207fff81e9019aef09f4c2866"
+    PLAYBOOK_REF: "v0.14.0"
+    PLAYBOOK_SHA: "cfadbc32b079d85c6328a20d3dadc583faa8aef1"
 
 commands:
   startup:
@@ -84,8 +84,8 @@ commands:
           # warn to stderr and exit 0 so the sandbox comes up without the
           # playbook (it self-heals on a later start once the clone can run).
           set -u
-          ref="${PLAYBOOK_REF:-v0.12.1}"
-          sha="${PLAYBOOK_SHA:-79cb496da9be67c207fff81e9019aef09f4c2866}"
+          ref="${PLAYBOOK_REF:-v0.14.0}"
+          sha="${PLAYBOOK_SHA:-cfadbc32b079d85c6328a20d3dadc583faa8aef1}"
           repo="https://github.com/GSA-TTS/agentic-coding-playbook.git"
           dir="$HOME/.agentic-coding-playbook"
 


### PR DESCRIPTION
## Summary

Bumps the pinned `agentic-coding-playbook` release used by `integrations/isolation/sbx-kits/playbook-kit` from **v0.12.1** to **v0.14.0** to incorporate recent playbook updates.

## Changes

Updated `spec.yaml` — both the `environment.variables` pins and the matching startup-command fallback defaults (kept in sync per the spec comments):

- `PLAYBOOK_REF`: `v0.12.1` → `v0.14.0`
- `PLAYBOOK_SHA`: `79cb496da9be67c207fff81e9019aef09f4c2866` → `cfadbc32b079d85c6328a20d3dadc583faa8aef1`

## Verification

- SHA verified against the remote tag:
  ```
  git ls-remote https://github.com/GSA-TTS/agentic-coding-playbook.git refs/tags/v0.14.0
  cfadbc32b079d85c6328a20d3dadc583faa8aef1  refs/tags/v0.14.0
  ```
- The startup command re-verifies the cloned `HEAD` equals `PLAYBOOK_SHA` at container start and refuses to link on mismatch (integrity pin).

## Rollback

Revert this commit (or reset the two `PLAYBOOK_REF`/`PLAYBOOK_SHA` values and the fallback defaults) back to v0.12.1 / 79cb496.

## Security Impact

Low. No change to auth, network allowlist, or linking behavior. The bump moves the pinned playbook rules/skills content to a newer, tag-and-SHA-verified release.

## AI Attribution

AI-assisted (OpenCode). Changes reviewed by the author.