### PR TITLE
feat(acq-kits): add environment vocabulary to hybrid/v1 schema

### DIFF
--- a/integrations/isolation/acq-kits/README.md
+++ b/integrations/isolation/acq-kits/README.md
@@ -44,6 +44,12 @@ vocabulary:
 - `commands[]` — lifecycle commands, each with a `phase` (`install` /
   `initFiles` / `startup`), `user`, and argv `command`.
 - `agentContext` — markdown surfaced to the agent.
+- `environment` — a flat map of NAME → value for **non-secret** guest
+  environment variables (e.g. `OPENCODE_CONFIG`, `GITLAB_HOST`). Names must be
+  POSIX identifiers (`[A-Za-z_][A-Za-z0-9_]*`); values are plain strings. Each
+  backend maps these onto its native env mechanism (sbx `environment.variables`;
+  msb `--env NAME=value`). **Secrets do NOT go here** — they flow through the
+  backend credential/secret path (`acq secret …`), never the kit spec.
 - `backend_shortcuts.<backend>` — a native primitive that replaces the
   declarative path for one backend (e.g. msb's `--trust-host-cas` for the
   Zscaler kit). Adapters check this first; if present, `caps`/`files`/`commands`

--- a/integrations/isolation/acq-kits/validate-kits.py
+++ b/integrations/isolation/acq-kits/validate-kits.py
@@ -7,6 +7,10 @@ JSON Schema cannot express on its own:
 
   - every files[].source resolves to an existing file under the kit dir
   - every backend_shortcuts / backend_extras key is a known backend
+  - every environment[] key is a valid POSIX env var NAME, and its value is a
+    plain string (defense-in-depth over the schema pattern: env vars reach the
+    guest environment and possibly a shell, so a bad name is reported explicitly
+    rather than only failing the schema's additionalProperties rule)
   - a README.md exists (parity note lives there)
 
 It also emits WARN-level advisories (non-fatal by default) for likely re-home
@@ -35,6 +39,12 @@ import jsonschema
 import yaml
 
 KNOWN_BACKENDS = {"sbx", "msb", "ppp"}
+
+# Env var NAME must be a POSIX-portable identifier. Env values reach the guest
+# environment and possibly a shell; the schema enforces this via patternProperties,
+# but we ALSO check it here so a bad name is reported with a clear message at the
+# gate (the maintainer of quickstart#202 wants field-level validation here).
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 # Extensions that indicate a kit-provided payload/script a command expects to
 # have been dropped by files[] (as opposed to a base-image binary, a runtime-
@@ -97,6 +107,22 @@ def validate_kit(kit_dir: Path, schema: dict) -> tuple[list[str], list[str]]:
         for backend in (spec.get(section) or {}):
             if backend not in KNOWN_BACKENDS:
                 errors.append(f"{kit_dir.name}: {section}: unknown backend '{backend}'")
+
+    environment = spec.get("environment") or {}
+    if not isinstance(environment, dict):
+        errors.append(f"{kit_dir.name}: environment must be a mapping of NAME -> value")
+    else:
+        for name, value in environment.items():
+            if not _ENV_NAME_RE.match(str(name)):
+                errors.append(
+                    f"{kit_dir.name}: environment: invalid env var name '{name}' "
+                    f"(must match [A-Za-z_][A-Za-z0-9_]*)"
+                )
+            if not isinstance(value, str):
+                errors.append(
+                    f"{kit_dir.name}: environment['{name}']: value must be a string "
+                    f"(got {type(value).__name__})"
+                )
 
     if not (kit_dir / "README.md").exists():
         errors.append(f"{kit_dir.name}: missing README.md (parity note required)")

--- a/integrations/isolation/docs/decisions/0001-neutral-hybrid-v1-acq-kits.md
+++ b/integrations/isolation/docs/decisions/0001-neutral-hybrid-v1-acq-kits.md
@@ -66,7 +66,9 @@ Adopt **Option 1**.
   2020-12) capturing the neutral fields: `caps.network.allow`, `files[]`
   (`content` or `source:` + optional `phase`), `commands[]`
   (`phase`/`user`/`command`), `agentContext`, `backend_shortcuts.<backend>`,
-  `backend_extras.<backend>`. A repo validator
+  `backend_extras.<backend>`, and `environment` (a flat NAME → value map of
+  non-secret guest env vars; added post-1.6.0 — see the amendment note below).
+  A repo validator
   (`integrations/isolation/acq-kits/validate-kits.py`) enforces schema + source
   resolution + known-backend keys + README presence + a registry cross-check.
 - **Registry** `integrations/isolation/acq-kits/kits.yaml` — kit → supported
@@ -156,6 +158,46 @@ The schema's backend enum and `KNOWN_BACKENDS` list three backends:
   sandbox (no nested sandboxes); each kit's `scripts/verify` runs on a
   sandbox-capable host. The offline gate (schema validation, the usai node
   tests, `bash -n`, unsafe-shell scan) runs everywhere.
+
+## Amendment: `environment` vocabulary (post-1.6.0)
+
+The initial `hybrid/v1` vocabulary had **no way to express guest environment
+variables**. The two sbx-v2 kits that used env (`playbook-kit`, `openchamber`)
+carried an `environment.variables` block that was dropped in the Phase-2
+conversion and re-expressed as inline `KEY=val \` prefixes on their startup
+commands — a workaround, not a first-class mechanism. A downstream team
+(quickstart#202 review) needs `environment.variables`-style config
+(`OPENCODE_CONFIG`, `OPENCODE_TUI_CONFIG`, `GITLAB_HOST`) as a first-class kit
+mechanism, which the neutral format could not express.
+
+**Decision:** add a top-level `environment` block — a **flat map** of
+`NAME → value`, both strings. Deliberately minimal (YAGNI):
+
+- Static string values only. No interpolation/templating, no references to
+  paths staged by `files[]`. None of the reference kits need more; a kit that
+  needs a computed value uses a `commands[]` step as before.
+- Env var **names** are validated against `^[A-Za-z_][A-Za-z0-9_]*$` at the
+  schema (`patternProperties` + `additionalProperties: false`) AND in
+  `validate-kits.py` (explicit field-level check with a clear message). Names
+  reach the guest environment and possibly a shell, so a bad name is rejected,
+  not silently passed.
+- **Secrets do NOT go here.** This block is plain, human-readable config. API
+  keys / tokens continue to flow through the backend credential/secret path
+  (sbx secret proxy, msb `--secret ENV@HOST`), never the kit spec.
+
+**Backend mapping** (implemented in the quickstart translate layer):
+
+- **sbx** — emit the native sbx-v2 `environment: { variables: { … } }` block
+  (the mechanism the pre-Phase-2 `playbook-kit`/`openchamber` kits used). sbx
+  sets these in the guest environment natively; no `commands` workaround needed.
+- **msb** — thread each `NAME=value` as an `msb exec -e NAME=value` on the
+  kit's lifecycle commands (msb's native per-exec env flag, already used for
+  `HOME=/home/agent`). Per-exec `-e` scopes the env to the kit's own commands
+  and mirrors how `msb.sh` already threads env.
+
+The schema addition is additive and backward-compatible (existing kits without
+`environment` are unaffected). See quickstart#202 for the translate-layer
+implementation and ADR-0011 there.
 
 ## Follow-ups (tracked, not in this change)
 

--- a/schemas/kit-hybrid-v1.schema.json
+++ b/schemas/kit-hybrid-v1.schema.json
@@ -133,6 +133,17 @@
         }
       }
     },
+    "environment": {
+      "type": "object",
+      "description": "Non-secret guest environment variables to set for the sandbox. A flat map of NAME -> value (both strings). Each backend maps these onto its native env mechanism (sbx: environment.variables; msb: create/exec --env NAME=value). SECRETS MUST NOT go here — use the backend credential/secret path instead (this block is plain, human-readable config that lands in the guest environment and may reach a shell).",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[A-Za-z_][A-Za-z0-9_]*$": {
+          "type": "string",
+          "description": "Environment variable value (a plain, non-secret string)."
+        }
+      }
+    },
     "agentContext": {
       "type": "string",
       "description": "Markdown context surfaced to the agent (written to the agent context root by each backend)."


### PR DESCRIPTION
## Summary

Adds an `environment` vocabulary to the neutral acq kit schema (`hybrid/v1`) so a kit can declare **non-secret guest environment variables** as a first-class mechanism. This closes the env-var gap raised in [quickstart#202 review comment 5004158773](https://github.com/GSA-TTS/agentic-coding-quickstart/pull/202#issuecomment-5004158773) (@basiliskus): `hybrid/v1` modeled `caps.network.allow`, `files[]`, `commands[]`, and `agentContext`, but had no way to express "set these env vars in the guest."

## Design

A new top-level `environment` block: a **flat map** of `NAME → value` (both strings).

- **Static string values only** (YAGNI): no interpolation/templating, no references to `files[]`-staged paths. None of the reference kits need more; a kit needing a computed value uses a `commands[]` step as before.
- **Env var names are validated** against `^[A-Za-z_][A-Za-z0-9_]*$`:
  - in the JSON Schema via `patternProperties` + `additionalProperties: false`, and
  - in `validate-kits.py` with an explicit field-level check and a clear message (the maintainer of #202 asked for field validation at the gate). Names reach the guest environment and possibly a shell, so a bad name is rejected, not silently passed.
- **Secrets do NOT go here.** This block is plain, human-readable config (`OPENCODE_CONFIG`, `GITLAB_HOST`, …). Secrets continue through the backend credential/secret path, never the kit spec.

Additive and backward-compatible — existing kits without `environment` are unaffected.

### Backend mapping (implemented in quickstart#202's translate layer)

- **sbx** → native sbx-v2 `environment: { variables: { … } }` (the mechanism the pre-Phase-2 `playbook-kit`/`openchamber` kits used).
- **msb** → each `NAME=value` threaded onto the kit's lifecycle commands as `msb exec -e NAME=value` (msb's native per-exec env flag).

## Changes

- `schemas/kit-hybrid-v1.schema.json` — add the `environment` object property (patternProperties string→string, `additionalProperties: false`).
- `integrations/isolation/acq-kits/validate-kits.py` — field-level env-name + value-type validation.
- `integrations/isolation/acq-kits/README.md` — document the vocabulary item.
- `integrations/isolation/docs/decisions/0001-neutral-hybrid-v1-acq-kits.md` — amendment recording the decision + backend mapping.

The four existing acq-kits are **not modified**: none currently expresses a guest env var (usai-provider merges config into the global path; the playbook kit passes its pins inline on its startup command by design). Converting those is not warranted here.

## Test plan

- `python integrations/isolation/acq-kits/validate-kits.py --root .` → all 5 acq-kits valid.
- Fixture with a bad env name (`1BAD`) is rejected by BOTH the schema and the explicit field check (verified).
- `python -m py_compile validate-kits.py`; schema parses as valid JSON + `Draft202012Validator.check_schema` passes.

## AI-assisted disclosure

This change was prepared with AI assistance (OpenCode agent) and reviewed against the actual schema/validator before commit. Requires human review before merge.
