### PR TITLE
feat(schema): add collection + routing taxonomy foundation (#238)

### DIFF
--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -3,152 +3,6 @@ repo: GSA-TTS/agentic-coding-patterns
 description: Community patterns for agentic coding
 patterns:
   skills:
-  - path: skills/compliance-claim-checker/SKILL.md
-    id: compliance-claim-checker
-    title: Compliance Claim Checker
-    type: skill
-    status: experimental
-    categories:
-    - security
-    - compliance
-    - documentation
-  - path: skills/documentation-review/SKILL.md
-    id: documentation-review
-    title: Documentation Review
-    type: skill
-    status: experimental
-    categories:
-    - documentation
-    - review
-  - path: skills/least-privilege-review/SKILL.md
-    id: least-privilege-review
-    title: Least Privilege Review
-    type: skill
-    status: experimental
-    categories:
-    - security
-    - review
-  - path: skills/untrusted-input-boundary-review/SKILL.md
-    id: untrusted-input-boundary-review
-    title: Untrusted Input Boundary Review
-    type: skill
-    status: experimental
-    categories:
-    - security
-    - review
-  - path: skills/over-engineering-review/SKILL.md
-    id: over-engineering-review
-    title: Over-Engineering Review
-    type: skill
-    status: experimental
-    categories:
-    - review
-    - development
-  - path: skills/dependency-analysis/SKILL.md
-    id: dependency-analysis
-    title: Dependency Security Analysis
-    type: skill
-    status: experimental
-    categories:
-    - security
-    - dependencies
-    - supply-chain
-  - path: skills/safe-shell-script-author/SKILL.md
-    id: safe-shell-script-author
-    title: Safe Shell Script Author
-    type: skill
-    status: experimental
-    categories:
-    - security
-    - development
-  - path: skills/incident-evidence-review/SKILL.md
-    id: incident-evidence-review
-    title: Incident Evidence Review
-    type: skill
-    status: experimental
-    categories:
-    - security
-    - incident-response
-    - review
-  - path: skills/agentic-actions-auditor/SKILL.md
-    id: agentic-actions-auditor
-    title: Agentic Actions Auditor
-    type: skill
-    status: experimental
-    categories:
-    - security
-    - review
-    - supply-chain
-  - path: skills/backdoor-review/SKILL.md
-    id: backdoor-review
-    title: Backdoor Review
-    type: skill
-    status: experimental
-    categories:
-    - security
-    - review
-  - path: skills/test-generation/SKILL.md
-    id: test-generation
-    title: Test Case Generation
-    type: skill
-    status: experimental
-    categories:
-    - testing
-  - path: skills/secure-code-review/SKILL.md
-    id: secure-code-review
-    title: Secure Code Review
-    type: skill
-    status: experimental
-    categories:
-    - security
-    - review
-  - path: skills/outreach/explainer-video/SKILL.md
-    id: explainer-video
-    title: Explainer Video (HTML to MP4)
-    type: skill
-    status: experimental
-    categories:
-    - documentation
-    - supply-chain
-  - path: skills/outreach/explainer-gif/SKILL.md
-    id: explainer-gif
-    title: Explainer GIF (Terminal Screencast)
-    type: skill
-    status: experimental
-    categories:
-    - documentation
-  - path: skills/frontend/uswds-prototype/SKILL.md
-    id: uswds-prototype
-    title: USWDS Front-End Prototype
-    type: skill
-    status: experimental
-    categories:
-    - frontend
-  - path: skills/frontend/uswds-landing-page/SKILL.md
-    id: uswds-landing-page
-    title: USWDS Service Landing Page
-    type: skill
-    status: experimental
-    categories:
-    - frontend
-  - path: skills/frontend/plain-language-review/SKILL.md
-    id: plain-language-review
-    title: Federal Plain Language Review
-    type: skill
-    status: experimental
-    categories:
-    - frontend
-    - documentation
-    - review
-  - path: skills/frontend/federal-service-blueprint/SKILL.md
-    id: federal-service-blueprint
-    title: Federal Service Blueprint
-    type: skill
-    status: experimental
-    categories:
-    - frontend
-    - compliance
-    - documentation
   - path: skills/frontend/accessibility-review/SKILL.md
     id: accessibility-review
     title: Federal Accessibility Review
@@ -158,6 +12,172 @@ patterns:
     - frontend
     - review
     - compliance
+    collection: null
+    routing: {}
+  - path: skills/agentic-actions-auditor/SKILL.md
+    id: agentic-actions-auditor
+    title: Agentic Actions Auditor
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - review
+    - supply-chain
+    collection: null
+    routing: {}
+  - path: skills/backdoor-review/SKILL.md
+    id: backdoor-review
+    title: Backdoor Review
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - review
+    collection: null
+    routing: {}
+  - path: skills/compliance-claim-checker/SKILL.md
+    id: compliance-claim-checker
+    title: Compliance Claim Checker
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - compliance
+    - documentation
+    collection: null
+    routing: {}
+  - path: skills/dependency-analysis/SKILL.md
+    id: dependency-analysis
+    title: Dependency Security Analysis
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - dependencies
+    - supply-chain
+    collection: null
+    routing: {}
+  - path: skills/documentation-review/SKILL.md
+    id: documentation-review
+    title: Documentation Review
+    type: skill
+    status: experimental
+    categories:
+    - documentation
+    - review
+    collection: null
+    routing: {}
+  - path: skills/outreach/explainer-gif/SKILL.md
+    id: explainer-gif
+    title: Explainer GIF (Terminal Screencast)
+    type: skill
+    status: experimental
+    categories:
+    - documentation
+    collection: null
+    routing: {}
+  - path: skills/outreach/explainer-video/SKILL.md
+    id: explainer-video
+    title: Explainer Video (HTML to MP4)
+    type: skill
+    status: experimental
+    categories:
+    - documentation
+    - supply-chain
+    collection: null
+    routing: {}
+  - path: skills/frontend/federal-service-blueprint/SKILL.md
+    id: federal-service-blueprint
+    title: Federal Service Blueprint
+    type: skill
+    status: experimental
+    categories:
+    - frontend
+    - compliance
+    - documentation
+    collection: null
+    routing: {}
+  - path: skills/incident-evidence-review/SKILL.md
+    id: incident-evidence-review
+    title: Incident Evidence Review
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - incident-response
+    - review
+    collection: null
+    routing: {}
+  - path: skills/least-privilege-review/SKILL.md
+    id: least-privilege-review
+    title: Least Privilege Review
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - review
+    collection: null
+    routing: {}
+  - path: skills/over-engineering-review/SKILL.md
+    id: over-engineering-review
+    title: Over-Engineering Review
+    type: skill
+    status: experimental
+    categories:
+    - review
+    - development
+    collection: null
+    routing: {}
+  - path: skills/frontend/plain-language-review/SKILL.md
+    id: plain-language-review
+    title: Federal Plain Language Review
+    type: skill
+    status: experimental
+    categories:
+    - frontend
+    - documentation
+    - review
+    collection: null
+    routing: {}
+  - path: skills/safe-shell-script-author/SKILL.md
+    id: safe-shell-script-author
+    title: Safe Shell Script Author
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - development
+    collection: null
+    routing: {}
+  - path: skills/secure-code-review/SKILL.md
+    id: secure-code-review
+    title: Secure Code Review
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - review
+    collection: null
+    routing: {}
+  - path: skills/test-generation/SKILL.md
+    id: test-generation
+    title: Test Case Generation
+    type: skill
+    status: experimental
+    categories:
+    - testing
+    collection: null
+    routing: {}
+  - path: skills/untrusted-input-boundary-review/SKILL.md
+    id: untrusted-input-boundary-review
+    title: Untrusted Input Boundary Review
+    type: skill
+    status: experimental
+    categories:
+    - security
+    - review
+    collection: null
+    routing: {}
   - path: skills/frontend/uswds-form-flow/SKILL.md
     id: uswds-form-flow
     title: USWDS Accessible Form Flow
@@ -166,7 +186,36 @@ patterns:
     categories:
     - frontend
     - compliance
+    collection: null
+    routing: {}
+  - path: skills/frontend/uswds-landing-page/SKILL.md
+    id: uswds-landing-page
+    title: USWDS Service Landing Page
+    type: skill
+    status: experimental
+    categories:
+    - frontend
+    collection: null
+    routing: {}
+  - path: skills/frontend/uswds-prototype/SKILL.md
+    id: uswds-prototype
+    title: USWDS Front-End Prototype
+    type: skill
+    status: experimental
+    categories:
+    - frontend
+    collection: null
+    routing: {}
   prompts:
+  - path: prompts/planning/implementation-plan/SKILL.md
+    id: implementation-plan
+    title: Implementation Plan Generator
+    type: prompt
+    status: experimental
+    categories:
+    - development
+    collection: null
+    routing: {}
   - path: prompts/review/qa-round/SKILL.md
     id: qa-round
     title: QA Round Review
@@ -175,13 +224,8 @@ patterns:
     categories:
     - testing
     - review
-  - path: prompts/planning/implementation-plan/SKILL.md
-    id: implementation-plan
-    title: Implementation Plan Generator
-    type: prompt
-    status: experimental
-    categories:
-    - development
+    collection: null
+    routing: {}
   - path: prompts/security/safe-code-review/SKILL.md
     id: safe-code-review
     title: Security-Focused Code Review
@@ -190,6 +234,8 @@ patterns:
     categories:
     - security
     - review
+    collection: null
+    routing: {}
   agents:
   - path: agents/documentation/AGENTS.md
     id: documentation-agent
@@ -198,6 +244,8 @@ patterns:
     status: experimental
     categories:
     - documentation
+    collection: null
+    routing: {}
   - path: agents/general/AGENTS.md
     id: general-agent
     title: General Agent Instructions
@@ -205,6 +253,8 @@ patterns:
     status: experimental
     categories:
     - development
+    collection: null
+    routing: {}
   - path: agents/security-review/AGENTS.md
     id: security-review-agent
     title: Security Review Agent Instructions
@@ -213,6 +263,8 @@ patterns:
     categories:
     - security
     - review
+    collection: null
+    routing: {}
   workflows:
   - path: workflows/issue-to-merge-request/SKILL.md
     id: issue-to-merge-request
@@ -223,6 +275,8 @@ patterns:
     - development
     - review
     - testing
+    collection: null
+    routing: {}
   - path: workflows/qa-round/SKILL.md
     id: qa-workflow
     title: QA Round Workflow
@@ -231,6 +285,8 @@ patterns:
     categories:
     - testing
     - review
+    collection: null
+    routing: {}
   - path: workflows/security-scan-review/SKILL.md
     id: security-scan-review
     title: Language-Aware Security Scan & Triage Workflow
@@ -239,6 +295,8 @@ patterns:
     categories:
     - security
     - review
+    collection: null
+    routing: {}
   lessons:
   - path: lessons-learned/example-agentic-session/SKILL.md
     id: example-agentic-session
@@ -248,6 +306,8 @@ patterns:
     categories:
     - security
     - documentation
+    collection: null
+    routing: {}
 categories:
   security:
   - agentic-actions-auditor
@@ -320,6 +380,9 @@ categories:
   - uswds-form-flow
   - uswds-landing-page
   - uswds-prototype
+collections: {}
+task_types: {}
+output_artifacts: {}
 stats:
   total_patterns: 30
   skills: 20

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -185,6 +185,82 @@
       "minItems": 1,
       "uniqueItems": true
     },
+    "collection": {
+      "type": "string",
+      "description": "Primary human-navigation home for the pattern (organizational, not the security taxonomy axis). Closed controlled vocabulary; see schemas/taxonomy.yaml.",
+      "enum": [
+        "meta",
+        "engineering",
+        "security",
+        "content",
+        "digital-service",
+        "communications"
+      ]
+    },
+    "routing": {
+      "type": "object",
+      "description": "Machine-routing facets used by the pattern-router (#237). Values in task_types / input_artifacts / output_artifacts are cross-checked against schemas/taxonomy.yaml by the validator.",
+      "additionalProperties": false,
+      "properties": {
+        "task_types": {
+          "type": "array",
+          "description": "Controlled task verbs this pattern performs (see taxonomy.yaml task_types).",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        },
+        "input_artifacts": {
+          "type": "array",
+          "description": "Controlled artifact slugs this pattern consumes (see taxonomy.yaml artifact_types).",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        },
+        "output_artifacts": {
+          "type": "array",
+          "description": "Controlled artifact slugs this pattern produces (see taxonomy.yaml artifact_types).",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        },
+        "prefer_when": {
+          "type": "array",
+          "description": "Natural-language conditions under which this pattern is the right choice.",
+          "items": {"type": "string"}
+        },
+        "avoid_when": {
+          "type": "array",
+          "description": "Natural-language conditions under which this pattern must NOT be selected (hard exclusion in scoring).",
+          "items": {"type": "string"}
+        },
+        "delegates": {
+          "type": "array",
+          "description": "Patterns that own a more specific lane; the router should prefer the delegate when its condition holds.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["pattern", "when"],
+            "properties": {
+              "pattern": {
+                "type": "string",
+                "description": "Target pattern id (kebab-case).",
+                "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+              },
+              "when": {"type": "string"}
+            }
+          }
+        },
+        "aliases": {
+          "type": "array",
+          "description": "Alternative phrasings a request may use for this pattern.",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        },
+        "priority": {
+          "type": "integer",
+          "description": "Tie-break precedence; higher wins. Default 50.",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    },
     "risk_tier": {
       "type": "string",
       "description": "Risk tier of the skill's actions (security-governance field; required for security skills via validator).",

--- a/schemas/taxonomy.yaml
+++ b/schemas/taxonomy.yaml
@@ -1,0 +1,134 @@
+# Routing taxonomy — controlled vocabularies for the pattern-router (#237, PR1 #238).
+#
+# WHY a separate file (not baked into skill.schema.json): task_types and
+# artifact_types will grow as the catalog grows. Keeping them here lets the
+# vocabulary evolve via a small data PR without editing the JSON Schema on every
+# addition. The frontmatter validator cross-checks `routing.task_types`,
+# `routing.input_artifacts`, and `routing.output_artifacts` against these lists
+# and REJECTS unknown values (closes the classifier-injection path where an
+# unknown facet could dodge avoid/delegated scoring penalties).
+#
+# `collection` is intentionally NOT here — it is a small, stable enum owned by
+# skill.schema.json. This file owns only the two open-growth vocabularies.
+#
+# Governance: additions require a PR that updates this file plus at least one
+# consuming pattern or router test; new terms start documented here before use.
+
+schema_version: "1.0"
+
+# Controlled task verbs. Small on purpose — prefer reusing a verb over adding one.
+task_types:
+  discover:
+    description: Find or gather information / prior art / candidates.
+    aliases: [research, find, gather, survey]
+  plan:
+    description: Produce a plan, decomposition, or sequence of steps.
+    aliases: [design, decompose, scope]
+  author:
+    description: Create new prose, code, or a first-draft artifact.
+    aliases: [write, create, draft, generate]
+  transform:
+    description: Convert or restructure an existing artifact into another form.
+    aliases: [convert, refactor, migrate, reformat]
+  analyze:
+    description: Inspect and reason about an artifact without changing it.
+    aliases: [assess, evaluate, inspect, examine]
+  review:
+    description: Judge an artifact against criteria and report findings.
+    aliases: [audit, critique, check]
+  test:
+    description: Exercise behavior and assert correctness.
+    aliases: [verify, validate, qa]
+  visualize:
+    description: Design the visual/narrative structure of an artifact.
+    aliases: [storyboard, layout, compose]
+  render:
+    description: Produce a concrete file/output from a design or source.
+    aliases: [build, export, compile]
+  orchestrate:
+    description: Coordinate multiple patterns/stages toward an outcome.
+    aliases: [coordinate, pipeline, workflow]
+
+# Controlled artifact slugs — inputs a pattern consumes and outputs it produces.
+# Grouped by rough domain for human readability; the flat slug is the key.
+artifact_types:
+  # code / engineering
+  source-code:
+    description: Application or library source files.
+    aliases: [code, source]
+  pull-request-diff:
+    description: A unified diff / PR under review.
+    aliases: [diff, pr, changeset]
+  shell-script:
+    description: A shell script (bash/sh/zsh).
+    aliases: [bash-script, sh]
+  ci-workflow:
+    description: A CI/CD workflow definition (e.g. GitHub Actions).
+    aliases: [github-actions, pipeline-config, workflow-file]
+  infrastructure-as-code:
+    description: IaC definitions (Terraform, Helm, etc.).
+    aliases: [iac, terraform, helm]
+  dependency-manifest:
+    description: A package/dependency manifest or lockfile.
+    aliases: [package-manifest, lockfile, sbom-input]
+  # docs / content
+  documentation:
+    description: Developer or user documentation.
+    aliases: [docs, readme]
+  compliance-claim:
+    description: A stated compliance/control assertion to verify.
+    aliases: [control-claim]
+  incident-evidence:
+    description: Logs/artifacts gathered during incident response.
+    aliases: [incident-artifact]
+  # digital service / frontend
+  web-page:
+    description: A generic web page.
+    aliases: [page, html-page]
+  web-prototype:
+    description: An interactive web prototype.
+    aliases: [prototype]
+  landing-page:
+    description: A marketing/landing page.
+    aliases: []
+  form:
+    description: A (multi-step) form flow.
+    aliases: [form-flow]
+  service-blueprint:
+    description: A federal service design blueprint.
+    aliases: [blueprint]
+  # communications / design artifacts
+  artifact-brief:
+    description: Audience/action/message/evidence/constraints brief for a design artifact.
+    aliases: [brief]
+  storyboard:
+    description: An ordered visual/narrative plan.
+    aliases: []
+  diagram:
+    description: A technical diagram.
+    aliases: [technical-diagram]
+  one-pager:
+    description: A single-page executive summary artifact.
+    aliases: []
+  slide-deck:
+    description: A presentation deck.
+    aliases: [deck, slides]
+  marketing-asset:
+    description: A marketing/outreach asset.
+    aliases: [marketing-kit]
+  terminal-demo:
+    description: A recorded terminal demo.
+    aliases: []
+  explainer-video:
+    description: A rendered explainer video.
+    aliases: [promo-video, animated-overview]
+  explainer-gif:
+    description: A rendered explainer GIF.
+    aliases: []
+  # review / QA outputs
+  security-review:
+    description: A security review report.
+    aliases: [security-report]
+  qa-report:
+    description: A QA assessment report.
+    aliases: [qa-assessment]

--- a/scripts/generate_index.py
+++ b/scripts/generate_index.py
@@ -28,6 +28,25 @@ def extract_frontmatter(content: str) -> dict | None:
         return None
 
 
+def _index_routing(routing: dict | None) -> dict:
+    """Project the routing block into the compact facets kept in INDEX.yaml.
+
+    Only the shortlist facets are surfaced (task/input/output artifacts +
+    aliases); the full prefer_when/avoid_when/delegates prose stays in the
+    SKILL.md source of truth. Returns {} when the pattern has no routing block.
+    """
+    if not isinstance(routing, dict):
+        return {}
+    projected = {}
+    for facet in ("task_types", "input_artifacts", "output_artifacts", "aliases"):
+        values = routing.get(facet)
+        if values:
+            projected[facet] = sorted(values) if isinstance(values, list) else values
+    if "priority" in routing:
+        projected["priority"] = routing["priority"]
+    return projected
+
+
 def find_patterns(root: Path) -> dict[str, list[dict]]:
     """Find all patterns organized by type."""
     patterns = {
@@ -66,6 +85,8 @@ def find_patterns(root: Path) -> dict[str, list[dict]]:
                         "type": frontmatter.get("type", pattern_type),
                         "status": frontmatter.get("status", "experimental"),
                         "categories": frontmatter.get("categories", []),
+                        "collection": frontmatter.get("collection"),
+                        "routing": _index_routing(frontmatter.get("routing")),
                     }
                 )
 
@@ -85,8 +106,17 @@ def find_patterns(root: Path) -> dict[str, list[dict]]:
                             "type": "agent",
                             "status": frontmatter.get("status", "experimental"),
                             "categories": frontmatter.get("categories", []),
+                            "collection": frontmatter.get("collection"),
+                            "routing": _index_routing(frontmatter.get("routing")),
                         }
                     )
+
+    # Deterministic ordering (#243): rglob order is filesystem-dependent, so sort
+    # every pattern list by id (fallback path) before serialization. Without this
+    # INDEX.yaml diffs are unstable across machines and `--check` can spuriously
+    # fail after a rename or on a different OS.
+    for pattern_type in patterns:
+        patterns[pattern_type].sort(key=lambda p: (p.get("id", ""), p.get("path", "")))
 
     return patterns
 
@@ -124,6 +154,36 @@ def facet_by_category(patterns: dict[str, list[dict]]) -> dict[str, list[str]]:
     return facets
 
 
+def facet_by_collection(patterns: dict[str, list[dict]]) -> dict[str, list[str]]:
+    """Build a collection -> [pattern id] reverse facet (#238).
+
+    Only collections that are actually used appear (unlike the closed category
+    vocab); empty because no pattern carries `collection` until PR3 (#240).
+    """
+    facets: dict[str, list[str]] = {}
+    for items in patterns.values():
+        for item in items:
+            coll = item.get("collection")
+            if coll:
+                facets.setdefault(coll, []).append(item["id"])
+    return {k: sorted(v) for k, v in sorted(facets.items())}
+
+
+def facet_by_routing(patterns: dict[str, list[dict]], key: str) -> dict[str, list[str]]:
+    """Build a routing-facet-value -> [pattern id] reverse facet (#238).
+
+    `key` is one of task_types / input_artifacts / output_artifacts. Empty until
+    patterns carry routing blocks (PR3 #240).
+    """
+    facets: dict[str, list[str]] = {}
+    for items in patterns.values():
+        for item in items:
+            routing = item.get("routing") or {}
+            for value in routing.get(key, []) or []:
+                facets.setdefault(value, []).append(item["id"])
+    return {k: sorted(v) for k, v in sorted(facets.items())}
+
+
 def generate_index(root: Path) -> dict:
     """Generate the INDEX.yaml structure."""
     patterns = find_patterns(root)
@@ -137,6 +197,9 @@ def generate_index(root: Path) -> dict:
         "description": "Community patterns for agentic coding",
         "patterns": patterns,
         "categories": facet_by_category(patterns),
+        "collections": facet_by_collection(patterns),
+        "task_types": facet_by_routing(patterns, "task_types"),
+        "output_artifacts": facet_by_routing(patterns, "output_artifacts"),
         "stats": {
             "total_patterns": total,
             "skills": len(patterns["skills"]),

--- a/scripts/search_patterns.py
+++ b/scripts/search_patterns.py
@@ -63,10 +63,36 @@ def matches_filters(
     persona: str | None,
     tool: str | None,
     query: str | None,
+    collection: str | None = None,
+    ptype: str | None = None,
+    task: str | None = None,
+    input_artifact: str | None = None,
+    output_artifact: str | None = None,
 ) -> bool:
     """Check if pattern matches all filter criteria."""
     # Status filter
     if status and pattern.get("status") != status:
+        return False
+
+    # Collection filter (#238) — read from enriched INDEX, no file reopen needed.
+    if collection and (details.get("collection") or pattern.get("collection")) != collection:
+        return False
+
+    # Pattern-type filter (#238).
+    if ptype and pattern.get("type") != ptype:
+        return False
+
+    # Routing-facet filters (#238). Prefer details (source of truth), fall back
+    # to the INDEX projection.
+    def _routing_values(facet: str) -> list:
+        r = details.get("routing") or pattern.get("routing") or {}
+        return r.get(facet, []) or []
+
+    if task and task not in _routing_values("task_types"):
+        return False
+    if input_artifact and input_artifact not in _routing_values("input_artifacts"):
+        return False
+    if output_artifact and output_artifact not in _routing_values("output_artifacts"):
         return False
 
     # Tag filter
@@ -178,6 +204,11 @@ def search_patterns(
     tool: str | None,
     query: str | None,
     output_json: bool,
+    collection: str | None = None,
+    ptype: str | None = None,
+    task: str | None = None,
+    input_artifact: str | None = None,
+    output_artifact: str | None = None,
 ) -> int:
     """Search patterns and print results. Returns exit code."""
     all_patterns = []
@@ -192,7 +223,20 @@ def search_patterns(
     matching = []
     for pattern in all_patterns:
         details = load_pattern_details(repo_root, pattern.get("path", ""))
-        if matches_filters(pattern, details, tag, status, persona, tool, query):
+        if matches_filters(
+            pattern,
+            details,
+            tag,
+            status,
+            persona,
+            tool,
+            query,
+            collection,
+            ptype,
+            task,
+            input_artifact,
+            output_artifact,
+        ):
             matching.append((pattern, details))
 
     # Output results
@@ -238,6 +282,13 @@ Examples:
   # Keyword search
   %(prog)s --query "code review"
 
+  # Faceted routing filters (#238)
+  %(prog)s --collection communications
+  %(prog)s --task review
+  %(prog)s --input ci-workflow
+  %(prog)s --output slide-deck
+  %(prog)s --type workflow
+
   # Combined filters
   %(prog)s --tag security --status experimental --tool cursor
 
@@ -268,6 +319,31 @@ Examples:
         help="Keyword search in titles and descriptions",
     )
     parser.add_argument(
+        "--collection",
+        choices=["meta", "engineering", "security", "content", "digital-service", "communications"],
+        help="Filter by collection (#238)",
+    )
+    parser.add_argument(
+        "--type",
+        dest="ptype",
+        choices=["skill", "prompt", "workflow", "agent", "lesson"],
+        help="Filter by pattern type (#238)",
+    )
+    parser.add_argument(
+        "--task",
+        help="Filter by routing task type (e.g., review, author) (#238)",
+    )
+    parser.add_argument(
+        "--input",
+        dest="input_artifact",
+        help="Filter by routing input artifact (e.g., ci-workflow) (#238)",
+    )
+    parser.add_argument(
+        "--output",
+        dest="output_artifact",
+        help="Filter by routing output artifact (e.g., slide-deck) (#238)",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Output results in JSON format",
@@ -291,6 +367,11 @@ Examples:
         args.tool,
         args.query,
         args.json,
+        args.collection,
+        args.ptype,
+        args.task,
+        args.input_artifact,
+        args.output_artifact,
     )
 
     sys.exit(exit_code)

--- a/scripts/tests/test_generate_index.py
+++ b/scripts/tests/test_generate_index.py
@@ -179,3 +179,56 @@ class TestCategoryFacet:
         assert "test-skill" in index["categories"]["security"]
         assert "test-skill" in index["categories"]["review"]
         assert index["categories"]["frontend"] == []
+
+
+class TestDeterminism:
+    """#243: INDEX generation must be deterministic (rglob order is FS-dependent)."""
+
+    def test_generation_is_idempotent(self, temp_repo):
+        import yaml
+
+        first = yaml.dump(generate_index(temp_repo), sort_keys=False, allow_unicode=True)
+        second = yaml.dump(generate_index(temp_repo), sort_keys=False, allow_unicode=True)
+        assert first == second
+
+    def test_pattern_lists_sorted_by_id(self, tmp_path):
+        # Two skills whose FS discovery order is not guaranteed; assert sorted by id.
+        for sid in ("zzz-skill", "aaa-skill"):
+            d = tmp_path / "skills" / sid
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(f"---\nid: {sid}\ntitle: {sid}\ntype: skill\nstatus: experimental\n---\n")
+        index = generate_index(tmp_path)
+        ids = [p["id"] for p in index["patterns"]["skills"]]
+        assert ids == sorted(ids)
+
+
+class TestRoutingFacets:
+    """#238: collection + routing reverse facets."""
+
+    def test_reverse_facets_present_and_empty_when_unused(self, temp_repo):
+        index = generate_index(temp_repo)
+        # New top-level facets exist; empty because temp patterns carry no routing.
+        assert index["collections"] == {}
+        assert index["task_types"] == {}
+        assert index["output_artifacts"] == {}
+
+    def test_collection_and_routing_surface_into_facets(self, tmp_path):
+        d = tmp_path / "skills" / "demo"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            "---\n"
+            "id: demo\ntitle: Demo\ntype: skill\nstatus: experimental\n"
+            "collection: security\n"
+            "routing:\n"
+            "  task_types: [review]\n"
+            "  output_artifacts: [security-review]\n"
+            "---\n"
+        )
+        index = generate_index(tmp_path)
+        assert index["collections"]["security"] == ["demo"]
+        assert index["task_types"]["review"] == ["demo"]
+        assert index["output_artifacts"]["security-review"] == ["demo"]
+        # Per-entry projection is present too.
+        entry = next(p for p in index["patterns"]["skills"] if p["id"] == "demo")
+        assert entry["collection"] == "security"
+        assert entry["routing"]["task_types"] == ["review"]

--- a/scripts/tests/test_validate_frontmatter.py
+++ b/scripts/tests/test_validate_frontmatter.py
@@ -6,10 +6,12 @@ from pathlib import Path
 import pytest
 
 from scripts.validate_frontmatter import (
+    check_routing_taxonomy,
     check_security_governance,
     extract_frontmatter,
     find_pattern_files,
     load_schema,
+    load_taxonomy,
     validate_file,
 )
 
@@ -394,3 +396,115 @@ class TestRealSchemaStrictness:
         fm = self._base()
         fm["last_updated"] = "2026-07-01"
         jsonschema.validate(instance=fm, schema=real_schema)
+
+    # --- #238: collection + routing schema acceptance -------------------------
+
+    def test_collection_accepted(self, real_schema):
+        import jsonschema
+
+        fm = self._base()
+        fm["collection"] = "security"
+        jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_collection_unknown_value_rejected(self, real_schema):
+        import jsonschema
+
+        fm = self._base()
+        fm["collection"] = "not-a-collection"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_routing_block_accepted(self, real_schema):
+        import jsonschema
+
+        fm = self._base()
+        fm["routing"] = {
+            "task_types": ["review", "analyze"],
+            "input_artifacts": ["source-code"],
+            "output_artifacts": ["security-review"],
+            "prefer_when": ["asks for vulnerabilities"],
+            "avoid_when": ["only about permissions"],
+            "delegates": [{"pattern": "least-privilege-review", "when": "permissions minimality"}],
+            "aliases": ["vulnerability review"],
+            "priority": 50,
+        }
+        jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_routing_unknown_subkey_rejected(self, real_schema):
+        """routing is additionalProperties:false — a typo'd sub-key is rejected."""
+        import jsonschema
+
+        fm = self._base()
+        fm["routing"] = {"task_typez": ["review"]}  # typo
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_routing_delegate_requires_pattern_and_when(self, real_schema):
+        import jsonschema
+
+        fm = self._base()
+        fm["routing"] = {"delegates": [{"pattern": "x"}]}  # missing 'when'
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=fm, schema=real_schema)
+
+
+class TestRoutingTaxonomy:
+    """#238: routing.* facet values are cross-checked against schemas/taxonomy.yaml."""
+
+    @pytest.fixture
+    def taxonomy(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        return load_taxonomy(repo_root / "schemas" / "taxonomy.yaml")
+
+    def test_taxonomy_loads(self, taxonomy):
+        assert taxonomy is not None
+        assert "review" in taxonomy["task_types"]
+        assert "source-code" in taxonomy["artifact_types"]
+
+    def test_no_routing_block_is_noop(self, taxonomy):
+        assert check_routing_taxonomy({"id": "x"}, taxonomy) == []
+
+    def test_known_facets_pass(self, taxonomy):
+        fm = {"routing": {"task_types": ["review"], "output_artifacts": ["security-review"]}}
+        assert check_routing_taxonomy(fm, taxonomy) == []
+
+    def test_unknown_task_type_rejected(self, taxonomy):
+        fm = {"routing": {"task_types": ["frobnicate"]}}
+        errors = check_routing_taxonomy(fm, taxonomy)
+        assert errors and "task_types" in errors[0]
+
+    def test_unknown_artifact_rejected(self, taxonomy):
+        fm = {"routing": {"output_artifacts": ["hologram"]}}
+        errors = check_routing_taxonomy(fm, taxonomy)
+        assert errors and "artifact_types" in errors[0]
+
+    def test_absent_taxonomy_skips(self):
+        fm = {"routing": {"task_types": ["anything"]}}
+        assert check_routing_taxonomy(fm, None) == []
+
+
+class TestSecurityGateUnaffectedByRouting:
+    """Regression (#238): adding a routing block must NOT change the security gate."""
+
+    def test_security_gate_still_fires_with_routing(self):
+        fm = {
+            "categories": ["security"],
+            "routing": {"task_types": ["review"]},
+            # deliberately missing the 6 governance fields
+        }
+        errors, _ = check_security_governance(Path("skills/x/SKILL.md"), fm)
+        assert errors and "security-governance field" in errors[0]
+
+    def test_security_gate_passes_with_routing_and_fields(self):
+        fm = {
+            "categories": ["security"],
+            "routing": {"task_types": ["review"]},
+            "risk_tier": "moderate",
+            "human_review_required": True,
+            "allowed_tools": [],
+            "network_policy": "deny",
+            "write_policy": "deny",
+            "script_policy": "deny",
+        }
+        errors, _ = check_security_governance(Path("skills/x/SKILL.md"), fm)
+        assert errors == []

--- a/scripts/validate_frontmatter.py
+++ b/scripts/validate_frontmatter.py
@@ -111,6 +111,54 @@ def load_schema(schema_path: Path) -> dict[str, Any]:
         return json.load(f)
 
 
+def load_taxonomy(taxonomy_path: Path) -> dict[str, set[str]] | None:
+    """Load the routing taxonomy controlled vocabularies (schemas/taxonomy.yaml).
+
+    Returns {"task_types": {...}, "artifact_types": {...}} of allowed slugs, or
+    None if the file is absent (routing validation is then skipped — the JSON
+    Schema still enforces structure).
+    """
+    if not taxonomy_path.exists():
+        return None
+    data = yaml.safe_load(taxonomy_path.read_text()) or {}
+    return {
+        "task_types": set((data.get("task_types") or {}).keys()),
+        "artifact_types": set((data.get("artifact_types") or {}).keys()),
+    }
+
+
+def check_routing_taxonomy(frontmatter: dict[str, Any], taxonomy: dict[str, set[str]] | None) -> list[str]:
+    """Cross-check routing.* facet values against the controlled vocabularies.
+
+    REJECTS unknown values (does not silently pass) — closes the classifier
+    injection path where an unknown facet could dodge avoid/delegated scoring.
+    No-op if the pattern has no `routing` block or the taxonomy file is absent.
+    """
+    if taxonomy is None:
+        return []
+    routing = frontmatter.get("routing")
+    if not isinstance(routing, dict):
+        return []
+
+    errors: list[str] = []
+    facet_vocab = {
+        "task_types": ("task_types", taxonomy["task_types"]),
+        "input_artifacts": ("artifact_types", taxonomy["artifact_types"]),
+        "output_artifacts": ("artifact_types", taxonomy["artifact_types"]),
+    }
+    for facet, (vocab_name, allowed) in facet_vocab.items():
+        values = routing.get(facet) or []
+        if not isinstance(values, list):
+            continue
+        unknown = [v for v in values if v not in allowed]
+        if unknown:
+            errors.append(
+                f"routing.{facet} contains value(s) not in taxonomy.yaml "
+                f"{vocab_name}: {', '.join(sorted(map(str, unknown)))}"
+            )
+    return errors
+
+
 def extract_frontmatter(content: str) -> dict[str, Any] | None:
     """Extract YAML frontmatter from markdown content."""
     if not content.startswith("---\n"):
@@ -134,7 +182,9 @@ def find_pattern_files(root: Path) -> list[Path]:
     return sorted(patterns)
 
 
-def validate_file(file_path: Path, schema: dict[str, Any]) -> tuple[bool, list[str], list[str]]:
+def validate_file(
+    file_path: Path, schema: dict[str, Any], taxonomy: dict[str, set[str]] | None = None
+) -> tuple[bool, list[str], list[str]]:
     """Validate a single file. Returns (success, errors, warnings)."""
     # Read file
     try:
@@ -160,6 +210,11 @@ def validate_file(file_path: Path, schema: dict[str, Any]) -> tuple[bool, list[s
     if gov_errors:
         return False, gov_errors, gov_warnings
 
+    # Routing facet vocabulary check (#238): reject unknown task/artifact slugs.
+    routing_errors = check_routing_taxonomy(frontmatter, taxonomy)
+    if routing_errors:
+        return False, routing_errors, gov_warnings
+
     return True, [], gov_warnings
 
 
@@ -177,6 +232,7 @@ def main() -> int:
         return 1
 
     schema = load_schema(schema_path)
+    taxonomy = load_taxonomy(root / "schemas" / "taxonomy.yaml")
 
     # Find all pattern files
     files = find_pattern_files(root)
@@ -189,7 +245,7 @@ def main() -> int:
     warned = 0
     for file_path in files:
         rel_path = file_path.relative_to(root)
-        success, errors, warnings = validate_file(file_path, schema)
+        success, errors, warnings = validate_file(file_path, schema, taxonomy)
 
         if success:
             print(f"✓ {rel_path}")


### PR DESCRIPTION
Closes #238. Part of epic #237. Also fixes #243 (unsorted rglob → nondeterministic INDEX).

**Schema-first, additive, reversible.** No pattern file carries the new keys yet — that is PR3 (#240). Legacy `categories` and the `categories==security` governance gate are **untouched** (regression test proves it).

## What changed

- **`schemas/skill.schema.json`** — optional top-level `collection` (enum: meta/engineering/security/content/digital-service/communications) and `routing` object (`task_types`, `input_artifacts`, `output_artifacts`, `prefer_when`, `avoid_when`, `delegates[{pattern,when}]`, `aliases`, `priority`). Both `additionalProperties: false` per repo convention.
- **`schemas/taxonomy.yaml`** (NEW) — controlled vocab for `task_types` + `artifact_types`, kept **out of** the JSON Schema so it can grow via small data PRs. The validator cross-checks `routing.task_types/input_artifacts/output_artifacts` against it and **rejects unknown values** (consensus condition — closes the classifier facet-dodge path).
- **`scripts/generate_index.py`** — sort pattern lists by `id`/`path` before serialization (fixes latent `rglob` nondeterminism, #243); surface per-entry `collection`/`routing` and new reverse facets (`collections`, `task_types`, `output_artifacts`).
- **`scripts/search_patterns.py`** — new `--collection`, `--type`, `--task`, `--input`, `--output` filters.
- **`scripts/validate_frontmatter.py`** — `load_taxonomy` + `check_routing_taxonomy`, wired **after** the security gate so gate ordering is unchanged.
- **Tests** — schema acceptance for `collection`/`routing`, unknown-facet rejection, **security-gate-unaffected regression**, and index determinism + reverse-facet shape.

## Verification
- `make validate` ✓ · `make generate-check` ✓ · `194 tests pass` ✓
- INDEX diff is additive (`collection: null` + `routing: {}` on all 30 entries; new sorted order); no content dropped.

## Review notes (per standing rules)
Schema change → **human/code-owner review required; do not admin-merge.** Multi-model consensus approved the design 7/7 (`higher_order`); a `pr_review` panel is attached in a follow-up comment.

Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>