### PR TITLE
docs(skills): Security Skills Pack overview + agent routing (M4 #159, #161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,37 @@ stats:
 
 **Default for new contributions:** `experimental`
 
+## Security Skills Pack
+
+A curated set of skills for **security review and secure authoring**. Every
+skill declares `categories: [security]`, which triggers extra governance: a
+required human review, a deny-by-default tool/network/write/script policy, and
+explicit `risk_tier`. Policy authority lives in the
+[playbook](https://github.com/GSA-TTS/agentic-coding-playbook) — this pack
+references it rather than restating it.
+
+- **Governance model:** [`docs/security-skill-governance.md`](docs/security-skill-governance.md)
+- **Agent routing (which skill for which trigger):** [`docs/AI-AGENT-GUIDE.md`](docs/AI-AGENT-GUIDE.md#security-skill-routing)
+- **Taxonomy:** `categories` is a closed vocabulary (see `schemas/skill.schema.json`);
+  `security` is the axis that gates this pack.
+
+| Skill | Risk | Use it for |
+|-------|------|------------|
+| [`secure-code-review`](skills/secure-code-review/) | moderate | Reviewing a code change or diff for vulnerabilities |
+| [`agentic-actions-auditor`](skills/agentic-actions-auditor/) | high | Auditing a GitHub Actions workflow for unsafe triggers/privilege |
+| [`least-privilege-review`](skills/least-privilege-review/) | moderate | Checking permissions/`GITHUB_TOKEN` scope for over-grant |
+| [`untrusted-input-boundary-review`](skills/untrusted-input-boundary-review/) | moderate | Prompt-injection / trust-boundary analysis of untrusted input |
+| [`backdoor-review`](skills/backdoor-review/) | high | Hunting for backdoors, auth bypass, hidden persistence |
+| [`dependency-analysis`](skills/dependency-analysis/) | moderate | Supply-chain / dependency vulnerability assessment |
+| [`compliance-claim-checker`](skills/compliance-claim-checker/) | low | Verifying a FedRAMP/NIST compliance claim against evidence |
+| [`incident-evidence-review`](skills/incident-evidence-review/) | high | Postmortem / incident evidence-discipline review |
+| [`safe-shell-script-author`](skills/safe-shell-script-author/) | moderate | Authoring a shell script that must pass the unsafe-shell scanner |
+
+> **Human-review gate:** security skills are `human_review_required: true`. An
+> agent may *apply* one, but promotion `experimental → recommended` and any
+> change to a security skill require human sign-off — see the
+> [human-review gates](docs/security-skill-governance.md#human-review-gates).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines.

--- a/docs/AI-AGENT-GUIDE.md
+++ b/docs/AI-AGENT-GUIDE.md
@@ -200,6 +200,41 @@ if deps['has_dependencies']:
     print(f"Requires: {deps['skills']}")
 ```
 
+## Security Skill Routing
+
+Security skills (`categories: [security]`) overlap by design, so pick by the
+**specific trigger**, not by keyword alone. Map the user's request to one skill:
+
+| The user asks… | Route to | Not |
+|----------------|----------|-----|
+| "review this PR / diff / code for vulnerabilities" | `secure-code-review` | not `backdoor-review` (that's for *deliberate* hidden malice, not general vulns) |
+| "is this GitHub Actions workflow safe?" / "audit this `.github/workflows/*`" | `agentic-actions-auditor` | not `least-privilege-review` (auditor covers triggers + privilege; LPR is scope-only) |
+| "are these permissions / `GITHUB_TOKEN` scopes too broad?" | `least-privilege-review` | not `agentic-actions-auditor` unless it's a *workflow* |
+| "could untrusted input / prompt injection cross a trust boundary here?" | `untrusted-input-boundary-review` | not `secure-code-review` (broader) |
+| "does this hide a backdoor / auth bypass / persistence?" | `backdoor-review` | not `secure-code-review` |
+| "assess these dependencies / supply-chain risk" | `dependency-analysis` | — |
+| "verify this FedRAMP/NIST compliance claim" | `compliance-claim-checker` | not `secure-code-review` |
+| "review this incident postmortem / evidence" | `incident-evidence-review` | — |
+| "write me a safe bash/cleanup script" | `safe-shell-script-author` | — (authoring, not review) |
+
+**Disambiguation rules when two seem to fit:**
+
+1. **Workflow vs. permissions:** anything about a *CI workflow file* →
+   `agentic-actions-auditor`; a *permissions block / token scope* in isolation →
+   `least-privilege-review`. The auditor already includes a least-privilege pass
+   for workflows, so don't run both on the same workflow.
+2. **General vulns vs. deliberate malice:** default to `secure-code-review`;
+   escalate to `backdoor-review` only when the ask implies *intentional* hidden
+   behavior (obfuscation, unexplained network calls, hidden auth paths).
+3. **Broad review vs. injection:** if the concern is specifically *untrusted
+   input crossing a boundary*, prefer `untrusted-input-boundary-review` over the
+   broader `secure-code-review`.
+
+**Before applying any security skill**, an agent MUST honor its governance
+frontmatter — `human_review_required: true` means the *output* is advisory and a
+human must sign off before it drives a merge/promotion decision. See
+[`security-skill-governance.md`](security-skill-governance.md).
+
 ## Understanding Output Contracts
 
 Patterns define expected outputs:


### PR DESCRIPTION
## Summary

M4 documentation for the Security Skills Pack. Docs-only, no behavior change.

Closes #159, closes #161.

## Changes

**`README.md` — Security Skills Pack section (#159)**
- What the pack is, the `categories: [security]` governance trigger, and the closed taxonomy axis
- 9-skill table with risk tier + "use it for" per skill, each linking its directory
- Human-review-gate callout linking `docs/security-skill-governance.md#human-review-gates`
- References the playbook for policy rather than restating it

**`docs/AI-AGENT-GUIDE.md` — Security Skill Routing section (#161)**
- `trigger → skill` table so an agent picks by the specific ask, not keyword overlap
- Disambiguation rules for the overlapping skills:
  - workflow file → `agentic-actions-auditor`; permissions/token scope → `least-privilege-review` (and don't run both on the same workflow)
  - general vulns → `secure-code-review`; *deliberate* hidden malice → `backdoor-review`
  - untrusted-input/injection specifically → `untrusted-input-boundary-review` over the broader `secure-code-review`
- Reminder that `human_review_required: true` makes the output advisory until a human signs off

## Validation

- `make validate` passes
- `markdownlint-cli2` clean (0 errors)
- All relative links + heading anchors resolve (`#security-skill-routing`, `#human-review-gates`, all 9 `skills/<name>/` dirs)

## Safety checklist

- [x] No secrets / PII / CUI / internal URLs
- [x] References playbook for policy; no duplicated normative content
- [x] Docs-only; no skill behavior or governance-field changes
- [x] Status of skills unchanged (no self-promotion to `recommended`)

AI-assisted (OpenCode); human review requested.
