### PR TITLE
fix(acq-kits): reject shell-metachar paths in kit specs (#225)

### DIFF
--- a/integrations/isolation/acq-kits/validate-kits.py
+++ b/integrations/isolation/acq-kits/validate-kits.py
@@ -54,6 +54,12 @@ KNOWN_BACKENDS = {"sbx", "msb", "ppp"}
 # sanitized the value.
 _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
+# Safe charset for a kit-dropped absolute path (#225). Adapters may interpolate
+# files[].path into a shell command, so disallow anything that could break out
+# of quoting or introduce a metacharacter — only absolute paths of
+# alphanumerics and . _ / - are permitted. Mirrors the schema's path pattern.
+_SAFE_PATH_RE = re.compile(r"^/[A-Za-z0-9._/-]+$")
+
 # Extensions that indicate a kit-provided payload/script a command expects to
 # have been dropped by files[] (as opposed to a base-image binary, a runtime-
 # generated file, or a system destination path).
@@ -110,6 +116,18 @@ def validate_kit(kit_dir: Path, schema: dict) -> tuple[list[str], list[str]]:
         src = f.get("source")
         if src and not (kit_dir / src).exists():
             errors.append(f"{kit_dir.name}: files[].source not found: {src}")
+        # Defense-in-depth over the schema's path pattern (#225): a backend
+        # adapter may interpolate files[].path into a command (e.g. the msb
+        # adapter's `chmod $mode '$path'` in a root `sh -c`). A path carrying a
+        # shell metacharacter — or a single quote that breaks out of the
+        # adapter's quoting — is a root-command-injection vector. Reject any
+        # path outside the safe charset even if the schema check were bypassed.
+        path = f.get("path")
+        if path is not None and not _SAFE_PATH_RE.match(str(path)):
+            errors.append(
+                f"{kit_dir.name}: files[].path has an unsafe character "
+                f"(allowed: absolute path, alphanumerics . _ / -): {path!r}"
+            )
 
     for section in ("backend_shortcuts", "backend_extras"):
         for backend in (spec.get(section) or {}):

--- a/schemas/kit-hybrid-v1.schema.json
+++ b/schemas/kit-hybrid-v1.schema.json
@@ -73,8 +73,8 @@
         "properties": {
           "path": {
             "type": "string",
-            "pattern": "^/",
-            "description": "Absolute path inside the sandbox."
+            "pattern": "^/[A-Za-z0-9._/-]+$",
+            "description": "Absolute path inside the sandbox. Safe charset only (alphanumerics . _ / -): kit-dropped paths must not contain shell metacharacters, since backend adapters may interpolate the path into a command (e.g. chmod). See #225."
           },
           "mode": {
             "type": "string",

--- a/scripts/tests/test_validate_kits_injection.py
+++ b/scripts/tests/test_validate_kits_injection.py
@@ -45,6 +45,7 @@ def _base(**extra) -> dict:
 
 # --- schema-level: hostile mode / user / path must not validate ---------------
 
+
 @pytest.mark.parametrize(
     "instance, why",
     [
@@ -67,6 +68,7 @@ def test_schema_accepts_valid_file_entry():
 
 # --- validate_kit defense-in-depth: unsafe path is reported even if reached ---
 
+
 def test_validate_kit_flags_unsafe_path(tmp_path):
     validate_kit = _load_validate_kit()
     kit = tmp_path / "evilkit"
@@ -79,8 +81,8 @@ def test_validate_kit_flags_unsafe_path(tmp_path):
         "displayName: Evil\n"
         "description: d\n"
         "files:\n"
-        "  - path: \"/home/agent/x'; id #\"\n"
-        "    mode: \"0644\"\n"
+        '  - path: "/home/agent/x\'; id #"\n'
+        '    mode: "0644"\n'
         "    source: files/x\n"
     )
     errors, _warnings = validate_kit(kit, _load_schema())

--- a/scripts/tests/test_validate_kits_injection.py
+++ b/scripts/tests/test_validate_kits_injection.py
@@ -1,0 +1,87 @@
+"""Regression tests for the acq-kits validator's injection guards (#225).
+
+The neutral hybrid/v1 kit spec's files[].path / files[].mode / commands[].user
+flow into backend adapters that may interpolate them into a (root) shell — so a
+hostile or typo'd value is a command-injection vector. The schema patterns +
+validate_kit's defense-in-depth path check must REJECT such values at the gate.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "schemas" / "kit-hybrid-v1.schema.json"
+VALIDATOR_PATH = ROOT / "integrations" / "isolation" / "acq-kits" / "validate-kits.py"
+
+
+def _load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def _load_validate_kit():
+    spec = importlib.util.spec_from_file_location("validate_kits", VALIDATOR_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.validate_kit
+
+
+def _base(**extra) -> dict:
+    d = {
+        "schemaVersion": "hybrid/v1",
+        "kind": "mixin",
+        "name": "t",
+        "displayName": "T",
+        "description": "d",
+    }
+    d.update(extra)
+    return d
+
+
+# --- schema-level: hostile mode / user / path must not validate ---------------
+
+@pytest.mark.parametrize(
+    "instance, why",
+    [
+        (_base(files=[{"path": "/home/agent/x", "mode": "0644; id", "source": "files/x"}]), "mode injection"),
+        (_base(commands=[{"phase": "startup", "user": "0; id", "command": ["sh"]}]), "user injection"),
+        (_base(files=[{"path": "/home/agent/x'; id #", "mode": "0644", "source": "files/x"}]), "quote in path"),
+        (_base(files=[{"path": "/home/agent/$(id)", "mode": "0644", "source": "files/x"}]), "cmd-subst in path"),
+        (_base(files=[{"path": "/home/agent/x y", "mode": "0644", "source": "files/x"}]), "space in path"),
+    ],
+)
+def test_schema_rejects_injection_shaped_values(instance, why):
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=instance, schema=_load_schema())
+
+
+def test_schema_accepts_valid_file_entry():
+    inst = _base(files=[{"path": "/home/agent/x.sh", "mode": "0755", "source": "files/x"}])
+    jsonschema.validate(instance=inst, schema=_load_schema())  # must not raise
+
+
+# --- validate_kit defense-in-depth: unsafe path is reported even if reached ---
+
+def test_validate_kit_flags_unsafe_path(tmp_path):
+    validate_kit = _load_validate_kit()
+    kit = tmp_path / "evilkit"
+    kit.mkdir()
+    (kit / "README.md").write_text("# evil\n")
+    (kit / "spec.yaml").write_text(
+        "schemaVersion: hybrid/v1\n"
+        "kind: mixin\n"
+        "name: evilkit\n"
+        "displayName: Evil\n"
+        "description: d\n"
+        "files:\n"
+        "  - path: \"/home/agent/x'; id #\"\n"
+        "    mode: \"0644\"\n"
+        "    source: files/x\n"
+    )
+    errors, _warnings = validate_kit(kit, _load_schema())
+    assert any("unsafe character" in e or "does not match" in e for e in errors), errors


### PR DESCRIPTION
## Summary

Closes #225. Fixes the remaining root-command-injection vector in neutral hybrid/v1 kit specs: an unvalidated `files[].path` with a shell metacharacter flows into a backend adapter that interpolates it into a root `sh -c`.

## What was actually vulnerable (narrowed from the issue)

Investigating #225, `files[].mode` and `commands[].user` turned out to be **already gated** by their schema patterns (`^0[0-7]{3}$` and `^[0-9]+$`), and `validate-kits.py` applies the schema — so `mode: "0644; id"` / `user: "0; id"` already fail the gate. Verified.

The **real remaining hole is `files[].path`**: the schema only required `^/` (absolute), so these validated cleanly:
- `/home/agent/x'; id #`  ← the single quote breaks out of the msb adapter's `chmod $mode '$path'`
- `/home/agent/$(id)`

The msb adapter (quickstart) runs `msb exec … -u 0 -- sh -c "chmod $mode '$path'"`, so a `'`-bearing path is a root command injection from a data file (guest-scoped, but unauthenticated root RCE).

## Fix

- **schema:** tighten `files[].path` pattern `^/` → `^/[A-Za-z0-9._/-]+$` (safe charset; kit-dropped paths never need shell metacharacters).
- **validate-kits.py:** defense-in-depth `_SAFE_PATH_RE` check on `files[].path` — the gate reports an unsafe path with a clear message even if the schema check were bypassed.
- **tests:** `scripts/tests/test_validate_kits_injection.py` — schema rejects hostile `mode`/`user`/`path` (quote, cmd-subst, space), accepts a valid entry, and `validate_kit` reports the unsafe path.

## Validation

- 7 new tests pass; full patterns suite **177 passed**.
- All 5 real acq-kits still validate clean (`--strict`).

## Companion

The msb adapter should also stop interpolating `mode`/`path` into `sh -c` defensively — tracked on the quickstart side. This PR closes the shared-gate half (protects every backend).

AI-assisted (OpenCode). Security-hardening of an existing gate.
