### PR TITLE
docs(acq-kits): note env values are not shell-escaped (backends pass as argv)

### DIFF
--- a/integrations/isolation/acq-kits/validate-kits.py
+++ b/integrations/isolation/acq-kits/validate-kits.py
@@ -44,6 +44,14 @@ KNOWN_BACKENDS = {"sbx", "msb", "ppp"}
 # environment and possibly a shell; the schema enforces this via patternProperties,
 # but we ALSO check it here so a bad name is reported with a clear message at the
 # gate (the maintainer of quickstart#202 wants field-level validation here).
+#
+# NOTE: only the NAME is validated. The VALUE is intentionally NOT sanitized or
+# shell-escaped here (it may legitimately contain newlines or shell
+# metacharacters). Safety is guaranteed *downstream, by construction*: backends
+# MUST pass each value as argv / native env (msb `exec -e NAME=value`; sbx's
+# native `environment.variables` block) and MUST NOT interpolate a value into a
+# shell string. A new backend adapter must uphold this — do not assume this gate
+# sanitized the value.
 _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 # Extensions that indicate a kit-provided payload/script a command expects to

--- a/integrations/isolation/docs/decisions/0001-neutral-hybrid-v1-acq-kits.md
+++ b/integrations/isolation/docs/decisions/0001-neutral-hybrid-v1-acq-kits.md
@@ -184,6 +184,13 @@ mechanism, which the neutral format could not express.
 - **Secrets do NOT go here.** This block is plain, human-readable config. API
   keys / tokens continue to flow through the backend credential/secret path
   (sbx secret proxy, msb `--secret ENV@HOST`), never the kit spec.
+- **Env var *values* are NOT validated or shell-escaped here** — only names are.
+  A value is `type: string` and may contain newlines or shell metacharacters.
+  This is safe *by construction downstream, not by validation here*: backends
+  MUST pass each value as argv / native env (msb `exec -e NAME=value`; sbx's
+  native `environment.variables` block), and MUST NOT interpolate a value into a
+  shell string. A future backend adapter (e.g. `ppp`) must uphold this contract
+  — do not assume the gate sanitized the value.
 
 **Backend mapping** (implemented in the quickstart translate layer):
 


### PR DESCRIPTION
## Summary

Follow-up to the approving review on #227 (@wz-gsa). The `environment`
vocabulary validates the env var **name** but intentionally does not validate or
shell-escape the **value** (a value is `type: string` and may legitimately
contain newlines or shell metacharacters). Add one line to both the decision
record and `validate-kits.py` making the safety contract explicit: values are
safe **by construction downstream**, because backends MUST pass each value as
argv / native env (msb `exec -e NAME=value`; sbx's native
`environment.variables` block) and MUST NOT interpolate a value into a shell
string.

This is "cheap insurance against a future `ppp` adapter doing the wrong thing"
(reviewer's words) — so the next person wiring a backend doesn't assume the gate
sanitized the value.

## Related

- Review that requested this: #227 (pullrequestreview-4725897992)
- Translate-layer sink that upholds the contract: quickstart#202

## Changes

- `integrations/isolation/docs/decisions/0001-neutral-hybrid-v1-acq-kits.md` —
  amendment bullet under the `environment` decision.
- `integrations/isolation/acq-kits/validate-kits.py` — a comment above
  `_ENV_NAME_RE` documenting the name-only / value-downstream contract.

Docs/comment only; no behavior change.

## Test plan

- `python3 integrations/isolation/acq-kits/validate-kits.py` — 5/5 kits valid.
- `markdownlint-cli2` — 0 errors.

AI-assisted (OpenCode); human review required before merge.