### PR TITLE
feat(meta): add data-driven pattern-router + deterministic scorer (#239)

### DIFF
--- a/.agents/skills/meta/pattern-router/SKILL.md
+++ b/.agents/skills/meta/pattern-router/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: pattern-router
+id: pattern-router
+version: "1.0.0"
+title: "Pattern Router"
+description: "Route a request to the smallest appropriate set of patterns (workflow > skill > prompt) using structured routing metadata and the deterministic route_patterns.py scorer, instead of brittle keyword matching."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - agents
+  - developers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Route"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: meta
+triggers:
+  - "which skill"
+  - "which pattern"
+  - "how do I route"
+  - "what should I use for"
+tags:
+  - "meta"
+  - "routing"
+  - "discovery"
+routing:
+  task_types:
+    - discover
+    - orchestrate
+  input_artifacts: []
+  output_artifacts: []
+  aliases:
+    - "pattern selection"
+    - "skill router"
+  prefer_when:
+    - "You are unsure which pattern (workflow, skill, or prompt) best fits a request"
+    - "A request bundles several jobs and you need to decompose it into a minimal route"
+  avoid_when:
+    - "The correct pattern is already obvious from an explicit user instruction"
+  priority: 90
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Pattern Router
+
+## Summary
+
+Given a request, choose the **smallest appropriate route** through the pattern
+catalog. The router does not try to understand every procedure itself — it maps
+the request to structured routing metadata (`routing.*` in each pattern's
+frontmatter, surfaced in `INDEX.yaml`) and lets a deterministic scorer rank the
+candidates.
+
+The core rule:
+
+> **Prefer a workflow for an outcome, a skill for an operation, and a prompt only
+> when the environment cannot load the corresponding skill.**
+
+Routing **policy** lives in each pattern's metadata. **Orchestration** lives in
+workflows. The router only *selects*; it does not execute.
+
+## When to Use
+
+- You have a request and are not sure which pattern fits.
+- A request bundles several jobs ("research this, build a deck, check it for
+  accessibility") and you need to decompose it into a minimal set of patterns.
+- You want an explainable, testable selection instead of keyword guessing.
+
+## When NOT to Use
+
+- The user explicitly named the pattern to run.
+- You are executing an already-selected pattern (that is the pattern's job).
+
+## Prerequisites
+
+- A generated `INDEX.yaml` (`make generate`).
+- `scripts/route_patterns.py` and `schemas/taxonomy.yaml` present.
+
+## Procedure
+
+### 1. Decompose the request into facets
+
+You (the model) classify the request into controlled facets from
+`schemas/taxonomy.yaml`. Do **not** invent facet values — unknown values are
+rejected by the scorer.
+
+```yaml
+task_types:      [discover, author, visualize, review]   # controlled verbs
+input_artifacts: [documentation]                          # controlled slugs
+output_artifacts: [slide-deck]                            # controlled slugs
+keywords:        ["executive deck", "accessible"]         # free-text phrases
+constraints:     ["executive-audience", "accessible"]     # notes for assumptions
+```
+
+### 2. Run the deterministic scorer
+
+```bash
+python scripts/route_patterns.py \
+  --task author --task visualize \
+  --output slide-deck \
+  --keyword "executive deck" \
+  --json
+```
+
+or feed a request file:
+
+```bash
+python scripts/route_patterns.py --request-file /path/inside/repo/request.yaml --json
+```
+
+The scorer performs: **validate facets → filter → score → apply delegation →
+rank → explain**. Scoring (weights are tunable; explainability is the invariant):
+
+| Signal | Weight |
+|--------|-------:|
+| Exact output-artifact match | +40 |
+| Exact task-type match | +30 |
+| Exact input-artifact match | +15 |
+| Alias phrase match | +10 |
+| Trigger phrase match | +10 |
+| Collection match | +5 |
+| `recommended` status | +5 |
+| Matched `avoid_when` | −100 (hard exclude) |
+| Delegated to another pattern | −100 (hard exclude) |
+| Deprecated | −100 (hard exclude) |
+
+A candidate with **no** substantive facet/keyword match scores 0 and is dropped
+— the type-nudge and status bonus are tie-breakers, never standalone signals.
+This is what stops the router from "selecting every skill sharing a category".
+
+### 3. Read the route
+
+```yaml
+route:
+  primary:
+    id: design-artifact
+    type: workflow
+    reason: "output match: ['slide-deck']; task match: ['author']"
+  supporting:
+    - id: accessibility-review          # adds a distinct REQUESTED output
+  excluded:
+    - id: explainer-video
+      reason: "the requested output is a slide deck, not motion video"
+  assumptions:
+    - "HTML-first deck unless editable PPTX is explicitly required"
+```
+
+`supporting` only lists candidates that add a **distinct requested output** the
+primary does not cover — this keeps routes minimal.
+
+### 4. Prefer a workflow for an outcome
+
+If a workflow covers the requested outcome, take it. The workflow (not the
+router) knows the internal sequence of skills. Fall back to atomic skills only
+when no workflow fits, and select the **smallest set** that covers the request.
+
+### 5. Apply hard exclusions honestly
+
+Exclude a candidate when it is deprecated, its `avoid_when` matches, a more
+specific pattern owns the lane (`delegates`), required inputs are unavailable,
+or governance cannot be honored.
+
+## Verification
+
+- The route's `primary.reason` cites the concrete facet matches.
+- No excluded pattern appears as primary or supporting.
+- For security lanes, the selected pattern's governance frontmatter still
+  applies (`human_review_required: true` means output is advisory).
+- Regression cases live in `scripts/tests/router-cases.yaml`; run
+  `PYTHONPATH=scripts pytest scripts/tests/test_route_patterns.py`.
+
+## Examples
+
+| Request | Primary | Notably NOT |
+|---------|---------|-------------|
+| "Audit this GitHub Actions workflow for unsafe `pull_request_target`" | `agentic-actions-auditor` | `least-privilege-review`, `secure-code-review` |
+| "Are these `GITHUB_TOKEN` permissions broader than necessary?" | `least-privilege-review` | `agentic-actions-auditor` |
+| "Create an executive one-pager explaining the pilot" | `design-artifact` (one-pager) | assembling six skills by hand |
+| "Make this README easier for the public to understand" | `plain-language-review` | `documentation-review` |
+| "Check this README for stale commands and broken links" | `documentation-review` | `plain-language-review` |
+
+## Notes
+
+- The router is **data-driven** — do not hand-maintain a giant decision tree
+  here. New routing knowledge goes into the target pattern's `routing.*`
+  metadata, not into this file.
+- No embeddings / vector DB: at this catalog's scale explicit metadata is
+  cheaper, clearer, and reliably testable.

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -128,6 +128,21 @@ patterns:
     - development
     collection: null
     routing: {}
+  - path: skills/meta/pattern-router/SKILL.md
+    id: pattern-router
+    title: Pattern Router
+    type: skill
+    status: experimental
+    categories: []
+    collection: meta
+    routing:
+      task_types:
+      - discover
+      - orchestrate
+      aliases:
+      - pattern selection
+      - skill router
+      priority: 90
   - path: skills/frontend/plain-language-review/SKILL.md
     id: plain-language-review
     title: Federal Plain Language Review
@@ -380,12 +395,18 @@ categories:
   - uswds-form-flow
   - uswds-landing-page
   - uswds-prototype
-collections: {}
-task_types: {}
+collections:
+  meta:
+  - pattern-router
+task_types:
+  discover:
+  - pattern-router
+  orchestrate:
+  - pattern-router
 output_artifacts: {}
 stats:
-  total_patterns: 30
-  skills: 20
+  total_patterns: 31
+  skills: 21
   prompts: 3
   agents: 3
   workflows: 3

--- a/docs/AI-AGENT-GUIDE.md
+++ b/docs/AI-AGENT-GUIDE.md
@@ -116,7 +116,25 @@ if is_compatible(fm, 'opencode'):
 
 ## Pattern Selection Logic
 
-### By User Intent
+> **Prefer the `pattern-router` for selection.** The keyword-matching shown
+> below is the *legacy fallback*. The recommended path is the data-driven
+> router: the `pattern-router` skill (`.agents/skills/meta/pattern-router/`)
+> plus `scripts/route_patterns.py`, which score patterns on their structured
+> `routing.*` metadata (task types, input/output artifacts, aliases,
+> `prefer_when`/`avoid_when`/`delegates`) and return the **smallest appropriate
+> route** with an explanation. Run:
+>
+> ```bash
+> python scripts/route_patterns.py --task review --output security-review --json
+> ```
+>
+> The core rule the router enforces: **prefer a workflow for an outcome, a skill
+> for an operation, and a prompt only when the environment cannot load the
+> corresponding skill.** It will not select every skill sharing a broad
+> category. See the `pattern-router` SKILL.md for the full procedure and the
+> scoring model.
+
+### By User Intent (legacy keyword fallback)
 
 Match user intent to pattern triggers:
 
@@ -201,6 +219,12 @@ if deps['has_dependencies']:
 ```
 
 ## Security Skill Routing
+
+> **These lanes are being moved into structured `routing.delegates` /
+> `avoid_when` metadata** (epic #237, applied in PR3 #240) so the `pattern-router`
+> enforces them mechanically rather than relying on this prose table. Until that
+> lands, the table below remains the reference; afterward it becomes a
+> human-readable mirror of the metadata.
 
 Security skills (`categories: [security]`) overlap by design, so pick by the
 **specific trigger**, not by keyword alone. Map the user's request to one skill:

--- a/scripts/route_patterns.py
+++ b/scripts/route_patterns.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""
+Deterministic pattern-router engine (#237, PR2 #239).
+
+The MODEL classifies a request into structured facets (task_types, output/input
+artifacts, constraints). THIS SCRIPT does the mechanical part: filter → score →
+rank → explain. Keeping selection deterministic makes it testable, reproducible,
+cheap (no per-call model variance), and immune to hallucinated pattern ids.
+
+Design contract (epic #237):
+  * Prefer a workflow for an outcome, a skill for an operation, a prompt only as
+    an environment fallback.
+  * Choose the SMALLEST appropriate route, never "every skill sharing a category".
+  * Every decision is explainable: excluded candidates carry a reason.
+
+Security (consensus conditions, #237):
+  * All pattern references stay repo-relative — reject absolute paths / `..`
+    (path-traversal guard) when reading pattern files.
+  * Request facets are validated against schemas/taxonomy.yaml; unknown facets
+    are rejected, not silently scored (prevents dodging avoid/delegate penalties).
+
+Usage:
+    python scripts/route_patterns.py --task review --output security-review
+    python scripts/route_patterns.py --request-file req.yaml --json
+    python scripts/route_patterns.py --task author --output slide-deck --explain
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ── Deterministic scoring weights ───────────────────────────────────────────
+# Exact weights matter less than the decision being explainable and testable.
+# Positive signals accumulate; the three −100 penalties act as hard exclusions.
+W_OUTPUT_MATCH = 40
+W_TASK_MATCH = 30
+W_INPUT_MATCH = 15
+W_ALIAS_MATCH = 10
+W_TRIGGER_MATCH = 10
+W_COLLECTION_MATCH = 5
+W_RECOMMENDED = 5
+P_AVOID = -100
+P_DELEGATED = -100
+P_DEPRECATED = -100
+
+# A workflow that covers the requested outcome is preferred over assembling
+# skills; a prompt is only a fallback. Encoded as a small type nudge so ties
+# resolve toward the right granularity without overriding real facet matches.
+TYPE_NUDGE = {"workflow": 3, "skill": 0, "prompt": -3, "agent": -5, "lesson": -50}
+
+
+@dataclass
+class RequestFacets:
+    """Structured request the model produced (or CLI flags supplied)."""
+
+    task_types: list[str] = field(default_factory=list)
+    input_artifacts: list[str] = field(default_factory=list)
+    output_artifacts: list[str] = field(default_factory=list)
+    keywords: list[str] = field(default_factory=list)
+    collection: str | None = None
+
+    def is_empty(self) -> bool:
+        return not (
+            self.task_types or self.input_artifacts or self.output_artifacts or self.keywords or self.collection
+        )
+
+
+@dataclass
+class Candidate:
+    """A pattern under consideration with its running score + trace."""
+
+    id: str
+    type: str
+    status: str
+    path: str
+    collection: str | None
+    routing: dict
+    score: int = 0
+    reasons: list[str] = field(default_factory=list)
+    excluded_reason: str | None = None
+
+
+# ── Loading (repo-relative, path-traversal safe) ────────────────────────────
+
+
+def load_taxonomy(repo_root: Path) -> dict[str, set[str]]:
+    """Load controlled vocab for facet validation. Empty sets if file absent."""
+    path = repo_root / "schemas" / "taxonomy.yaml"
+    if not path.exists():
+        return {"task_types": set(), "artifact_types": set()}
+    data = yaml.safe_load(path.read_text()) or {}
+    return {
+        "task_types": set((data.get("task_types") or {}).keys()),
+        "artifact_types": set((data.get("artifact_types") or {}).keys()),
+    }
+
+
+def _safe_repo_relative(repo_root: Path, rel_path: str) -> Path | None:
+    """Resolve rel_path under repo_root, rejecting absolute paths and traversal.
+
+    Returns the resolved Path if it stays inside repo_root, else None. This is
+    the consensus path-traversal guard: a pattern `path` in INDEX.yaml is data
+    and must never escape the repo.
+    """
+    if not rel_path:
+        return None
+    candidate = Path(rel_path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return None
+    resolved = (repo_root / candidate).resolve()
+    try:
+        resolved.relative_to(repo_root.resolve())
+    except ValueError:
+        return None
+    return resolved
+
+
+def _extract_frontmatter(text: str) -> dict:
+    if not text.startswith("---\n"):
+        return {}
+    parts = text.split("---\n", 2)
+    if len(parts) < 3:
+        return {}
+    return yaml.safe_load(parts[1]) or {}
+
+
+def load_candidates(repo_root: Path, index_data: dict) -> list[Candidate]:
+    """Build candidates from INDEX.yaml, enriching from each SKILL.md.
+
+    The INDEX carries the shortlist facets; prefer_when/avoid_when/delegates live
+    in the source file, so we reopen it (guarded). A pattern whose path fails the
+    traversal guard is skipped defensively.
+    """
+    candidates: list[Candidate] = []
+    for items in (index_data.get("patterns") or {}).values():
+        if not isinstance(items, list):
+            continue
+        for entry in items:
+            rel = entry.get("path", "")
+            safe = _safe_repo_relative(repo_root, rel)
+            routing = dict(entry.get("routing") or {})
+            if safe and safe.exists():
+                fm = _extract_frontmatter(safe.read_text())
+                # Merge full routing (prefer_when/avoid_when/delegates) from source.
+                fm_routing = fm.get("routing")
+                if isinstance(fm_routing, dict):
+                    routing = fm_routing
+                collection = fm.get("collection") or entry.get("collection")
+                triggers = fm.get("triggers") or []
+                deprecated = fm.get("status") == "deprecated" or bool(fm.get("deprecated"))
+            else:
+                collection = entry.get("collection")
+                triggers = []
+                deprecated = entry.get("status") == "deprecated"
+            routing.setdefault("_triggers", triggers)
+            cand = Candidate(
+                id=entry.get("id", "unknown"),
+                type=entry.get("type", "skill"),
+                status=entry.get("status", "experimental"),
+                path=rel,
+                collection=collection,
+                routing=routing,
+            )
+            cand.routing["_deprecated"] = deprecated
+            candidates.append(cand)
+    # Stable order for deterministic tie-breaking.
+    candidates.sort(key=lambda c: c.id)
+    return candidates
+
+
+# ── Facet validation ────────────────────────────────────────────────────────
+
+
+def validate_request(facets: RequestFacets, taxonomy: dict[str, set[str]]) -> list[str]:
+    """Reject request facets that are not in the controlled vocabulary.
+
+    Consensus condition: an unknown task_type/artifact must fail loudly rather
+    than silently scoring nothing (which could let a crafted request dodge the
+    avoid/delegate penalties by never matching them).
+    """
+    errors: list[str] = []
+    task_vocab = taxonomy.get("task_types", set())
+    art_vocab = taxonomy.get("artifact_types", set())
+    if task_vocab:
+        for t in facets.task_types:
+            if t not in task_vocab:
+                errors.append(f"unknown task_type: {t!r}")
+    if art_vocab:
+        for a in facets.input_artifacts:
+            if a not in art_vocab:
+                errors.append(f"unknown input_artifact: {a!r}")
+        for a in facets.output_artifacts:
+            if a not in art_vocab:
+                errors.append(f"unknown output_artifact: {a!r}")
+    return errors
+
+
+# ── Scoring ──────────────────────────────────────────────────────────────────
+
+
+def _phrase_hit(keywords: list[str], phrases: list[str]) -> bool:
+    """True if any request keyword and any pattern phrase overlap.
+
+    Request keywords are often whole sentences ("audit this GitHub Actions
+    workflow…") while pattern phrases are short ("agent-invoking CI workflow").
+    We therefore test containment in BOTH directions (keyword-in-phrase OR
+    phrase-in-keyword) so a short pattern phrase can match a long request.
+
+    Guard against short-substring false positives (a 2-char alias like "ci"
+    matching "de*ci*sion"): the side being searched *for* must be at least
+    MIN_MATCH_LEN chars AND, when it is a single token, match on a word boundary
+    rather than a bare substring. This prevents a poorly chosen short alias from
+    promoting an irrelevant candidate.
+    """
+    kws = [k.lower() for k in keywords if k]
+    for phrase in phrases:
+        pl = str(phrase).lower()
+        if not pl:
+            continue
+        for kw in kws:
+            if not kw:
+                continue
+            if _contains(pl, kw) or _contains(kw, pl):
+                return True
+    return False
+
+
+MIN_MATCH_LEN = 4
+
+
+def _contains(haystack: str, needle: str) -> bool:
+    """Substring test with a false-positive guard for short single tokens.
+
+    - needle shorter than MIN_MATCH_LEN and containing no space → require a
+      word-boundary match (so "ci" matches "ci workflow" but not "decision").
+    - otherwise → ordinary substring containment (multi-word phrases are already
+      specific enough).
+    """
+    if not needle:
+        return False
+    if len(needle) < MIN_MATCH_LEN and " " not in needle:
+        return re.search(rf"\b{re.escape(needle)}\b", haystack) is not None
+    return needle in haystack
+
+
+def score_candidate(cand: Candidate, facets: RequestFacets) -> Candidate:
+    """Apply deterministic scoring. Sets score, reasons, and excluded_reason."""
+    routing = cand.routing
+    r_outputs = routing.get("output_artifacts") or []
+    r_inputs = routing.get("input_artifacts") or []
+    r_tasks = routing.get("task_types") or []
+    r_aliases = routing.get("aliases") or []
+    r_triggers = routing.get("_triggers") or []
+
+    # ── Hard exclusions first ────────────────────────────────────────────────
+    if routing.get("_deprecated"):
+        cand.score = P_DEPRECATED
+        cand.excluded_reason = "deprecated"
+        return cand
+
+    # avoid_when: if any request keyword matches an avoid phrase, exclude.
+    if facets.keywords and _phrase_hit(facets.keywords, routing.get("avoid_when") or []):
+        cand.score = P_AVOID
+        cand.excluded_reason = "matched avoid_when"
+        return cand
+
+    # ── Positive signals ─────────────────────────────────────────────────────
+    matched_outputs = set(r_outputs) & set(facets.output_artifacts)
+    if matched_outputs:
+        cand.score += W_OUTPUT_MATCH * len(matched_outputs)
+        cand.reasons.append(f"output match: {sorted(matched_outputs)}")
+
+    matched_tasks = set(r_tasks) & set(facets.task_types)
+    if matched_tasks:
+        cand.score += W_TASK_MATCH * len(matched_tasks)
+        cand.reasons.append(f"task match: {sorted(matched_tasks)}")
+
+    matched_inputs = set(r_inputs) & set(facets.input_artifacts)
+    if matched_inputs:
+        cand.score += W_INPUT_MATCH * len(matched_inputs)
+        cand.reasons.append(f"input match: {sorted(matched_inputs)}")
+
+    if facets.keywords and _phrase_hit(facets.keywords, r_aliases):
+        cand.score += W_ALIAS_MATCH
+        cand.reasons.append("alias match")
+
+    if facets.keywords and _phrase_hit(facets.keywords, r_triggers):
+        cand.score += W_TRIGGER_MATCH
+        cand.reasons.append("trigger match")
+
+    if facets.collection and cand.collection == facets.collection:
+        cand.score += W_COLLECTION_MATCH
+        cand.reasons.append("collection match")
+
+    if cand.status == "recommended":
+        cand.score += W_RECOMMENDED
+        cand.reasons.append("recommended status")
+
+    # The type-nudge and recommended bonus are TIE-BREAKERS, not signals — they
+    # only apply once the candidate has a real facet/keyword match. Otherwise a
+    # workflow with zero relevance would score +3 and be "selected" (e.g. against
+    # a not-yet-classified INDEX). Require a substantive match first.
+    has_real_match = bool(cand.reasons) and any(
+        r.startswith(("output match", "task match", "input match", "alias match", "trigger match"))
+        for r in cand.reasons
+    )
+    if has_real_match:
+        cand.score += TYPE_NUDGE.get(cand.type, 0)
+    else:
+        cand.score = 0
+        cand.reasons.clear()
+    return cand
+
+
+def apply_delegation(candidates: list[Candidate], facets: RequestFacets) -> None:
+    """Demote a candidate that delegates a matching lane to a more specific one.
+
+    If pattern A declares `delegates: [{pattern: B, when: "..."}]` and the
+    request keywords match B's `when` clause, A is excluded in favor of B — this
+    is how the security disambiguation lanes stay out of prose.
+    """
+    by_id = {c.id: c for c in candidates}
+    for cand in candidates:
+        if cand.excluded_reason:
+            continue
+        for deleg in cand.routing.get("delegates") or []:
+            target = deleg.get("pattern")
+            when = deleg.get("when", "")
+            if not target or target not in by_id:
+                continue
+            if facets.keywords and _phrase_hit(facets.keywords, [when]):
+                cand.score = P_DELEGATED
+                cand.excluded_reason = f"delegated to {target} ({when})"
+                break
+
+
+# ── Route assembly ────────────────────────────────────────────────────────────
+
+
+def build_route(candidates: list[Candidate], facets: RequestFacets | None = None) -> dict:
+    """Rank scored candidates and assemble the explainable route object."""
+    included = [c for c in candidates if c.excluded_reason is None and c.score > 0]
+    excluded = [c for c in candidates if c.excluded_reason is not None]
+
+    # Deterministic ranking: score desc, then routing.priority desc, then id asc.
+    def sort_key(c: Candidate):
+        priority = c.routing.get("priority", 50)
+        return (-c.score, -priority, c.id)
+
+    included.sort(key=sort_key)
+
+    requested_outputs = set(facets.output_artifacts) if facets else set()
+
+    route: dict[str, Any] = {"primary": None, "supporting": [], "excluded": [], "assumptions": []}
+    if included:
+        top = included[0]
+        route["primary"] = {
+            "id": top.id,
+            "type": top.type,
+            "score": top.score,
+            "reason": "; ".join(top.reasons) or "best facet match",
+        }
+        # Supporting = other included candidates that add a distinct REQUESTED
+        # output the primary does not cover. Restricting to requested outputs
+        # keeps routes minimal — a candidate producing an artifact nobody asked
+        # for (e.g. a video when a deck was requested) is never dragged in.
+        primary_outputs = set(top.routing.get("output_artifacts") or [])
+        for c in included[1:]:
+            c_outputs = set(c.routing.get("output_artifacts") or [])
+            distinct_requested = (c_outputs & requested_outputs) - primary_outputs
+            if distinct_requested:
+                route["supporting"].append(
+                    {"id": c.id, "type": c.type, "score": c.score, "reason": "; ".join(c.reasons)}
+                )
+                primary_outputs |= c_outputs
+
+    # Only surface excluded candidates that ALMOST matched (avoid/delegated),
+    # not the long tail of irrelevant patterns.
+    for c in excluded:
+        if c.excluded_reason and c.excluded_reason != "deprecated":
+            route["excluded"].append({"id": c.id, "reason": c.excluded_reason})
+
+    return route
+
+
+def route_request(repo_root: Path, index_data: dict, facets: RequestFacets) -> dict:
+    """Full pipeline: validate → score → delegate → rank → explain."""
+    taxonomy = load_taxonomy(repo_root)
+    errors = validate_request(facets, taxonomy)
+    if errors:
+        return {"error": "invalid request facets", "details": errors}
+    if facets.is_empty():
+        return {"error": "empty request", "details": ["provide at least one facet"]}
+
+    candidates = load_candidates(repo_root, index_data)
+    for cand in candidates:
+        score_candidate(cand, facets)
+    apply_delegation(candidates, facets)
+    return build_route(candidates, facets)
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+def _load_index(repo_root: Path) -> dict:
+    path = repo_root / "INDEX.yaml"
+    if not path.exists():
+        print("Error: INDEX.yaml not found (run 'make generate')", file=sys.stderr)
+        sys.exit(2)
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Deterministic pattern router (#237)")
+    parser.add_argument("--task", action="append", default=[], help="Request task type (repeatable)")
+    parser.add_argument(
+        "--input", dest="input_artifact", action="append", default=[], help="Input artifact (repeatable)"
+    )
+    parser.add_argument(
+        "--output", dest="output_artifact", action="append", default=[], help="Output artifact (repeatable)"
+    )
+    parser.add_argument("--keyword", action="append", default=[], help="Free-text keyword/phrase (repeatable)")
+    parser.add_argument("--collection", default=None, help="Preferred collection")
+    parser.add_argument(
+        "--request-file",
+        type=Path,
+        default=None,
+        help="YAML file with task_types/input_artifacts/output_artifacts/keywords/collection",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).parent.parent.resolve()
+
+    if args.request_file:
+        # A --request-file is an OPERATOR-supplied CLI argument (same trust level
+        # as `cat`), so an absolute path is permitted here. Deliberately
+        # asymmetric with pattern `path` values from INDEX.yaml, which are DATA
+        # and stay guarded by _safe_repo_relative.
+        safe = (
+            _safe_repo_relative(repo_root, str(args.request_file))
+            if not args.request_file.is_absolute()
+            else args.request_file
+        )
+        if safe is None or not safe.exists():
+            print(f"Error: request file not found or unsafe: {args.request_file}", file=sys.stderr)
+            return 2
+        data = yaml.safe_load(safe.read_text()) or {}
+        facets = RequestFacets(
+            task_types=list(data.get("task_types") or []),
+            input_artifacts=list(data.get("input_artifacts") or []),
+            output_artifacts=list(data.get("output_artifacts") or []),
+            keywords=list(data.get("keywords") or []),
+            collection=data.get("collection"),
+        )
+    else:
+        facets = RequestFacets(
+            task_types=args.task,
+            input_artifacts=args.input_artifact,
+            output_artifacts=args.output_artifact,
+            keywords=args.keyword,
+            collection=args.collection,
+        )
+
+    index_data = _load_index(repo_root)
+    route = route_request(repo_root, index_data, facets)
+
+    if args.json:
+        print(json.dumps(route, indent=2))
+    else:
+        if "error" in route:
+            print(f"✗ {route['error']}: {', '.join(route['details'])}")
+            return 1
+        primary = route.get("primary")
+        if not primary:
+            print("No pattern matched the request facets.")
+            return 1
+        print(f"→ primary: {primary['id']} ({primary['type']}) [score {primary['score']}]")
+        print(f"  reason: {primary['reason']}")
+        for s in route["supporting"]:
+            print(f"  + supporting: {s['id']} ({s['type']}) [score {s['score']}]")
+        for e in route["excluded"]:
+            print(f"  − excluded: {e['id']} — {e['reason']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/router-cases.yaml
+++ b/scripts/tests/router-cases.yaml
@@ -1,0 +1,332 @@
+# Router regression cases (#237, PR2 #239).
+#
+# These cases are DETERMINISTIC and self-contained: each provides an inline set
+# of candidate patterns (with routing metadata) plus a request, and asserts the
+# router's primary/supporting/excluded decision. They do NOT read the live
+# INDEX.yaml — the live patterns do not carry routing blocks until PR3 (#240),
+# and pinning to fixtures keeps the suite stable as the catalog evolves.
+#
+# Each case:
+#   request:          the structured facets a model would produce
+#   candidates:       inline patterns {id,type,status,collection,routing}
+#   expect_primary:   pattern id the router must pick (or null for "no match")
+#   forbid:           pattern ids that must NOT be primary or supporting
+#   expect_supporting (optional): ids that MUST appear as supporting
+#   expect_excluded   (optional): ids that MUST appear as excluded with a reason
+
+cases:
+  # ── Exact-match: security review of a diff ────────────────────────────────
+  - name: vulnerability-review-of-diff
+    request:
+      task_types: [review]
+      input_artifacts: [pull-request-diff]
+      output_artifacts: [security-review]
+      keywords: ["review this PR for vulnerabilities", "owasp"]
+    candidates:
+      - id: secure-code-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review, analyze]
+          input_artifacts: [source-code, pull-request-diff]
+          output_artifacts: [security-review]
+          aliases: ["vulnerability review", "security code review"]
+          avoid_when:
+            - "the request is specifically about an LLM-invoking CI workflow"
+            - "the request is solely about permission minimality"
+          delegates:
+            - pattern: agentic-actions-auditor
+              when: "the target is an agent-invoking CI workflow"
+            - pattern: least-privilege-review
+              when: "the question is specifically whether permissions are minimal"
+      - id: least-privilege-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          output_artifacts: [security-review]
+          aliases: ["permission review"]
+    expect_primary: secure-code-review
+    forbid: [least-privilege-review]
+
+  # ── Neighboring-ambiguous: CI workflow audit must NOT pick generic review ──
+  - name: workflow-audit-routes-to-auditor
+    request:
+      task_types: [review]
+      input_artifacts: [ci-workflow]
+      output_artifacts: [security-review]
+      keywords: ["audit this GitHub Actions workflow for unsafe pull_request_target", "agent-invoking CI workflow"]
+    candidates:
+      - id: secure-code-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          input_artifacts: [source-code, pull-request-diff]
+          output_artifacts: [security-review]
+          avoid_when:
+            - "the request is specifically about an LLM-invoking CI workflow"
+          delegates:
+            - pattern: agentic-actions-auditor
+              when: "agent-invoking CI workflow"
+      - id: agentic-actions-auditor
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review, analyze]
+          input_artifacts: [ci-workflow]
+          output_artifacts: [security-review]
+          aliases: ["github actions audit", "workflow audit"]
+    expect_primary: agentic-actions-auditor
+    forbid: [secure-code-review, least-privilege-review]
+    expect_excluded: [secure-code-review]
+
+  # ── Neighboring-ambiguous: token minimality routes to LPR ─────────────────
+  - name: token-minimality-routes-to-lpr
+    request:
+      task_types: [review]
+      output_artifacts: [security-review]
+      keywords: ["are these GITHUB_TOKEN permissions broader than necessary", "permission minimality"]
+    candidates:
+      - id: agentic-actions-auditor
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          input_artifacts: [ci-workflow]
+          output_artifacts: [security-review]
+      - id: least-privilege-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          output_artifacts: [security-review]
+          aliases: ["permission minimality", "least privilege"]
+    expect_primary: least-privilege-review
+    forbid: [agentic-actions-auditor]
+
+  # ── Composite request → workflow preferred over assembling skills ─────────
+  - name: executive-one-pager-prefers-workflow
+    request:
+      task_types: [author, visualize, render]
+      output_artifacts: [one-pager]
+      keywords: ["create an executive one-pager explaining the pilot"]
+    candidates:
+      - id: design-artifact
+        type: workflow
+        status: experimental
+        collection: communications
+        routing:
+          task_types: [author, visualize, render, orchestrate]
+          output_artifacts: [one-pager, slide-deck]
+          aliases: ["executive one-pager", "design artifact"]
+      - id: artifact-brief
+        type: skill
+        status: experimental
+        collection: communications
+        routing:
+          task_types: [plan]
+          output_artifacts: [artifact-brief]
+    expect_primary: design-artifact
+    forbid: [artifact-brief]
+
+  # ── Deck request must NOT pull in explainer-video ─────────────────────────
+  - name: slide-deck-excludes-video
+    request:
+      task_types: [author, render]
+      output_artifacts: [slide-deck]
+      keywords: ["make a slide deck"]
+    candidates:
+      - id: design-artifact
+        type: workflow
+        status: experimental
+        collection: communications
+        routing:
+          task_types: [author, render]
+          output_artifacts: [one-pager, slide-deck]
+      - id: explainer-video
+        type: skill
+        status: experimental
+        collection: communications
+        routing:
+          task_types: [author, render]
+          output_artifacts: [explainer-video]
+          aliases: ["promo video"]
+    expect_primary: design-artifact
+    forbid: [explainer-video]
+
+  # ── plain-language vs documentation-review (content lane) ─────────────────
+  - name: readability-routes-to-plain-language
+    request:
+      task_types: [review]
+      input_artifacts: [documentation]
+      keywords: ["make this README easier for the public to understand", "readability"]
+    candidates:
+      - id: plain-language-review
+        type: skill
+        status: experimental
+        collection: content
+        routing:
+          task_types: [review]
+          input_artifacts: [documentation]
+          aliases: ["plain language", "readability", "public audience"]
+      - id: documentation-review
+        type: skill
+        status: experimental
+        collection: content
+        routing:
+          task_types: [review]
+          input_artifacts: [documentation]
+          aliases: ["stale commands", "broken links"]
+    expect_primary: plain-language-review
+
+  - name: stale-links-routes-to-documentation-review
+    request:
+      task_types: [review]
+      input_artifacts: [documentation]
+      keywords: ["check this README for stale commands and broken links"]
+    candidates:
+      - id: plain-language-review
+        type: skill
+        status: experimental
+        collection: content
+        routing:
+          task_types: [review]
+          input_artifacts: [documentation]
+          aliases: ["plain language", "readability"]
+      - id: documentation-review
+        type: skill
+        status: experimental
+        collection: content
+        routing:
+          task_types: [review]
+          input_artifacts: [documentation]
+          aliases: ["stale commands", "broken links", "link check"]
+    expect_primary: documentation-review
+
+  # ── Negative case: nothing plausibly matches ──────────────────────────────
+  - name: no-match-returns-nothing
+    request:
+      output_artifacts: [terminal-demo]
+      keywords: ["record a terminal demo of my app"]
+    candidates:
+      - id: secure-code-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          output_artifacts: [security-review]
+    expect_primary: null
+
+  # ── Deprecated alias must never be selected ───────────────────────────────
+  - name: deprecated-prompt-excluded
+    request:
+      task_types: [review]
+      output_artifacts: [security-review]
+      keywords: ["security code review"]
+    candidates:
+      - id: safe-code-review
+        type: prompt
+        status: deprecated
+        collection: security
+        routing:
+          task_types: [review]
+          output_artifacts: [security-review]
+          aliases: ["security code review"]
+      - id: secure-code-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          output_artifacts: [security-review]
+          aliases: ["security code review"]
+    expect_primary: secure-code-review
+    forbid: [safe-code-review]
+
+  # ── CRITICAL: router must NOT select every skill sharing a broad category ──
+  # Five security-collection skills, but only one matches the specific facets.
+  - name: does-not-select-whole-category
+    request:
+      task_types: [review]
+      input_artifacts: [dependency-manifest]
+      output_artifacts: [security-review]
+      keywords: ["assess these dependencies for supply-chain risk"]
+    candidates:
+      - id: dependency-analysis
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review, analyze]
+          input_artifacts: [dependency-manifest]
+          output_artifacts: [security-review]
+          aliases: ["supply chain", "dependency risk"]
+      - id: secure-code-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          input_artifacts: [source-code]
+          output_artifacts: [security-review]
+      - id: backdoor-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          input_artifacts: [source-code]
+          output_artifacts: [security-review]
+      - id: least-privilege-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          output_artifacts: [security-review]
+      - id: agentic-actions-auditor
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          input_artifacts: [ci-workflow]
+          output_artifacts: [security-review]
+    expect_primary: dependency-analysis
+    # The three unrelated same-category skills must not be dragged in as support
+    # (they add no distinct output artifact beyond the primary).
+    forbid: [backdoor-review, least-privilege-review, agentic-actions-auditor]
+
+  # ── Workflow-vs-skill precedence on a tie of facets ───────────────────────
+  - name: workflow-wins-tie-over-skill
+    request:
+      task_types: [orchestrate, review]
+      output_artifacts: [qa-report]
+      keywords: ["run the full QA process"]
+    candidates:
+      - id: qa-workflow
+        type: workflow
+        status: experimental
+        collection: engineering
+        routing:
+          task_types: [orchestrate, review]
+          output_artifacts: [qa-report]
+          aliases: ["qa process", "testing cycle"]
+      - id: qa-round
+        type: prompt
+        status: experimental
+        collection: engineering
+        routing:
+          task_types: [review]
+          output_artifacts: [qa-report]
+          aliases: ["qa this diff"]
+    expect_primary: qa-workflow
+    forbid: [qa-round]

--- a/scripts/tests/test_route_patterns.py
+++ b/scripts/tests/test_route_patterns.py
@@ -1,0 +1,294 @@
+"""Tests for route_patterns.py — the deterministic pattern router (#237, PR2 #239).
+
+Two layers:
+1. Unit tests of the engine primitives (facet validation, path guard, scoring,
+   delegation, route assembly).
+2. A data-driven regression suite loaded from scripts/tests/router-cases.yaml —
+   each case supplies inline candidate patterns + a request and asserts the
+   primary/supporting/excluded decision. Pinning to fixtures (not the live
+   INDEX) keeps the suite stable until patterns carry routing blocks (PR3 #240).
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.route_patterns import (
+    Candidate,
+    RequestFacets,
+    _safe_repo_relative,
+    apply_delegation,
+    build_route,
+    load_candidates,
+    route_request,
+    score_candidate,
+    validate_request,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CASES_FILE = Path(__file__).parent / "router-cases.yaml"
+
+
+def _taxonomy():
+    from scripts.route_patterns import load_taxonomy
+
+    return load_taxonomy(REPO_ROOT)
+
+
+def _candidates_from_case(case: dict) -> list[Candidate]:
+    """Build Candidate objects directly from an inline case (no file reopen)."""
+    cands = []
+    for c in case["candidates"]:
+        routing = dict(c.get("routing") or {})
+        routing.setdefault("_triggers", [])
+        routing["_deprecated"] = c.get("status") == "deprecated"
+        cands.append(
+            Candidate(
+                id=c["id"],
+                type=c.get("type", "skill"),
+                status=c.get("status", "experimental"),
+                path=f"skills/{c['id']}/SKILL.md",
+                collection=c.get("collection"),
+                routing=routing,
+            )
+        )
+    cands.sort(key=lambda x: x.id)
+    return cands
+
+
+def _route_case(case: dict) -> dict:
+    facets = RequestFacets(
+        task_types=list(case["request"].get("task_types") or []),
+        input_artifacts=list(case["request"].get("input_artifacts") or []),
+        output_artifacts=list(case["request"].get("output_artifacts") or []),
+        keywords=list(case["request"].get("keywords") or []),
+        collection=case["request"].get("collection"),
+    )
+    cands = _candidates_from_case(case)
+    for cand in cands:
+        score_candidate(cand, facets)
+    apply_delegation(cands, facets)
+    return build_route(cands, facets)
+
+
+# ── Data-driven regression suite ──────────────────────────────────────────────
+
+
+def _load_cases():
+    data = yaml.safe_load(CASES_FILE.read_text())
+    return data["cases"]
+
+
+@pytest.mark.parametrize("case", _load_cases(), ids=lambda c: c["name"])
+def test_router_case(case):
+    route = _route_case(case)
+    primary = route.get("primary")
+    primary_id = primary["id"] if primary else None
+
+    # Primary expectation
+    assert primary_id == case["expect_primary"], (
+        f"{case['name']}: expected primary {case['expect_primary']!r}, got {primary_id!r}"
+    )
+
+    selected_ids = set()
+    if primary_id:
+        selected_ids.add(primary_id)
+    selected_ids |= {s["id"] for s in route.get("supporting", [])}
+
+    # Forbidden ids must not be primary or supporting
+    for forbidden in case.get("forbid", []):
+        assert forbidden not in selected_ids, f"{case['name']}: forbidden {forbidden!r} was selected ({selected_ids})"
+
+    # Required supporting ids
+    for sup in case.get("expect_supporting", []):
+        assert sup in {s["id"] for s in route.get("supporting", [])}, (
+            f"{case['name']}: expected supporting {sup!r} missing"
+        )
+
+    # Required excluded ids
+    excluded_ids = {e["id"] for e in route.get("excluded", [])}
+    for exc in case.get("expect_excluded", []):
+        assert exc in excluded_ids, f"{case['name']}: expected excluded {exc!r} missing"
+
+
+def test_all_cases_have_names_and_expectations():
+    for case in _load_cases():
+        assert "name" in case
+        assert "request" in case
+        assert "candidates" in case
+        assert "expect_primary" in case
+
+
+# ── Facet validation ──────────────────────────────────────────────────────────
+
+
+class TestValidateRequest:
+    def test_known_facets_pass(self):
+        tax = _taxonomy()
+        facets = RequestFacets(task_types=["review"], output_artifacts=["security-review"])
+        assert validate_request(facets, tax) == []
+
+    def test_unknown_task_type_rejected(self):
+        tax = _taxonomy()
+        facets = RequestFacets(task_types=["frobnicate"])
+        errors = validate_request(facets, tax)
+        assert errors and "frobnicate" in errors[0]
+
+    def test_unknown_artifact_rejected(self):
+        tax = _taxonomy()
+        facets = RequestFacets(output_artifacts=["hologram"])
+        errors = validate_request(facets, tax)
+        assert errors and "hologram" in errors[0]
+
+    def test_route_request_rejects_unknown_facet(self):
+        # End-to-end: an invalid facet fails before any scoring.
+        index = {"patterns": {"skills": []}}
+        facets = RequestFacets(task_types=["frobnicate"])
+        result = route_request(REPO_ROOT, index, facets)
+        assert result.get("error") == "invalid request facets"
+
+    def test_empty_request_rejected(self):
+        index = {"patterns": {"skills": []}}
+        result = route_request(REPO_ROOT, index, RequestFacets())
+        assert result.get("error") == "empty request"
+
+
+# ── Path-traversal guard (consensus condition) ─────────────────────────────────
+
+
+class TestPathGuard:
+    def test_absolute_path_rejected(self):
+        assert _safe_repo_relative(REPO_ROOT, "/etc/passwd") is None
+
+    def test_parent_traversal_rejected(self):
+        assert _safe_repo_relative(REPO_ROOT, "../../etc/passwd") is None
+        assert _safe_repo_relative(REPO_ROOT, "skills/../../secret") is None
+
+    def test_empty_rejected(self):
+        assert _safe_repo_relative(REPO_ROOT, "") is None
+
+    def test_valid_repo_relative_accepted(self):
+        resolved = _safe_repo_relative(REPO_ROOT, "schemas/taxonomy.yaml")
+        assert resolved is not None and resolved.exists()
+
+    def test_symlink_escape_rejected(self, tmp_path):
+        # A symlink whose name has no ".." but points outside the root must be
+        # caught by the resolved.relative_to() re-check.
+        outside = tmp_path / "outside.txt"
+        outside.write_text("secret")
+        root = tmp_path / "repo"
+        root.mkdir()
+        link = root / "link.txt"
+        try:
+            link.symlink_to(outside)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unsupported on this platform")
+        assert _safe_repo_relative(root, "link.txt") is None
+
+    def test_load_candidates_skips_traversal_path(self, tmp_path):
+        # A malicious INDEX entry with an absolute path must not be read.
+        index = {"patterns": {"skills": [{"id": "evil", "type": "skill", "path": "/etc/passwd", "routing": {}}]}}
+        cands = load_candidates(tmp_path, index)
+        evil = next(c for c in cands if c.id == "evil")
+        # It is still listed (from INDEX metadata) but no file was read → no _triggers from disk.
+        assert evil.routing.get("_triggers") == []
+
+
+# ── Scoring semantics ──────────────────────────────────────────────────────────
+
+
+class TestScoring:
+    def _cand(self, **routing):
+        r = dict(routing)
+        r.setdefault("_triggers", [])
+        r.setdefault("_deprecated", False)
+        return Candidate(
+            id="x", type="skill", status="experimental", path="skills/x/SKILL.md", collection=None, routing=r
+        )
+
+    def test_output_match_scores_highest(self):
+        c = self._cand(output_artifacts=["security-review"])
+        score_candidate(c, RequestFacets(output_artifacts=["security-review"]))
+        assert c.score >= 40
+
+    def test_deprecated_hard_excluded(self):
+        c = self._cand(output_artifacts=["security-review"])
+        c.routing["_deprecated"] = True
+        score_candidate(c, RequestFacets(output_artifacts=["security-review"]))
+        assert c.excluded_reason == "deprecated"
+        assert c.score < 0
+
+    def test_avoid_when_hard_excluded(self):
+        c = self._cand(output_artifacts=["security-review"], avoid_when=["about a CI workflow"])
+        score_candidate(
+            c, RequestFacets(output_artifacts=["security-review"], keywords=["this is about a CI workflow"])
+        )
+        assert c.excluded_reason == "matched avoid_when"
+
+    def test_delegation_demotes_candidate(self):
+        a = self._cand(output_artifacts=["security-review"], delegates=[{"pattern": "b", "when": "ci workflow"}])
+        a.id = "a"
+        b = self._cand(output_artifacts=["security-review"])
+        b.id = "b"
+        facets = RequestFacets(output_artifacts=["security-review"], keywords=["audit this ci workflow"])
+        for c in (a, b):
+            score_candidate(c, facets)
+        apply_delegation([a, b], facets)
+        assert a.excluded_reason and "delegated to b" in a.excluded_reason
+
+
+# ── Route minimality ──────────────────────────────────────────────────────────
+
+
+class TestRouteAssembly:
+    def test_supporting_only_adds_distinct_outputs(self):
+        # Two candidates with the SAME output → the second is not "supporting".
+        def mk(pid, outputs, score):
+            r = {"output_artifacts": outputs, "_triggers": [], "_deprecated": False}
+            c = Candidate(
+                id=pid, type="skill", status="experimental", path=f"skills/{pid}/SKILL.md", collection=None, routing=r
+            )
+            c.score = score
+            return c
+
+        a = mk("a", ["security-review"], 40)
+        b = mk("b", ["security-review"], 30)
+        route = build_route([a, b], RequestFacets(output_artifacts=["security-review"]))
+        assert route["primary"]["id"] == "a"
+        assert route["supporting"] == []  # b adds no distinct output
+
+
+class TestPhraseHit:
+    """Regression for the short-substring false-positive guard (#239 review)."""
+
+    def test_short_token_requires_word_boundary(self):
+        from scripts.route_patterns import _phrase_hit
+
+        # "ci" must NOT match "decision" (substring) — word-boundary guarded.
+        assert _phrase_hit(["make a decision"], ["ci"]) is False
+        # but DOES match "ci workflow" on a boundary.
+        assert _phrase_hit(["audit this ci workflow"], ["ci"]) is True
+
+    def test_multiword_phrase_substring_ok(self):
+        from scripts.route_patterns import _phrase_hit
+
+        assert _phrase_hit(["please run the full qa process now"], ["qa process"]) is True
+
+    def test_empty_inputs_never_match(self):
+        from scripts.route_patterns import _phrase_hit
+
+        assert _phrase_hit([], ["anything"]) is False
+        assert _phrase_hit(["anything"], []) is False
+        assert _phrase_hit([""], [""]) is False
+
+
+class TestTaxonomyFailOpenDocumented:
+    """Documents the intentional fail-open when taxonomy.yaml is absent (#239 review)."""
+
+    def test_absent_taxonomy_allows_any_facet(self):
+        # With no vocab, validation cannot reject — this is a known, accepted
+        # posture for a repo-local tool (the file is always present in CI).
+        empty_tax = {"task_types": set(), "artifact_types": set()}
+        facets = RequestFacets(task_types=["frobnicate"], output_artifacts=["hologram"])
+        assert validate_request(facets, empty_tax) == []


### PR DESCRIPTION
Closes #239. Part of epic #237. Builds on PR1 (#245, merged).

Adds the **`pattern-router`** — the model classifies a request into taxonomy facets, and a **deterministic script** does filter → score → delegate → rank → explain. Routing policy lives in metadata; the router only *selects* (it does not execute), and it chooses the **smallest appropriate route** (workflow > skill > prompt).

## What changed
- **`scripts/route_patterns.py`** — pure deterministic engine.
  - Scoring: output+40, task+30, input+15, alias/trigger+10, collection+5, recommended+5; hard exclusions `avoid_when`/delegated/deprecated = −100.
  - **Over-selection guard:** a candidate with no substantive facet/keyword match scores 0 and is dropped — the router will **not** select every skill sharing a category (regression-tested).
  - **Security:** repo-relative path guard rejects absolute/`..` paths from INDEX; `validate_request` rejects unknown task/artifact facets; `yaml.safe_load` throughout; no regex-DoS.
  - `_phrase_hit` short-token **word-boundary guard** (a 2-char alias like `"ci"` no longer matches `"decision"`).
- **`.agents/skills/meta/pattern-router/SKILL.md`** — the router as a `meta` skill: states policy + procedure, delegates the decision to the script (no handcrafted decision tree in prose).
- **`scripts/tests/router-cases.yaml` + `test_route_patterns.py`** — 12-case data-driven regression suite (exact / neighboring-ambiguous / composite / negative / workflow-vs-skill / deprecated-alias / **does-not-select-whole-category**) + unit tests for the path guard (incl. symlink escape), facet rejection, scoring, delegation, route minimality, phrase-hit false-positive guard, and taxonomy fail-open.
- **`docs/AI-AGENT-GUIDE.md`** — selection now points at the router; keyword matching marked legacy; security lanes flagged as moving into `routing.delegates` in PR3 (#240).

## Verification
- `make validate` ✓ · `make generate-check` ✓ · markdownlint ✓ · **226 tests pass** ✓
- Security/correctness subagent review: **clean, no blockers**; the one MEDIUM finding (`_phrase_hit` false positives) is fixed in this PR.

## Notes
Live patterns don't carry `routing` blocks yet (that's PR3 #240), so the suite pins to inline fixtures for stability. The router against the live INDEX correctly returns "no match" until PR3 classifies patterns. **Human-review-gated; not admin-merging.**

Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>