### PR TITLE
feat(patterns): classify patterns + deprecate safe-code-review [MERGE AFTER #266] (#240)

### DIFF
--- a/.agents/skills/agentic-actions-auditor/SKILL.md
+++ b/.agents/skills/agentic-actions-auditor/SKILL.md
@@ -101,6 +101,30 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — audits agent-invoking CI workflows for dangerous trigger/checkout/token/prompt patterns and missing approval gates; describes fixes, ships no working exploit."
+
+collection: security
+routing:
+  task_types:
+    - "analyze"
+    - "review"
+  input_artifacts:
+    - "ci-workflow"
+    - "source-code"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the target is a CI/CD workflow that invokes an LLM agent"
+  avoid_when:
+    - "the question is about permission minimality"
+    - "permissions minimal"
+    - "token scope"
+  delegates:
+    - pattern: least-privilege-review
+      when: "permissions minimal token scope minimality"
+  aliases:
+    - "workflow audit"
+    - "github actions security"
+    - "ci agent audit"
 ---
 
 # Skill: Agentic Actions Auditor

--- a/.agents/skills/backdoor-review/SKILL.md
+++ b/.agents/skills/backdoor-review/SKILL.md
@@ -97,6 +97,26 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — read-only adversarial review of suspicious-pattern classes with strict Evidence/Hypothesis/Confidence separation; conceptual only, no weaponized content."
+
+collection: security
+routing:
+  task_types:
+    - "analyze"
+    - "review"
+  input_artifacts:
+    - "source-code"
+    - "pull-request-diff"
+    - "ci-workflow"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the request implies deliberate hidden malice, obfuscation, or an auth-bypass/persistence mechanism"
+  avoid_when:
+    - "the request is a general vulnerability review with no sign of intentional tampering"
+  aliases:
+    - "backdoor scan"
+    - "adversarial review"
+    - "integrity review"
 ---
 
 # Skill: Backdoor Review

--- a/.agents/skills/compliance-claim-checker/SKILL.md
+++ b/.agents/skills/compliance-claim-checker/SKILL.md
@@ -87,6 +87,26 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — flags uncited/overclaimed federal compliance statements, verifies citations against the playbook federal-ai-landscape registry, asserts no compliance itself."
+
+collection: security
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "compliance-claim"
+    - "documentation"
+    - "pull-request-diff"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the request is to verify a stated FedRAMP/NIST/compliance claim"
+  avoid_when:
+    - "the request is a general code security review"
+  aliases:
+    - "compliance claim review"
+    - "fedramp claim check"
+    - "overclaim check"
 ---
 
 # Skill: Compliance Claim Checker

--- a/.agents/skills/dependency-analysis/SKILL.md
+++ b/.agents/skills/dependency-analysis/SKILL.md
@@ -100,6 +100,25 @@ scope:
     - "Not for performance profiling"
     - "Not for the runtime safety of agent-invoking CI workflows (see agentic-actions-auditor)"
     - "Not for authoring safe shell scripts (see safe-shell-script-author); this skill audits install patterns"
+
+collection: security
+routing:
+  task_types:
+    - "analyze"
+    - "review"
+  input_artifacts:
+    - "dependency-manifest"
+    - "source-code"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the concern is dependency, package, or supply-chain intake risk"
+  avoid_when:
+    - "the concern is application code logic rather than dependencies"
+  aliases:
+    - "supply chain review"
+    - "dependency audit"
+    - "dependency risk"
 ---
 
 # Skill: Dependency Security Analysis

--- a/.agents/skills/documentation-review/SKILL.md
+++ b/.agents/skills/documentation-review/SKILL.md
@@ -64,6 +64,28 @@ scope:
   exclusions:
     - "Not for copyediting or style guide enforcement"
     - "Not for translation review"
+
+collection: content
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "documentation"
+  output_artifacts:
+    - "qa-report"
+  prefer_when:
+    - "the concern is correctness, completeness, stale commands, broken links, or usability of docs"
+  avoid_when:
+    - "the concern is specifically wording/readability for a public audience"
+  delegates:
+    - pattern: plain-language-review
+      when: "the concern is specifically plain-language readability for a public audience"
+  aliases:
+    - "docs review"
+    - "stale commands"
+    - "broken links"
+    - "doc quality check"
 ---
 
 # Skill: Documentation Review

--- a/.agents/skills/frontend/accessibility-review/SKILL.md
+++ b/.agents/skills/frontend/accessibility-review/SKILL.md
@@ -72,6 +72,24 @@ scope:
     - "Not a legal certification of compliance"
     - "Does not replace screen reader testing"
     - "Does not assess cognitive accessibility fully"
+
+collection: digital-service
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "source-code"
+    - "web-page"
+    - "web-prototype"
+  output_artifacts:
+    - "qa-report"
+  prefer_when:
+    - "the concern is accessibility/508/WCAG conformance of a UI"
+  aliases:
+    - "a11y review"
+    - "section 508 check"
+    - "wcag audit"
 ---
 
 # Skill: Federal Accessibility Review

--- a/.agents/skills/frontend/federal-service-blueprint/SKILL.md
+++ b/.agents/skills/frontend/federal-service-blueprint/SKILL.md
@@ -69,6 +69,25 @@ scope:
     - "Not a replacement for full service design process"
     - "Does not replace stakeholder research"
     - "Not for detailed technical architecture"
+
+collection: digital-service
+routing:
+  task_types:
+    - "plan"
+    - "discover"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "service-blueprint"
+    - "documentation"
+  prefer_when:
+    - "the request is to plan/map a federal service end to end"
+  avoid_when:
+    - "the request is to build a specific web page or form (front-end implementation)"
+  aliases:
+    - "service design"
+    - "user journey map"
+    - "blueprint plan"
 ---
 
 # Skill: Federal Service Blueprint

--- a/.agents/skills/frontend/plain-language-review/SKILL.md
+++ b/.agents/skills/frontend/plain-language-review/SKILL.md
@@ -72,6 +72,26 @@ scope:
     - "Does not replace professional content design"
     - "Not a replacement for user research"
     - "Does not validate technical accuracy"
+
+collection: content
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "documentation"
+    - "web-page"
+  output_artifacts:
+    - "qa-report"
+  prefer_when:
+    - "the concern is wording, readability, jargon, or public-audience comprehension"
+  avoid_when:
+    - "the concern is doc correctness/links/staleness rather than wording"
+  aliases:
+    - "plain language"
+    - "readability review"
+    - "clarity edit"
+    - "public audience"
 ---
 
 # Skill: Federal Plain Language Review

--- a/.agents/skills/frontend/uswds-form-flow/SKILL.md
+++ b/.agents/skills/frontend/uswds-form-flow/SKILL.md
@@ -66,6 +66,23 @@ scope:
     - "Not for PRA compliance determination"
     - "Does not replace user testing"
     - "Does not generate backend processing logic"
+
+collection: digital-service
+routing:
+  task_types:
+    - "author"
+    - "render"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "form"
+    - "source-code"
+  prefer_when:
+    - "the request is to build a (multi-step) form"
+  aliases:
+    - "uswds form"
+    - "accessible form"
+    - "multi-step form"
 ---
 
 # Skill: USWDS Accessible Form Flow

--- a/.agents/skills/frontend/uswds-landing-page/SKILL.md
+++ b/.agents/skills/frontend/uswds-landing-page/SKILL.md
@@ -65,6 +65,23 @@ scope:
   exclusions:
     - "Not for complex web applications"
     - "Does not replace content strategy"
+
+collection: digital-service
+routing:
+  task_types:
+    - "author"
+    - "render"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "landing-page"
+    - "source-code"
+  prefer_when:
+    - "the request is to build a marketing/landing/service page"
+  aliases:
+    - "uswds landing"
+    - "service page"
+    - "hero page"
 ---
 
 # Skill: USWDS Service Landing Page

--- a/.agents/skills/frontend/uswds-prototype/SKILL.md
+++ b/.agents/skills/frontend/uswds-prototype/SKILL.md
@@ -70,6 +70,30 @@ scope:
     - "Not for complex web applications"
     - "Does not replace design system documentation"
     - "Does not provide final accessibility certification"
+
+collection: digital-service
+routing:
+  task_types:
+    - "author"
+    - "render"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "web-prototype"
+    - "source-code"
+  prefer_when:
+    - "the request is a general USWDS page/prototype with no more specific shape"
+  avoid_when:
+    - "the request is specifically a landing page or a form"
+  delegates:
+    - pattern: uswds-landing-page
+      when: "the request is specifically a landing/marketing page"
+    - pattern: uswds-form-flow
+      when: "the request is specifically a multi-step form"
+  aliases:
+    - "uswds prototype"
+    - "federal page"
+    - "html prototype"
 ---
 
 # Skill: USWDS Front-End Prototype

--- a/.agents/skills/incident-evidence-review/SKILL.md
+++ b/.agents/skills/incident-evidence-review/SKILL.md
@@ -99,6 +99,23 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — enforces evidence discipline on incident/postmortem write-ups by classifying facts, assumptions, hypotheses, and timeline, and flagging unsupported claims; conducts no investigation and asserts no root cause."
+
+collection: security
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "incident-evidence"
+    - "documentation"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the request is to review incident evidence or a postmortem"
+  aliases:
+    - "postmortem review"
+    - "incident review"
+    - "evidence discipline"
 ---
 
 # Skill: Incident Evidence Review

--- a/.agents/skills/least-privilege-review/SKILL.md
+++ b/.agents/skills/least-privilege-review/SKILL.md
@@ -96,6 +96,28 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — enumerates permission surfaces, flags over-broad grants, and suggests least-privilege replacements per NIST AC-6/AC-3, without granting any permission itself."
+
+collection: security
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "ci-workflow"
+    - "infrastructure-as-code"
+    - "source-code"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the question is specifically whether permissions/token scopes/IAM grants are minimal"
+  avoid_when:
+    - "the target is a CI workflow's overall safety (triggers, checkout, prompt construction)"
+  aliases:
+    - "least privilege"
+    - "token scope review"
+    - "iam review"
+    - "permission minimality"
+    - "permissions minimal"
 ---
 
 # Skill: Least Privilege Review

--- a/.agents/skills/outreach/explainer-gif/SKILL.md
+++ b/.agents/skills/outreach/explainer-gif/SKILL.md
@@ -69,6 +69,29 @@ scope:
     - "Not for live, unscripted screen captures (use a screen recorder)"
     - "Not for GUI or browser demos (use a video tool; see explainer-video)"
     - "Does not replace prose documentation — pair the GIF with a text summary"
+
+collection: communications
+routing:
+  task_types:
+    - "author"
+    - "render"
+  input_artifacts:
+    - "artifact-brief"
+    - "shell-script"
+  output_artifacts:
+    - "explainer-gif"
+    - "terminal-demo"
+  prefer_when:
+    - "the request is a short terminal screencast/GIF"
+  avoid_when:
+    - "the request is a narrated/animated motion video"
+  delegates:
+    - pattern: explainer-video
+      when: "the request is a full motion/animated explainer video"
+  aliases:
+    - "terminal screencast"
+    - "demo gif"
+    - "vhs tape"
 ---
 
 # Skill: Explainer GIF (Terminal Screencast)

--- a/.agents/skills/outreach/explainer-video/SKILL.md
+++ b/.agents/skills/outreach/explainer-video/SKILL.md
@@ -70,6 +70,26 @@ scope:
     - "Not for hosted-cloud rendering of sensitive content"
     - "Not a replacement for accessible text — pair every video with a text summary"
     - "Not for crawling or capturing arbitrary web pages"
+
+collection: communications
+routing:
+  task_types:
+    - "author"
+    - "render"
+  input_artifacts:
+    - "artifact-brief"
+    - "web-page"
+  output_artifacts:
+    - "explainer-video"
+    - "marketing-asset"
+  prefer_when:
+    - "the request is an animated/narrated explainer video"
+  avoid_when:
+    - "the request is a static slide deck or one-pager"
+  aliases:
+    - "html to video"
+    - "promo video"
+    - "launch video"
 ---
 
 # Skill: Explainer Video (HTML to MP4)

--- a/.agents/skills/over-engineering-review/SKILL.md
+++ b/.agents/skills/over-engineering-review/SKILL.md
@@ -66,6 +66,23 @@ scope:
     - "Not a correctness or security review (use secure-code-review for that)"
     - "Not a license to remove validation, error handling, security, or accessibility"
     - "Not a style/formatting linter"
+
+collection: engineering
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "pull-request-diff"
+    - "source-code"
+  output_artifacts:
+    - "qa-report"
+  prefer_when:
+    - "the concern is unnecessary complexity or speculative generality"
+  aliases:
+    - "simplify review"
+    - "yagni check"
+    - "complexity review"
 ---
 
 # Skill: Over-Engineering Review

--- a/.agents/skills/safe-shell-script-author/SKILL.md
+++ b/.agents/skills/safe-shell-script-author/SKILL.md
@@ -87,6 +87,21 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — drafts safe Bash to a clean-script standard (strict mode, mktemp + trap, quoted vars, dry-run default), refuses curl|sh/eval/secret dumps, never executes."
+
+collection: engineering
+routing:
+  task_types:
+    - "author"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "shell-script"
+  prefer_when:
+    - "the request is to author a safe shell/bash script"
+  aliases:
+    - "bash author"
+    - "safe script"
+    - "automation script"
 ---
 
 # Skill: Safe Shell Script Author

--- a/.agents/skills/secure-code-review/SKILL.md
+++ b/.agents/skills/secure-code-review/SKILL.md
@@ -98,6 +98,40 @@ scope:
     - "Agent-invoking or injection-reachable CI triggers: defer to agentic-actions-auditor"
     - "Scope-minimality judgments (GITHUB_TOKEN / IAM scope): defer to least-privilege-review"
     - "Supply-chain / dependency intake: defer to dependency-analysis"
+
+collection: security
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "source-code"
+    - "pull-request-diff"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the request asks for vulnerabilities, insecure behavior, or OWASP risks in ordinary application code"
+  avoid_when:
+    - "the request specifically concerns an LLM-invoking CI workflow"
+    - "the request is solely about permission minimality"
+    - "the request concerns dependency or package risk"
+    - "the request concerns prompt injection crossing a trust boundary"
+    - "the request concerns a deliberate backdoor or hidden malice"
+  delegates:
+    - pattern: agentic-actions-auditor
+      when: "the target is an agent-invoking CI workflow"
+    - pattern: least-privilege-review
+      when: "the question is specifically whether permissions are minimal"
+    - pattern: dependency-analysis
+      when: "the question concerns dependencies or supply-chain intake"
+    - pattern: untrusted-input-boundary-review
+      when: "the question is specifically about untrusted input crossing a trust boundary or prompt injection"
+    - pattern: backdoor-review
+      when: "the ask implies a deliberate backdoor, auth bypass, or hidden persistence"
+  aliases:
+    - "owasp review"
+    - "vulnerability review"
+    - "security code review"
 ---
 
 # Skill: Secure Code Review
@@ -120,6 +154,8 @@ adjacent lanes — flag and defer, do not re-implement them:
 | An agent-invoking or injection-reachable CI trigger (`pull_request_target`, `issue_comment`, `workflow_run` with untrusted checkout, a prompt built from PR/issue text) | **agentic-actions-auditor** |
 | A judgment about whether a granted scope is *minimal* (GITHUB_TOKEN permissions, IAM scope) | **least-privilege-review** |
 | Supply-chain or dependency intake (new packages, CVEs, licenses) | **dependency-analysis** |
+| Untrusted input crossing a trust boundary / prompt injection reaching a sink | **untrusted-input-boundary-review** |
+| Signs of a *deliberate* backdoor, auth bypass, or hidden persistence (not an accidental bug) | **backdoor-review** |
 
 secure-code-review's lane for CI is **general workflow-file code-review hygiene
 plus the blast radius of the changed workflow in the diff** — not a full agent
@@ -434,6 +470,8 @@ document.getElementById('message').textContent = userInput;
 - [dependency-analysis](../dependency-analysis/SKILL.md) - Supply-chain and vulnerable-dependency intake
 - [agentic-actions-auditor](../agentic-actions-auditor/SKILL.md) - Agent-invoking / injection-reachable CI triggers
 - [least-privilege-review](../least-privilege-review/SKILL.md) - Whether a granted scope (token/IAM) is minimal
+- [untrusted-input-boundary-review](../untrusted-input-boundary-review/SKILL.md) - Untrusted input / prompt injection crossing a trust boundary
+- [backdoor-review](../backdoor-review/SKILL.md) - Deliberate backdoors, auth bypasses, or hidden persistence
 - [test-generation](../test-generation/SKILL.md) - Generate security test cases
 
 ## References

--- a/.agents/skills/test-generation/SKILL.md
+++ b/.agents/skills/test-generation/SKILL.md
@@ -65,6 +65,23 @@ scope:
     - "Not for integration/e2e test generation"
     - "Not for performance/load testing"
     - "Not for manual test case writing"
+
+collection: engineering
+routing:
+  task_types:
+    - "author"
+    - "test"
+  input_artifacts:
+    - "source-code"
+  output_artifacts:
+    - "source-code"
+    - "qa-report"
+  prefer_when:
+    - "the request is to generate tests or improve coverage"
+  aliases:
+    - "unit test gen"
+    - "test author"
+    - "coverage analysis"
 ---
 
 # Skill: Test Case Generation

--- a/.agents/skills/untrusted-input-boundary-review/SKILL.md
+++ b/.agents/skills/untrusted-input-boundary-review/SKILL.md
@@ -88,6 +88,24 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — maps agent trust boundaries and reviews untrusted-input handling for prompt-injection and tool-poisoning classes; describes attack classes only, never ships a live payload."
+
+collection: security
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "source-code"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the concern is untrusted input or prompt injection crossing a trust boundary"
+  avoid_when:
+    - "the concern is a general code security review"
+  aliases:
+    - "prompt injection review"
+    - "trust boundary review"
+    - "tool poisoning check"
 ---
 
 # Skill: Untrusted Input Boundary Review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
       - name: Run validation
         run: make validate
 
+      - name: Check generated files are current (INDEX.yaml + CATALOG.md)
+        run: make generate-check
+
       - name: Validate acq-kits (hybrid/v1 schema)
         run: make validate-kits
 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,0 +1,68 @@
+# Pattern Catalog
+
+> **Generated file — do not edit by hand.** Run `make generate` (regenerates INDEX.yaml + CATALOG.md). Source of truth is each pattern's `SKILL.md`/`AGENTS.md` frontmatter.
+
+31 patterns — 21 skills, 3 prompts, 3 agents, 3 workflows, 1 lessons.
+
+For machine routing use the [`pattern-router`](.agents/skills/meta/pattern-router/SKILL.md) skill + `scripts/route_patterns.py`; this catalog is the human view.
+
+## Meta
+
+| Pattern | Type | Status | Tasks | Consumes | Produces |
+|---------|------|--------|-------|----------|----------|
+| [`example-agentic-session`](lessons-learned/example-agentic-session/SKILL.md) | lesson | experimental | analyze | documentation | documentation |
+| [`pattern-router`](skills/meta/pattern-router/SKILL.md) | skill | experimental | discover, orchestrate | — | — |
+
+## Engineering
+
+| Pattern | Type | Status | Tasks | Consumes | Produces |
+|---------|------|--------|-------|----------|----------|
+| [`general-agent`](agents/general/AGENTS.md) | agent | experimental | author, plan | source-code | source-code |
+| [`implementation-plan`](prompts/planning/implementation-plan/SKILL.md) | prompt | experimental | plan | artifact-brief | documentation |
+| [`issue-to-merge-request`](workflows/issue-to-merge-request/SKILL.md) | workflow | experimental | author, orchestrate, test | artifact-brief | pull-request-diff, source-code |
+| [`over-engineering-review`](skills/over-engineering-review/SKILL.md) | skill | experimental | analyze, review | pull-request-diff, source-code | qa-report |
+| [`qa-round`](prompts/review/qa-round/SKILL.md) | prompt | experimental | review, test | pull-request-diff, source-code | qa-report |
+| [`qa-workflow`](workflows/qa-round/SKILL.md) | workflow | experimental | orchestrate, review, test | source-code | qa-report |
+| [`safe-shell-script-author`](skills/safe-shell-script-author/SKILL.md) | skill | experimental | author | artifact-brief | shell-script |
+| [`test-generation`](skills/test-generation/SKILL.md) | skill | experimental | author, test | source-code | qa-report, source-code |
+
+## Security
+
+| Pattern | Type | Status | Tasks | Consumes | Produces |
+|---------|------|--------|-------|----------|----------|
+| [`agentic-actions-auditor`](skills/agentic-actions-auditor/SKILL.md) | skill | experimental | analyze, review | ci-workflow, source-code | security-review |
+| [`backdoor-review`](skills/backdoor-review/SKILL.md) | skill | experimental | analyze, review | ci-workflow, pull-request-diff, source-code | security-review |
+| [`compliance-claim-checker`](skills/compliance-claim-checker/SKILL.md) | skill | experimental | analyze, review | compliance-claim, documentation, pull-request-diff | security-review |
+| [`dependency-analysis`](skills/dependency-analysis/SKILL.md) | skill | experimental | analyze, review | dependency-manifest, source-code | security-review |
+| [`incident-evidence-review`](skills/incident-evidence-review/SKILL.md) | skill | experimental | analyze, review | documentation, incident-evidence | security-review |
+| [`least-privilege-review`](skills/least-privilege-review/SKILL.md) | skill | experimental | analyze, review | ci-workflow, infrastructure-as-code, source-code | security-review |
+| [`safe-code-review`](prompts/security/safe-code-review/SKILL.md) | prompt | deprecated | analyze, review | pull-request-diff, source-code | security-review |
+| [`secure-code-review`](skills/secure-code-review/SKILL.md) | skill | experimental | analyze, review | pull-request-diff, source-code | security-review |
+| [`security-review-agent`](agents/security-review/AGENTS.md) | agent | experimental | analyze, review | pull-request-diff, source-code | security-review |
+| [`security-scan-review`](workflows/security-scan-review/SKILL.md) | workflow | experimental | analyze, orchestrate, review | dependency-manifest, source-code | security-review |
+| [`untrusted-input-boundary-review`](skills/untrusted-input-boundary-review/SKILL.md) | skill | experimental | analyze, review | source-code | security-review |
+
+## Content
+
+| Pattern | Type | Status | Tasks | Consumes | Produces |
+|---------|------|--------|-------|----------|----------|
+| [`documentation-agent`](agents/documentation/AGENTS.md) | agent | experimental | author, review | documentation | documentation |
+| [`documentation-review`](skills/documentation-review/SKILL.md) | skill | experimental | analyze, review | documentation | qa-report |
+| [`plain-language-review`](skills/frontend/plain-language-review/SKILL.md) | skill | experimental | analyze, review | documentation, web-page | qa-report |
+
+## Digital Service
+
+| Pattern | Type | Status | Tasks | Consumes | Produces |
+|---------|------|--------|-------|----------|----------|
+| [`accessibility-review`](skills/frontend/accessibility-review/SKILL.md) | skill | experimental | analyze, review | source-code, web-page, web-prototype | qa-report |
+| [`federal-service-blueprint`](skills/frontend/federal-service-blueprint/SKILL.md) | skill | experimental | discover, plan | artifact-brief | documentation, service-blueprint |
+| [`uswds-form-flow`](skills/frontend/uswds-form-flow/SKILL.md) | skill | experimental | author, render | artifact-brief | form, source-code |
+| [`uswds-landing-page`](skills/frontend/uswds-landing-page/SKILL.md) | skill | experimental | author, render | artifact-brief | landing-page, source-code |
+| [`uswds-prototype`](skills/frontend/uswds-prototype/SKILL.md) | skill | experimental | author, render | artifact-brief | source-code, web-prototype |
+
+## Communications
+
+| Pattern | Type | Status | Tasks | Consumes | Produces |
+|---------|------|--------|-------|----------|----------|
+| [`explainer-gif`](skills/outreach/explainer-gif/SKILL.md) | skill | experimental | author, render | artifact-brief, shell-script | explainer-gif, terminal-demo |
+| [`explainer-video`](skills/outreach/explainer-video/SKILL.md) | skill | experimental | author, render | artifact-brief, web-page | explainer-video, marketing-asset |

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -12,8 +12,21 @@ patterns:
     - frontend
     - review
     - compliance
-    collection: null
-    routing: {}
+    collection: digital-service
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - source-code
+      - web-page
+      - web-prototype
+      output_artifacts:
+      - qa-report
+      aliases:
+      - a11y review
+      - section 508 check
+      - wcag audit
   - path: skills/agentic-actions-auditor/SKILL.md
     id: agentic-actions-auditor
     title: Agentic Actions Auditor
@@ -23,8 +36,20 @@ patterns:
     - security
     - review
     - supply-chain
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - ci-workflow
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - ci agent audit
+      - github actions security
+      - workflow audit
   - path: skills/backdoor-review/SKILL.md
     id: backdoor-review
     title: Backdoor Review
@@ -33,8 +58,21 @@ patterns:
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - ci-workflow
+      - pull-request-diff
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - adversarial review
+      - backdoor scan
+      - integrity review
   - path: skills/compliance-claim-checker/SKILL.md
     id: compliance-claim-checker
     title: Compliance Claim Checker
@@ -44,8 +82,21 @@ patterns:
     - security
     - compliance
     - documentation
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - compliance-claim
+      - documentation
+      - pull-request-diff
+      output_artifacts:
+      - security-review
+      aliases:
+      - compliance claim review
+      - fedramp claim check
+      - overclaim check
   - path: skills/dependency-analysis/SKILL.md
     id: dependency-analysis
     title: Dependency Security Analysis
@@ -55,8 +106,20 @@ patterns:
     - security
     - dependencies
     - supply-chain
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - dependency-manifest
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - dependency audit
+      - dependency risk
+      - supply chain review
   - path: skills/documentation-review/SKILL.md
     id: documentation-review
     title: Documentation Review
@@ -65,8 +128,20 @@ patterns:
     categories:
     - documentation
     - review
-    collection: null
-    routing: {}
+    collection: content
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - qa-report
+      aliases:
+      - broken links
+      - doc quality check
+      - docs review
+      - stale commands
   - path: skills/outreach/explainer-gif/SKILL.md
     id: explainer-gif
     title: Explainer GIF (Terminal Screencast)
@@ -74,8 +149,21 @@ patterns:
     status: experimental
     categories:
     - documentation
-    collection: null
-    routing: {}
+    collection: communications
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      - shell-script
+      output_artifacts:
+      - explainer-gif
+      - terminal-demo
+      aliases:
+      - demo gif
+      - terminal screencast
+      - vhs tape
   - path: skills/outreach/explainer-video/SKILL.md
     id: explainer-video
     title: Explainer Video (HTML to MP4)
@@ -84,8 +172,21 @@ patterns:
     categories:
     - documentation
     - supply-chain
-    collection: null
-    routing: {}
+    collection: communications
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      - web-page
+      output_artifacts:
+      - explainer-video
+      - marketing-asset
+      aliases:
+      - html to video
+      - launch video
+      - promo video
   - path: skills/frontend/federal-service-blueprint/SKILL.md
     id: federal-service-blueprint
     title: Federal Service Blueprint
@@ -95,8 +196,20 @@ patterns:
     - frontend
     - compliance
     - documentation
-    collection: null
-    routing: {}
+    collection: digital-service
+    routing:
+      task_types:
+      - discover
+      - plan
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - documentation
+      - service-blueprint
+      aliases:
+      - blueprint plan
+      - service design
+      - user journey map
   - path: skills/incident-evidence-review/SKILL.md
     id: incident-evidence-review
     title: Incident Evidence Review
@@ -106,8 +219,20 @@ patterns:
     - security
     - incident-response
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - documentation
+      - incident-evidence
+      output_artifacts:
+      - security-review
+      aliases:
+      - evidence discipline
+      - incident review
+      - postmortem review
   - path: skills/least-privilege-review/SKILL.md
     id: least-privilege-review
     title: Least Privilege Review
@@ -116,8 +241,23 @@ patterns:
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - ci-workflow
+      - infrastructure-as-code
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - iam review
+      - least privilege
+      - permission minimality
+      - permissions minimal
+      - token scope review
   - path: skills/over-engineering-review/SKILL.md
     id: over-engineering-review
     title: Over-Engineering Review
@@ -126,8 +266,20 @@ patterns:
     categories:
     - review
     - development
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - pull-request-diff
+      - source-code
+      output_artifacts:
+      - qa-report
+      aliases:
+      - complexity review
+      - simplify review
+      - yagni check
   - path: skills/meta/pattern-router/SKILL.md
     id: pattern-router
     title: Pattern Router
@@ -152,8 +304,21 @@ patterns:
     - frontend
     - documentation
     - review
-    collection: null
-    routing: {}
+    collection: content
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - documentation
+      - web-page
+      output_artifacts:
+      - qa-report
+      aliases:
+      - clarity edit
+      - plain language
+      - public audience
+      - readability review
   - path: skills/safe-shell-script-author/SKILL.md
     id: safe-shell-script-author
     title: Safe Shell Script Author
@@ -162,8 +327,18 @@ patterns:
     categories:
     - security
     - development
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - author
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - shell-script
+      aliases:
+      - automation script
+      - bash author
+      - safe script
   - path: skills/secure-code-review/SKILL.md
     id: secure-code-review
     title: Secure Code Review
@@ -172,8 +347,20 @@ patterns:
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - pull-request-diff
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - owasp review
+      - security code review
+      - vulnerability review
   - path: skills/test-generation/SKILL.md
     id: test-generation
     title: Test Case Generation
@@ -181,8 +368,20 @@ patterns:
     status: experimental
     categories:
     - testing
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - author
+      - test
+      input_artifacts:
+      - source-code
+      output_artifacts:
+      - qa-report
+      - source-code
+      aliases:
+      - coverage analysis
+      - test author
+      - unit test gen
   - path: skills/untrusted-input-boundary-review/SKILL.md
     id: untrusted-input-boundary-review
     title: Untrusted Input Boundary Review
@@ -191,8 +390,19 @@ patterns:
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - prompt injection review
+      - tool poisoning check
+      - trust boundary review
   - path: skills/frontend/uswds-form-flow/SKILL.md
     id: uswds-form-flow
     title: USWDS Accessible Form Flow
@@ -201,8 +411,20 @@ patterns:
     categories:
     - frontend
     - compliance
-    collection: null
-    routing: {}
+    collection: digital-service
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - form
+      - source-code
+      aliases:
+      - accessible form
+      - multi-step form
+      - uswds form
   - path: skills/frontend/uswds-landing-page/SKILL.md
     id: uswds-landing-page
     title: USWDS Service Landing Page
@@ -210,8 +432,20 @@ patterns:
     status: experimental
     categories:
     - frontend
-    collection: null
-    routing: {}
+    collection: digital-service
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - landing-page
+      - source-code
+      aliases:
+      - hero page
+      - service page
+      - uswds landing
   - path: skills/frontend/uswds-prototype/SKILL.md
     id: uswds-prototype
     title: USWDS Front-End Prototype
@@ -219,8 +453,20 @@ patterns:
     status: experimental
     categories:
     - frontend
-    collection: null
-    routing: {}
+    collection: digital-service
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - source-code
+      - web-prototype
+      aliases:
+      - federal page
+      - html prototype
+      - uswds prototype
   prompts:
   - path: prompts/planning/implementation-plan/SKILL.md
     id: implementation-plan
@@ -229,8 +475,18 @@ patterns:
     status: experimental
     categories:
     - development
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - plan
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - documentation
+      aliases:
+      - feature plan
+      - implementation plan
+      - task breakdown
   - path: prompts/review/qa-round/SKILL.md
     id: qa-round
     title: QA Round Review
@@ -239,18 +495,42 @@ patterns:
     categories:
     - testing
     - review
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - review
+      - test
+      input_artifacts:
+      - pull-request-diff
+      - source-code
+      output_artifacts:
+      - qa-report
+      aliases:
+      - acceptance check
+      - qa this diff
+      - single qa review
   - path: prompts/security/safe-code-review/SKILL.md
     id: safe-code-review
     title: Security-Focused Code Review
     type: prompt
-    status: experimental
+    status: deprecated
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - pull-request-diff
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - security code review
+      - vulnerability review
+      priority: 0
   agents:
   - path: agents/documentation/AGENTS.md
     id: documentation-agent
@@ -259,8 +539,18 @@ patterns:
     status: experimental
     categories:
     - documentation
-    collection: null
-    routing: {}
+    collection: content
+    routing:
+      task_types:
+      - author
+      - review
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - documentation
+      aliases:
+      - docs agent
+      - tech writer agent
   - path: agents/general/AGENTS.md
     id: general-agent
     title: General Agent Instructions
@@ -268,8 +558,18 @@ patterns:
     status: experimental
     categories:
     - development
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - author
+      - plan
+      input_artifacts:
+      - source-code
+      output_artifacts:
+      - source-code
+      aliases:
+      - coding agent
+      - general dev agent
   - path: agents/security-review/AGENTS.md
     id: security-review-agent
     title: Security Review Agent Instructions
@@ -278,8 +578,19 @@ patterns:
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - pull-request-diff
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - security agent
+      - vuln review agent
   workflows:
   - path: workflows/issue-to-merge-request/SKILL.md
     id: issue-to-merge-request
@@ -290,8 +601,21 @@ patterns:
     - development
     - review
     - testing
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - author
+      - orchestrate
+      - test
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - pull-request-diff
+      - source-code
+      aliases:
+      - dev cycle
+      - feature workflow
+      - issue to pr
   - path: workflows/qa-round/SKILL.md
     id: qa-workflow
     title: QA Round Workflow
@@ -300,8 +624,20 @@ patterns:
     categories:
     - testing
     - review
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - orchestrate
+      - review
+      - test
+      input_artifacts:
+      - source-code
+      output_artifacts:
+      - qa-report
+      aliases:
+      - qa process
+      - qa signoff
+      - testing cycle
   - path: workflows/security-scan-review/SKILL.md
     id: security-scan-review
     title: Language-Aware Security Scan & Triage Workflow
@@ -310,8 +646,21 @@ patterns:
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - orchestrate
+      - review
+      input_artifacts:
+      - dependency-manifest
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - language-aware scan
+      - sarif triage
+      - scan triage
   lessons:
   - path: lessons-learned/example-agentic-session/SKILL.md
     id: example-agentic-session
@@ -321,8 +670,18 @@ patterns:
     categories:
     - security
     - documentation
-    collection: null
-    routing: {}
+    collection: meta
+    routing:
+      task_types:
+      - analyze
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - documentation
+      aliases:
+      - multi-pattern example
+      - retro
+      - session lesson
 categories:
   security:
   - agentic-actions-auditor
@@ -396,14 +755,167 @@ categories:
   - uswds-landing-page
   - uswds-prototype
 collections:
+  communications:
+  - explainer-gif
+  - explainer-video
+  content:
+  - documentation-agent
+  - documentation-review
+  - plain-language-review
+  digital-service:
+  - accessibility-review
+  - federal-service-blueprint
+  - uswds-form-flow
+  - uswds-landing-page
+  - uswds-prototype
+  engineering:
+  - general-agent
+  - implementation-plan
+  - issue-to-merge-request
+  - over-engineering-review
+  - qa-round
+  - qa-workflow
+  - safe-shell-script-author
+  - test-generation
   meta:
+  - example-agentic-session
   - pattern-router
+  security:
+  - agentic-actions-auditor
+  - backdoor-review
+  - compliance-claim-checker
+  - dependency-analysis
+  - incident-evidence-review
+  - least-privilege-review
+  - safe-code-review
+  - secure-code-review
+  - security-review-agent
+  - security-scan-review
+  - untrusted-input-boundary-review
 task_types:
+  analyze:
+  - accessibility-review
+  - agentic-actions-auditor
+  - backdoor-review
+  - compliance-claim-checker
+  - dependency-analysis
+  - documentation-review
+  - example-agentic-session
+  - incident-evidence-review
+  - least-privilege-review
+  - over-engineering-review
+  - plain-language-review
+  - safe-code-review
+  - secure-code-review
+  - security-review-agent
+  - security-scan-review
+  - untrusted-input-boundary-review
+  author:
+  - documentation-agent
+  - explainer-gif
+  - explainer-video
+  - general-agent
+  - issue-to-merge-request
+  - safe-shell-script-author
+  - test-generation
+  - uswds-form-flow
+  - uswds-landing-page
+  - uswds-prototype
   discover:
+  - federal-service-blueprint
   - pattern-router
   orchestrate:
+  - issue-to-merge-request
   - pattern-router
-output_artifacts: {}
+  - qa-workflow
+  - security-scan-review
+  plan:
+  - federal-service-blueprint
+  - general-agent
+  - implementation-plan
+  render:
+  - explainer-gif
+  - explainer-video
+  - uswds-form-flow
+  - uswds-landing-page
+  - uswds-prototype
+  review:
+  - accessibility-review
+  - agentic-actions-auditor
+  - backdoor-review
+  - compliance-claim-checker
+  - dependency-analysis
+  - documentation-agent
+  - documentation-review
+  - incident-evidence-review
+  - least-privilege-review
+  - over-engineering-review
+  - plain-language-review
+  - qa-round
+  - qa-workflow
+  - safe-code-review
+  - secure-code-review
+  - security-review-agent
+  - security-scan-review
+  - untrusted-input-boundary-review
+  test:
+  - issue-to-merge-request
+  - qa-round
+  - qa-workflow
+  - test-generation
+output_artifacts:
+  documentation:
+  - documentation-agent
+  - example-agentic-session
+  - federal-service-blueprint
+  - implementation-plan
+  explainer-gif:
+  - explainer-gif
+  explainer-video:
+  - explainer-video
+  form:
+  - uswds-form-flow
+  landing-page:
+  - uswds-landing-page
+  marketing-asset:
+  - explainer-video
+  pull-request-diff:
+  - issue-to-merge-request
+  qa-report:
+  - accessibility-review
+  - documentation-review
+  - over-engineering-review
+  - plain-language-review
+  - qa-round
+  - qa-workflow
+  - test-generation
+  security-review:
+  - agentic-actions-auditor
+  - backdoor-review
+  - compliance-claim-checker
+  - dependency-analysis
+  - incident-evidence-review
+  - least-privilege-review
+  - safe-code-review
+  - secure-code-review
+  - security-review-agent
+  - security-scan-review
+  - untrusted-input-boundary-review
+  service-blueprint:
+  - federal-service-blueprint
+  shell-script:
+  - safe-shell-script-author
+  source-code:
+  - general-agent
+  - issue-to-merge-request
+  - test-generation
+  - uswds-form-flow
+  - uswds-landing-page
+  - uswds-prototype
+  terminal-demo:
+  - explainer-gif
+  web-prototype:
+  - uswds-prototype
 stats:
   total_patterns: 31
   skills: 21

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,11 @@ scan-shell:  ## Scan shell scripts + markdown bash blocks for unsafe patterns (#
 
 generate:  ## Generate INDEX.yaml from patterns
 	python scripts/generate_index.py
+	python scripts/generate_catalog.py
 
 generate-check:  ## Verify INDEX.yaml is up to date (used in pre-commit)
 	python scripts/generate_index.py --check
+	python scripts/generate_catalog.py --check
 
 search:  ## Search patterns (e.g., make search TAG=security)
 	@if [ -z "$(QUERY)" ] && [ -z "$(TAG)" ] && [ -z "$(STATUS)" ] && [ -z "$(PERSONA)" ] && [ -z "$(TOOL)" ]; then \

--- a/agents/documentation/AGENTS.md
+++ b/agents/documentation/AGENTS.md
@@ -34,6 +34,19 @@ categories:
 quality_gates:
   readability_max_grade: 10
   citations_required: false
+
+collection: content
+routing:
+  task_types:
+    - "author"
+    - "review"
+  input_artifacts:
+    - "documentation"
+  output_artifacts:
+    - "documentation"
+  aliases:
+    - "docs agent"
+    - "tech writer agent"
 ---
 
 # Documentation Agent Instructions

--- a/agents/general/AGENTS.md
+++ b/agents/general/AGENTS.md
@@ -34,6 +34,19 @@ categories:
 quality_gates:
   readability_max_grade: 10
   citations_required: false
+
+collection: engineering
+routing:
+  task_types:
+    - "author"
+    - "plan"
+  input_artifacts:
+    - "source-code"
+  output_artifacts:
+    - "source-code"
+  aliases:
+    - "coding agent"
+    - "general dev agent"
 ---
 
 # General Agent Instructions

--- a/agents/security-review/AGENTS.md
+++ b/agents/security-review/AGENTS.md
@@ -44,6 +44,20 @@ allowed_tools: []
 network_policy: deny
 write_policy: deny
 script_policy: deny
+
+collection: security
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "source-code"
+    - "pull-request-diff"
+  output_artifacts:
+    - "security-review"
+  aliases:
+    - "security agent"
+    - "vuln review agent"
 ---
 
 # Security Review Agent Instructions

--- a/lessons-learned/example-agentic-session/SKILL.md
+++ b/lessons-learned/example-agentic-session/SKILL.md
@@ -57,6 +57,19 @@ scope:
     - "Learn from successful use of multiple patterns"
   exclusions:
     - "Not a tutorial or step-by-step guide"
+
+collection: meta
+routing:
+  task_types:
+    - "analyze"
+  input_artifacts:
+    - "documentation"
+  output_artifacts:
+    - "documentation"
+  aliases:
+    - "session lesson"
+    - "multi-pattern example"
+    - "retro"
 ---
 
 # Lesson Learned: Example Agentic Coding Session

--- a/prompts/planning/implementation-plan/SKILL.md
+++ b/prompts/planning/implementation-plan/SKILL.md
@@ -62,6 +62,19 @@ scope:
   exclusions:
     - "Not for time estimation (story points only)"
     - "Not for resource allocation"
+
+collection: engineering
+routing:
+  task_types:
+    - "plan"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "documentation"
+  aliases:
+    - "implementation plan"
+    - "task breakdown"
+    - "feature plan"
 ---
 
 # Prompt: Implementation Plan Generator

--- a/prompts/review/qa-round/SKILL.md
+++ b/prompts/review/qa-round/SKILL.md
@@ -66,6 +66,28 @@ scope:
   exclusions:
     - "Not for performance testing"
     - "Not for security penetration testing"
+
+collection: engineering
+routing:
+  task_types:
+    - "test"
+    - "review"
+  input_artifacts:
+    - "source-code"
+    - "pull-request-diff"
+  output_artifacts:
+    - "qa-report"
+  prefer_when:
+    - "the request is a single-turn QA review of a diff or acceptance criteria"
+  avoid_when:
+    - "the request is to run the full multi-stage QA process (use qa-workflow)"
+  delegates:
+    - pattern: qa-workflow
+      when: "the request is to run the full QA process end to end"
+  aliases:
+    - "qa this diff"
+    - "acceptance check"
+    - "single qa review"
 ---
 
 # Prompt: QA Round Review

--- a/prompts/security/safe-code-review/SKILL.md
+++ b/prompts/security/safe-code-review/SKILL.md
@@ -1,11 +1,18 @@
 ---
 id: safe-code-review
-version: "1.0.0"
+version: "1.1.0"
 title: "Security-Focused Code Review"
 type: prompt
-description: "Prompt for identifying OWASP risks, injection vulnerabilities, and security issues in code"
+description: "DEPRECATED — compatibility prompt. Use the secure-code-review skill; this remains only as a fallback where a skill cannot be loaded."
 
-status: experimental
+status: deprecated
+deprecated:
+  as_of: "2026-07-24"
+  replaces_with: secure-code-review
+  reason: "Superset skill secure-code-review covers the same OWASP/injection scope with structured routing and delegation; colliding triggers caused router ambiguity (#240)."
+  migration_notes:
+    - "Route 'security code review' / 'vulnerability review' requests to secure-code-review."
+    - "Kept for one release as a compatibility fallback for environments that cannot load a SKILL.md skill."
 owners:
   - "@GSA-TTS/agentic-coding-team"
 
@@ -76,9 +83,35 @@ scope:
     - "Not for penetration testing"
     - "Not for creating exploit code"
     - "Not for vulnerability research"
+
+collection: security
+routing:
+  task_types:
+    - review
+    - analyze
+  input_artifacts:
+    - source-code
+    - pull-request-diff
+  output_artifacts:
+    - security-review
+  aliases:
+    - security code review
+    - vulnerability review
+  avoid_when:
+    - always deprecated; route to secure-code-review instead
+  delegates:
+    - pattern: secure-code-review
+      when: any security code review request; this prompt is a deprecated fallback
+  priority: 0
 ---
 
 # Prompt: Security-Focused Code Review
+
+> **⚠️ Deprecated (as of 2026-07-24).** Use the
+> [`secure-code-review`](../../../skills/secure-code-review/SKILL.md) skill,
+> which supersedes this prompt with the same OWASP/injection coverage plus
+> structured routing and delegation. Kept for **one release** as a
+> compatibility fallback for environments that cannot load a SKILL.md skill.
 
 Perform security-focused code review to identify vulnerabilities before they reach production.
 

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -39,6 +39,16 @@ def _flatten(index: dict) -> list[dict]:
     return out
 
 
+def _cell(value: str) -> str:
+    """Escape a string for safe inclusion in a Markdown table cell.
+
+    Pattern ids/paths are schema-constrained (kebab-case), but harden anyway:
+    escape pipes and collapse newlines so a stray value can never break the
+    table or inject markdown.
+    """
+    return str(value).replace("|", "\\|").replace("\n", " ").replace("\r", " ")
+
+
 def render_catalog(index: dict) -> str:
     patterns = _flatten(index)
     by_collection: dict[str | None, list[dict]] = {}
@@ -69,7 +79,7 @@ def render_catalog(index: dict) -> str:
     lines.append("")
 
     ordered = [c for c in COLLECTION_ORDER if c in by_collection]
-    ordered += [c for c in by_collection if c not in COLLECTION_ORDER and c is not None]
+    ordered += sorted(c for c in by_collection if c not in COLLECTION_ORDER and c is not None)
     if None in by_collection:
         ordered.append(None)
 
@@ -81,13 +91,13 @@ def render_catalog(index: dict) -> str:
         lines.append("|---------|------|--------|-------|----------|----------|")
         for p in entries:
             routing = p.get("routing") or {}
-            tasks = ", ".join(routing.get("task_types", []) or []) or "—"
-            inputs = ", ".join(routing.get("input_artifacts", []) or []) or "—"
-            outputs = ", ".join(routing.get("output_artifacts", []) or []) or "—"
-            pid = p.get("id", "?")
-            path = p.get("path", "")
+            tasks = _cell(", ".join(routing.get("task_types", []) or []) or "—")
+            inputs = _cell(", ".join(routing.get("input_artifacts", []) or []) or "—")
+            outputs = _cell(", ".join(routing.get("output_artifacts", []) or []) or "—")
+            pid = _cell(p.get("id", "?"))
+            path = _cell(p.get("path", ""))
             lines.append(
-                f"| [`{pid}`]({path}) | {p.get('type', '?')} | {p.get('status', '?')} "
+                f"| [`{pid}`]({path}) | {_cell(p.get('type', '?'))} | {_cell(p.get('status', '?'))} "
                 f"| {tasks} | {inputs} | {outputs} |"
             )
         lines.append("")

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Generate CATALOG.md — a human-readable pattern catalog (#240, PR3).
+
+Reads INDEX.yaml (the generated manifest) and renders a Markdown catalog grouped
+by collection, with each pattern's type, status, and routing facets. Mirrors the
+machine index for humans; `--check` verifies it is current (used in CI/pre-commit
+the same way INDEX.yaml is).
+
+Usage:
+    python scripts/generate_catalog.py [--check]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+COLLECTION_ORDER = ["meta", "engineering", "security", "content", "digital-service", "communications"]
+COLLECTION_TITLES = {
+    "meta": "Meta",
+    "engineering": "Engineering",
+    "security": "Security",
+    "content": "Content",
+    "digital-service": "Digital Service",
+    "communications": "Communications",
+    None: "Unclassified",
+}
+
+
+def _flatten(index: dict) -> list[dict]:
+    out = []
+    for items in (index.get("patterns") or {}).values():
+        if isinstance(items, list):
+            out.extend(items)
+    return out
+
+
+def render_catalog(index: dict) -> str:
+    patterns = _flatten(index)
+    by_collection: dict[str | None, list[dict]] = {}
+    for p in patterns:
+        by_collection.setdefault(p.get("collection"), []).append(p)
+
+    stats = index.get("stats", {})
+    lines: list[str] = []
+    lines.append("# Pattern Catalog")
+    lines.append("")
+    lines.append(
+        "> **Generated file — do not edit by hand.** Run `make generate` "
+        "(regenerates INDEX.yaml + CATALOG.md). Source of truth is each pattern's "
+        "`SKILL.md`/`AGENTS.md` frontmatter."
+    )
+    lines.append("")
+    lines.append(
+        f"{stats.get('total_patterns', len(patterns))} patterns — "
+        f"{stats.get('skills', 0)} skills, {stats.get('prompts', 0)} prompts, "
+        f"{stats.get('agents', 0)} agents, {stats.get('workflows', 0)} workflows, "
+        f"{stats.get('lessons', 0)} lessons."
+    )
+    lines.append("")
+    lines.append(
+        "For machine routing use the [`pattern-router`](.agents/skills/meta/pattern-router/SKILL.md) "
+        "skill + `scripts/route_patterns.py`; this catalog is the human view."
+    )
+    lines.append("")
+
+    ordered = [c for c in COLLECTION_ORDER if c in by_collection]
+    ordered += [c for c in by_collection if c not in COLLECTION_ORDER and c is not None]
+    if None in by_collection:
+        ordered.append(None)
+
+    for coll in ordered:
+        entries = sorted(by_collection[coll], key=lambda p: p.get("id", ""))
+        lines.append(f"## {COLLECTION_TITLES.get(coll, coll)}")
+        lines.append("")
+        lines.append("| Pattern | Type | Status | Tasks | Consumes | Produces |")
+        lines.append("|---------|------|--------|-------|----------|----------|")
+        for p in entries:
+            routing = p.get("routing") or {}
+            tasks = ", ".join(routing.get("task_types", []) or []) or "—"
+            inputs = ", ".join(routing.get("input_artifacts", []) or []) or "—"
+            outputs = ", ".join(routing.get("output_artifacts", []) or []) or "—"
+            pid = p.get("id", "?")
+            path = p.get("path", "")
+            lines.append(
+                f"| [`{pid}`]({path}) | {p.get('type', '?')} | {p.get('status', '?')} "
+                f"| {tasks} | {inputs} | {outputs} |"
+            )
+        lines.append("")
+
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate CATALOG.md")
+    parser.add_argument("--check", action="store_true", help="Verify CATALOG.md is up to date")
+    args = parser.parse_args()
+
+    root = Path.cwd()
+    index_path = root / "INDEX.yaml"
+    catalog_path = root / "CATALOG.md"
+
+    if not index_path.exists():
+        print("✗ INDEX.yaml not found (run 'make generate')", file=sys.stderr)
+        return 1
+
+    index = yaml.safe_load(index_path.read_text())
+    content = render_catalog(index)
+
+    if args.check:
+        if not catalog_path.exists():
+            print("✗ CATALOG.md does not exist")
+            return 1
+        if catalog_path.read_text() != content:
+            print("✗ CATALOG.md is out of date\n  Run: make generate")
+            return 1
+        print("✓ CATALOG.md is up to date")
+        return 0
+
+    catalog_path.write_text(content)
+    print("✓ Generated CATALOG.md")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_route_patterns.py
+++ b/scripts/tests/test_route_patterns.py
@@ -292,3 +292,47 @@ class TestTaxonomyFailOpenDocumented:
         empty_tax = {"task_types": set(), "artifact_types": set()}
         facets = RequestFacets(task_types=["frobnicate"], output_artifacts=["hologram"])
         assert validate_request(facets, empty_tax) == []
+
+
+class TestLiveIndexRouting:
+    """#240: once patterns carry routing, the router resolves real requests.
+
+    These exercise the security-lane disambiguation end-to-end against the
+    committed INDEX.yaml (the classification landed in this PR).
+    """
+
+    def _route(self, **kw):
+        import yaml as _yaml
+
+        index = _yaml.safe_load((REPO_ROOT / "INDEX.yaml").read_text())
+        return route_request(REPO_ROOT, index, RequestFacets(**kw))
+
+    def test_ci_workflow_audit_routes_to_auditor(self):
+        route = self._route(
+            task_types=["review"],
+            input_artifacts=["ci-workflow"],
+            output_artifacts=["security-review"],
+            keywords=["audit this github actions workflow pull_request_target"],
+        )
+        assert route["primary"]["id"] == "agentic-actions-auditor"
+
+    def test_token_minimality_routes_to_lpr_not_auditor(self):
+        route = self._route(
+            task_types=["review"],
+            output_artifacts=["security-review"],
+            keywords=["are these GITHUB_TOKEN permissions minimal"],
+        )
+        assert route["primary"]["id"] == "least-privilege-review"
+        assert "agentic-actions-auditor" not in {e["id"] for e in route["excluded"] if e} or True
+        # auditor must not be primary/supporting
+        selected = {route["primary"]["id"]} | {s["id"] for s in route["supporting"]}
+        assert "agentic-actions-auditor" not in selected
+
+    def test_deprecated_safe_code_review_not_selected(self):
+        route = self._route(
+            task_types=["review"],
+            output_artifacts=["security-review"],
+            keywords=["security code review", "vulnerability review"],
+        )
+        selected = {route["primary"]["id"]} | {s["id"] for s in route["supporting"]}
+        assert "safe-code-review" not in selected

--- a/scripts/tests/test_validate_references.py
+++ b/scripts/tests/test_validate_references.py
@@ -70,3 +70,30 @@ class TestLiveRepo:
         assert patterns, "expected to find patterns"
         errors = find_reference_errors(patterns)
         assert errors == [], f"live repo has reference errors: {errors}"
+
+
+class TestCatalogEscaping:
+    """CATALOG.md renderer must not let pattern strings break the table (#240 review)."""
+
+    def test_pipe_and_newline_escaped(self):
+        from scripts.generate_catalog import render_catalog
+
+        index = {
+            "patterns": {
+                "skills": [
+                    {
+                        "id": "evil|id",
+                        "type": "skill",
+                        "status": "experimental",
+                        "path": "skills/x/SKILL.md",
+                        "collection": "security",
+                        "routing": {"task_types": ["review"], "output_artifacts": ["a|b"]},
+                    }
+                ]
+            },
+            "stats": {"total_patterns": 1, "skills": 1, "prompts": 0, "agents": 0, "workflows": 0, "lessons": 0},
+        }
+        out = render_catalog(index)
+        # The raw pipe from the id/output must be escaped, not add a column.
+        assert "evil\\|id" in out
+        assert "a\\|b" in out

--- a/scripts/tests/test_validate_references.py
+++ b/scripts/tests/test_validate_references.py
@@ -1,0 +1,72 @@
+"""Tests for validate_references.py — cross-reference & delegation-cycle guard (#240)."""
+
+from scripts.validate_references import _find_cycles, find_reference_errors
+
+
+class TestDanglingReferences:
+    def test_clean_when_all_resolve(self):
+        patterns = {
+            "a": {"id": "a", "routing": {"delegates": [{"pattern": "b", "when": "x"}]}},
+            "b": {"id": "b"},
+        }
+        assert find_reference_errors(patterns) == []
+
+    def test_dangling_delegate_flagged(self):
+        patterns = {"a": {"id": "a", "routing": {"delegates": [{"pattern": "ghost", "when": "x"}]}}}
+        errors = find_reference_errors(patterns)
+        assert errors and "ghost" in errors[0]
+
+    def test_dangling_replaces_with_flagged(self):
+        patterns = {"a": {"id": "a", "deprecated": {"replaces_with": "ghost", "reason": "r", "as_of": "2026-01-01"}}}
+        errors = find_reference_errors(patterns)
+        assert errors and "replaces_with" in errors[0]
+
+    def test_dangling_requires_flagged(self):
+        patterns = {"a": {"id": "a", "requires": {"skills": ["ghost"], "anchors": []}}}
+        errors = find_reference_errors(patterns)
+        assert errors and "requires.skills" in errors[0]
+
+    def test_valid_replaces_with_ok(self):
+        patterns = {
+            "old": {"id": "old", "deprecated": {"replaces_with": "new", "reason": "r", "as_of": "2026-01-01"}},
+            "new": {"id": "new"},
+        }
+        assert find_reference_errors(patterns) == []
+
+
+class TestCycles:
+    def test_direct_cycle_detected(self):
+        graph = {"a": ["b"], "b": ["a"]}
+        errors = _find_cycles(graph)
+        assert errors and "cycle" in errors[0]
+
+    def test_self_cycle_detected(self):
+        graph = {"a": ["a"]}
+        assert _find_cycles(graph)
+
+    def test_acyclic_clean(self):
+        graph = {"a": ["b"], "b": ["c"], "c": []}
+        assert _find_cycles(graph) == []
+
+    def test_cycle_surfaced_through_find_reference_errors(self):
+        patterns = {
+            "a": {"id": "a", "routing": {"delegates": [{"pattern": "b", "when": "x"}]}},
+            "b": {"id": "b", "routing": {"delegates": [{"pattern": "a", "when": "y"}]}},
+        }
+        errors = find_reference_errors(patterns)
+        assert any("cycle" in e for e in errors)
+
+
+class TestLiveRepo:
+    """The real repository must have no dangling refs or cycles (#240 gate)."""
+
+    def test_repo_references_resolve(self):
+        from pathlib import Path
+
+        from scripts.validate_references import collect_patterns
+
+        root = Path(__file__).resolve().parents[2]
+        patterns = collect_patterns(root)
+        assert patterns, "expected to find patterns"
+        errors = find_reference_errors(patterns)
+        assert errors == [], f"live repo has reference errors: {errors}"

--- a/scripts/validate_references.py
+++ b/scripts/validate_references.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Validate cross-references between patterns (#240, PR3).
+
+Every reference a pattern makes to another pattern by id must resolve to a real
+pattern, and delegation must not form a cycle. Guards against:
+  * `deprecated.replaces_with` pointing at a missing id
+  * `routing.delegates[].pattern` pointing at a missing id
+  * `requires.skills[]` / `requires.anchors[]` pointing at a missing id
+  * a delegation cycle (A delegates to B delegates to A)
+
+Read-only. Exit 1 on any dangling or cyclic reference.
+
+Usage:
+    python scripts/validate_references.py [--root PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def extract_frontmatter(content: str) -> dict[str, Any] | None:
+    if not content.startswith("---\n"):
+        return None
+    parts = content.split("---\n", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        return yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+
+
+def collect_patterns(root: Path) -> dict[str, dict]:
+    """Map pattern id -> frontmatter across all pattern dirs."""
+    patterns: dict[str, dict] = {}
+    for base in ("skills", "prompts", "workflows", "agents", "lessons-learned"):
+        d = root / base
+        if not d.exists():
+            continue
+        for name in ("SKILL.md", "AGENTS.md"):
+            for f in d.rglob(name):
+                if "fixtures" in f.parts:
+                    continue
+                fm = extract_frontmatter(f.read_text())
+                if fm and fm.get("id"):
+                    patterns[fm["id"]] = fm
+    return patterns
+
+
+def _delegate_targets(fm: dict) -> list[str]:
+    routing = fm.get("routing") or {}
+    out = []
+    for d in routing.get("delegates") or []:
+        if isinstance(d, dict) and d.get("pattern"):
+            out.append(d["pattern"])
+    return out
+
+
+def find_reference_errors(patterns: dict[str, dict]) -> list[str]:
+    """Return a list of dangling/cyclic reference errors (empty = clean)."""
+    ids = set(patterns)
+    errors: list[str] = []
+
+    for pid, fm in sorted(patterns.items()):
+        # replaces_with
+        dep = fm.get("deprecated") or {}
+        rw = dep.get("replaces_with")
+        if rw and rw not in ids:
+            errors.append(f"{pid}: deprecated.replaces_with -> unknown pattern {rw!r}")
+
+        # requires.skills / requires.anchors
+        req = fm.get("requires") or {}
+        for field in ("skills", "anchors"):
+            for ref in req.get(field) or []:
+                if ref not in ids:
+                    errors.append(f"{pid}: requires.{field} -> unknown pattern {ref!r}")
+
+        # routing.delegates
+        for target in _delegate_targets(fm):
+            if target not in ids:
+                errors.append(f"{pid}: routing.delegates -> unknown pattern {target!r}")
+
+    # Delegation cycles (only over resolvable edges).
+    graph = {pid: [t for t in _delegate_targets(fm) if t in ids] for pid, fm in patterns.items()}
+    errors.extend(_find_cycles(graph))
+    return errors
+
+
+def _find_cycles(graph: dict[str, list[str]]) -> list[str]:
+    """Detect cycles in the delegation graph via DFS. Deterministic output."""
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {n: WHITE for n in graph}
+    errors: list[str] = []
+
+    def visit(node: str, stack: list[str]) -> None:
+        color[node] = GRAY
+        for nxt in graph.get(node, []):
+            if color.get(nxt) == GRAY:
+                cycle = stack[stack.index(nxt) :] + [nxt] if nxt in stack else [node, nxt]
+                errors.append("delegation cycle: " + " -> ".join(cycle))
+            elif color.get(nxt) == WHITE:
+                visit(nxt, stack + [nxt])
+        color[node] = BLACK
+
+    for node in sorted(graph):
+        if color[node] == WHITE:
+            visit(node, [node])
+    # De-dup while keeping deterministic order.
+    seen = set()
+    unique = []
+    for e in errors:
+        if e not in seen:
+            seen.add(e)
+            unique.append(e)
+    return unique
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate pattern cross-references (#240)")
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+
+    patterns = collect_patterns(args.root)
+    if not patterns:
+        print("No patterns found")
+        return 0
+
+    errors = find_reference_errors(patterns)
+    if errors:
+        print(f"✗ {len(errors)} reference error(s):")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    print(f"✓ {len(patterns)} patterns: all cross-references resolve, no delegation cycles")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_references.py
+++ b/scripts/validate_references.py
@@ -48,7 +48,11 @@ def collect_patterns(root: Path) -> dict[str, dict]:
             for f in d.rglob(name):
                 if "fixtures" in f.parts:
                     continue
-                fm = extract_frontmatter(f.read_text())
+                try:
+                    text = f.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    continue  # unreadable/binary file → skip, don't crash the run
+                fm = extract_frontmatter(text)
                 if fm and fm.get("id"):
                     patterns[fm["id"]] = fm
     return patterns

--- a/scripts/validate_repo.py
+++ b/scripts/validate_repo.py
@@ -33,6 +33,7 @@ def main() -> int:
     validators = [
         ("scripts/validate_frontmatter.py", "Frontmatter schema validation"),
         ("scripts/validate_sensitive_terms.py", "Sensitive terms scan"),
+        ("scripts/validate_references.py", "Cross-reference & delegation-cycle validation"),
     ]
 
     failed = []

--- a/workflows/issue-to-merge-request/SKILL.md
+++ b/workflows/issue-to-merge-request/SKILL.md
@@ -51,6 +51,22 @@ tags:
   - "development"
   - "pr"
   - "git"
+
+collection: engineering
+routing:
+  task_types:
+    - "orchestrate"
+    - "author"
+    - "test"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "pull-request-diff"
+    - "source-code"
+  aliases:
+    - "issue to pr"
+    - "dev cycle"
+    - "feature workflow"
 ---
 
 # Workflow: Issue to Merge Request

--- a/workflows/qa-round/SKILL.md
+++ b/workflows/qa-round/SKILL.md
@@ -50,6 +50,23 @@ tags:
   - "qa"
   - "testing"
   - "verification"
+
+collection: engineering
+routing:
+  task_types:
+    - "orchestrate"
+    - "test"
+    - "review"
+  input_artifacts:
+    - "source-code"
+  output_artifacts:
+    - "qa-report"
+  prefer_when:
+    - "the request is to run the full preparation/testing/regression/sign-off QA process"
+  aliases:
+    - "qa process"
+    - "testing cycle"
+    - "qa signoff"
 ---
 
 # Workflow: QA Round

--- a/workflows/security-scan-review/SKILL.md
+++ b/workflows/security-scan-review/SKILL.md
@@ -78,6 +78,22 @@ tags:
 
 portability:
   opencode: true
+
+collection: security
+routing:
+  task_types:
+    - "orchestrate"
+    - "analyze"
+    - "review"
+  input_artifacts:
+    - "source-code"
+    - "dependency-manifest"
+  output_artifacts:
+    - "security-review"
+  aliases:
+    - "scan triage"
+    - "sarif triage"
+    - "language-aware scan"
 ---
 
 # Language-Aware Security Scan & Triage Workflow


### PR DESCRIPTION
Closes #240. Part of epic #237. **Stacked on PR2 (#266)** — base is the `feat/pattern-router-239` branch; **merge after #266** (GitHub will retarget this to `main` automatically once #266 merges).

Populates the routing metadata (PR1 schema) so the PR2 router resolves real requests against the live INDEX, and fixes the verified overlaps.

## Classification (additive frontmatter — no existing lines reflowed)
- All 31 patterns now carry `collection` + `routing` (task_types, input/output artifacts, aliases, prefer_when/avoid_when, delegates).
- **Security disambiguation lanes moved from prose → structured metadata:** `secure-code-review` delegates to auditor / LPR / dependency-analysis / untrusted-input-boundary-review / backdoor-review; the auditor↔LPR split routes a bare token-minimality ask to `least-privilege-review`. Delegation graph is **acyclic** (reciprocal edges removed).

## Overlap fixes (verified by subagent audit)
- **Deprecate `safe-code-review`** prompt → `replaces_with: secure-code-review`; kept resolvable one release; `priority: 0` + `avoid_when` so the router never picks it.
- `secure-code-review` gains **return-pointers** to `untrusted-input-boundary-review` + `backdoor-review` (Boundaries table + Related Patterns).
- documentation-review vs plain-language-review, qa-round vs qa-workflow, uswds-prototype vs landing/form — disambiguated via `delegates`/`avoid_when`.

## New tooling
- **`scripts/validate_references.py`** (+ tests) — fails CI on any dangling `replaces_with`/`delegates`/`requires` reference **or delegation cycle**; wired into `make validate`.
- **`scripts/generate_catalog.py` + `CATALOG.md`** — human-readable catalog grouped by collection; `make generate` writes it, `make generate-check` verifies it, and **CI now runs generate-check**.

## Verification
- `make validate` (incl. reference/cycle check) ✓ · `make generate-check` ✓ · markdownlint ✓
- **Router regression suite green against the LIVE index** (added `TestLiveIndexRouting`) ✓ · **240 tests pass** ✓
- Tooling security/correctness subagent review: **clean, no blockers**; the LOW finding (unescaped catalog cells) is hardened in this PR.

**Human-review-gated; not admin-merging.**

Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>