### PR TITLE
feat(communications): design-artifact pack + workflow + multi-artifact output [MERGE AFTER #267] (#241)

### DIFF
--- a/.agents/skills/agentic-actions-auditor/SKILL.md
+++ b/.agents/skills/agentic-actions-auditor/SKILL.md
@@ -101,6 +101,30 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — audits agent-invoking CI workflows for dangerous trigger/checkout/token/prompt patterns and missing approval gates; describes fixes, ships no working exploit."
+
+collection: security
+routing:
+  task_types:
+    - "analyze"
+    - "review"
+  input_artifacts:
+    - "ci-workflow"
+    - "source-code"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the target is a CI/CD workflow that invokes an LLM agent"
+  avoid_when:
+    - "the question is about permission minimality"
+    - "permissions minimal"
+    - "token scope"
+  delegates:
+    - pattern: least-privilege-review
+      when: "permissions minimal token scope minimality"
+  aliases:
+    - "workflow audit"
+    - "github actions security"
+    - "ci agent audit"
 ---
 
 # Skill: Agentic Actions Auditor

--- a/.agents/skills/backdoor-review/SKILL.md
+++ b/.agents/skills/backdoor-review/SKILL.md
@@ -97,6 +97,26 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — read-only adversarial review of suspicious-pattern classes with strict Evidence/Hypothesis/Confidence separation; conceptual only, no weaponized content."
+
+collection: security
+routing:
+  task_types:
+    - "analyze"
+    - "review"
+  input_artifacts:
+    - "source-code"
+    - "pull-request-diff"
+    - "ci-workflow"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the request implies deliberate hidden malice, obfuscation, or an auth-bypass/persistence mechanism"
+  avoid_when:
+    - "the request is a general vulnerability review with no sign of intentional tampering"
+  aliases:
+    - "backdoor scan"
+    - "adversarial review"
+    - "integrity review"
 ---
 
 # Skill: Backdoor Review

--- a/.agents/skills/communications/artifact-brief/SKILL.md
+++ b/.agents/skills/communications/artifact-brief/SKILL.md
@@ -1,0 +1,145 @@
+---
+id: artifact-brief
+version: "1.0.0"
+title: "Artifact Brief"
+description: "Capture the audience, action, core message, evidence, and constraints for a communication artifact before any design or drafting begins, producing a small structured brief the rest of the design-artifact pipeline consumes."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Brief"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "artifact brief"
+  - "who is the audience"
+  - "what is the core message"
+tags:
+  - "communications"
+  - "planning"
+  - "briefing"
+routing:
+  task_types:
+    - plan
+  input_artifacts:
+    - documentation
+  output_artifacts:
+    - artifact-brief
+  aliases:
+    - "comms brief"
+    - "message brief"
+  prefer_when:
+    - "starting any executive/marketing/explainer artifact and the audience, action, or core message is not yet pinned down"
+  priority: 60
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Skill: Artifact Brief
+
+## Summary
+
+Before designing or drafting any communication artifact (one-pager, slide deck,
+explainer), capture the decisions that everything downstream depends on:
+**who** it's for, **what** you want them to do, the **one core message**, the
+**evidence** that supports it, and the **constraints** (length, format, brand,
+deadline). This produces a small structured brief the rest of the
+`design-artifact` pipeline reads — so narrative, visuals, and QA all serve the
+same goal instead of guessing.
+
+## When to Use
+
+- Kicking off an executive one-pager, slide deck, or explainer.
+- The audience, desired action, or core message is fuzzy or unstated.
+- Multiple people will contribute and need a shared source of truth.
+
+## When NOT to Use
+
+- The brief already exists (feed it straight to `narrative-architect`).
+- You are only reviewing an existing artifact (use `artifact-qa`).
+
+## Prerequisites
+
+- The raw material: what happened, the ask, and any supporting numbers.
+
+## Procedure
+
+1. **Audience.** Name the specific reader and their context (e.g. "an agency
+   CIO deciding whether to fund a pilot"), their prior knowledge, and what they
+   care about. One primary audience — not "everyone."
+2. **Action.** State the single decision or action you want them to take after
+   reading. If there are two, split into two artifacts.
+3. **Core message.** One sentence they should remember. Everything else supports
+   it or is cut.
+4. **Evidence.** The 3–5 strongest facts/numbers/quotes that make the core
+   message credible. Note the source of each (no fabricated figures).
+5. **Constraints.** Output profile (one-pager / slide-deck / explainer), length,
+   brand/USWDS requirements, accessibility level, deadline, and any prohibited
+   content.
+6. **Emit the brief** in the structured shape below.
+
+## Brief shape
+
+```yaml
+audience: "..."
+action: "..."
+core_message: "..."
+evidence:
+  - claim: "..."
+    source: "..."
+constraints:
+  profile: one-pager | slide-deck | technical-explainer | marketing-kit
+  length: "..."
+  accessibility: "508 / WCAG AA"
+  deadline: "..."
+```
+
+## Verification
+
+- Exactly one audience and one action.
+- Core message fits in one sentence.
+- Every evidence item names a real source (none invented).
+- Constraints name a concrete output profile.
+
+## Examples
+
+| Raw ask | Audience | Action | Core message |
+|---------|----------|--------|--------------|
+| "Tell leadership the pilot worked" | Agency CIO | Fund phase 2 | "The pilot cut review time 40% with no security regressions." |
+
+## Human Review Checklist
+
+- [ ] Audience is one specific reader, not "everyone."
+- [ ] The action is a single concrete decision.
+- [ ] Every number/quote traces to a real source.
+- [ ] No secrets, PII, CUI, or internal URLs.
+
+## Notes
+
+Feeds `narrative-architect` (structure) → `visual-direction` (look) →
+`one-pager`/`slide-deck` (render) → `artifact-qa` (validate). The
+`design-artifact` workflow orchestrates the whole chain.

--- a/.agents/skills/communications/artifact-qa/SKILL.md
+++ b/.agents/skills/communications/artifact-qa/SKILL.md
@@ -1,0 +1,134 @@
+---
+id: artifact-qa
+version: "1.0.0"
+title: "Artifact QA"
+description: "Render, inspect, and validate a produced communication artifact against its brief and visual contract — checking the actual output files (HTML/PDF/PNG), accessibility, offline-safety, and prohibited content — then report pass/fail with concrete fixes."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Findings"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "External CDN Links"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "artifact qa"
+  - "check this deck"
+  - "validate this one-pager"
+tags:
+  - "communications"
+  - "qa"
+  - "review"
+routing:
+  task_types:
+    - review
+    - test
+  input_artifacts:
+    - one-pager
+    - slide-deck
+  output_artifacts:
+    - qa-report
+  aliases:
+    - "design qa"
+    - "artifact review"
+  prefer_when:
+    - "a communication artifact (one-pager, deck, explainer) has been produced and needs validation of the actual files"
+  delegates:
+    - pattern: accessibility-review
+      when: "the artifact is a web page/prototype needing a full 508/WCAG audit"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Skill: Artifact QA
+
+## Summary
+
+Validate a **produced** communication artifact, not just a markdown answer:
+render it, inspect the **actual output files** (HTML/PDF/PNG), and check it
+against its brief and visual contract. Confirms accessibility, offline-safety
+(no external requests), and that no prohibited content leaked, then reports
+pass/fail with concrete fixes.
+
+## When to Use
+
+- A one-pager, slide deck, or explainer has been produced and needs sign-off.
+- You need to confirm the rendered files (not just the source) are correct.
+
+## When NOT to Use
+
+- Nothing has been rendered yet (produce it first).
+- A full web-app 508 audit is needed → delegate to `accessibility-review`.
+
+## Prerequisites
+
+- The artifact's output files + its brief and visual contract.
+- Offline headless renderer to re-render and inspect.
+
+## Procedure
+
+1. **Re-render** the source and confirm exports regenerate deterministically.
+2. **Inspect the actual files** — open the PDF/PNG/HTML; confirm the one-pager is
+   one page, the deck has the expected slide count, and the preview matches.
+3. **Brief conformance** — the core message leads and is dominant; the closing
+   action is present; primary beats are all there.
+4. **Accessibility** — WCAG AA contrast on every text/background pair; semantic
+   structure; alt text on images; sensible reading order.
+5. **Offline-safety** — no external network requests during render; all assets
+   vendored.
+6. **Prohibited content** — no secrets, real PII, real CUI, internal URLs.
+7. **Report** findings with concrete, actionable fixes; mark PASS/FAIL.
+
+## Findings
+
+Report as a table: check | result (pass/fail) | evidence | fix.
+
+## Verification
+
+- The check inspected the **rendered files**, not only the markdown/source.
+- Contrast ratios are stated, not assumed.
+- A FAIL names the exact file + fix.
+
+## Examples
+
+| Artifact | Typical finding |
+|----------|-----------------|
+| one-pager | "PDF spills to 2 pages — reduce proof-card padding" |
+| slide-deck | "Slide 4 body text 3.9:1 contrast (<4.5 AA) — darken text token" |
+
+## Human Review Checklist
+
+- [ ] Rendered files inspected (not just the source).
+- [ ] WCAG AA contrast verified with stated ratios.
+- [ ] No external requests; assets vendored.
+- [ ] No secrets, PII, CUI, or internal URLs in the artifact.
+
+## Notes
+
+Final stage of the `design-artifact` workflow. For web prototypes/pages, defer
+the deep conformance audit to `accessibility-review`.

--- a/.agents/skills/communications/narrative-architect/SKILL.md
+++ b/.agents/skills/communications/narrative-architect/SKILL.md
@@ -1,0 +1,136 @@
+---
+id: narrative-architect
+version: "1.0.0"
+title: "Narrative Architect"
+description: "Turn an artifact brief into an information hierarchy and argument sequence — the order in which points are made and how they build to the core message — before any visual design or rendering."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Narrative"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "narrative structure"
+  - "information hierarchy"
+  - "argument sequence"
+tags:
+  - "communications"
+  - "narrative"
+  - "structure"
+routing:
+  task_types:
+    - plan
+    - visualize
+  input_artifacts:
+    - artifact-brief
+  output_artifacts:
+    - storyboard
+  aliases:
+    - "story structure"
+    - "outline the argument"
+  prefer_when:
+    - "you have a brief and need the order + hierarchy of points before choosing visuals"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Skill: Narrative Architect
+
+## Summary
+
+Given an [`artifact-brief`](../artifact-brief/SKILL.md), decide the
+**information hierarchy** (what's primary vs supporting) and the **argument
+sequence** (the order that builds to the core message). Output a storyboard the
+visual and rendering skills follow — so the artifact leads with the point, not
+with background.
+
+## When to Use
+
+- You have a brief and need the structure before visuals or slides exist.
+- An artifact feels like a data dump with no through-line.
+
+## When NOT to Use
+
+- The brief doesn't exist yet (run `artifact-brief` first).
+- You're choosing colors/layout (that's `visual-direction`).
+
+## Prerequisites
+
+- A completed artifact brief (audience, action, core message, evidence).
+
+## Procedure
+
+1. **Lead with the core message.** The first beat states the takeaway; do not
+   bury it after setup.
+2. **Order the evidence** to build the argument — strongest support first for a
+   skeptical audience, or problem→solution→proof for a narrative one.
+3. **Assign hierarchy** — mark each beat primary (must land) or supporting
+   (cut first if space runs out).
+4. **Map beats to the output profile** — a one-pager gets ~3–5 beats; a slide
+   deck gets one beat per slide; an explainer gets a scene per beat.
+5. **End on the action** from the brief.
+6. **Emit the storyboard** below.
+
+## Narrative shape
+
+```yaml
+core_message: "..."
+beats:
+  - id: 1
+    point: "..."
+    role: primary | supporting
+    evidence_ref: "which brief evidence item"
+closing_action: "..."
+```
+
+## Verification
+
+- Beat 1 is the core message, not background.
+- Every beat maps to a brief evidence item or the action.
+- Primary beats alone still tell the whole story (supporting are droppable).
+- Beat count fits the target profile.
+
+## Examples
+
+| Profile | Beats |
+|---------|-------|
+| one-pager | message → 3 proofs → ask |
+| slide-deck | title/message → problem → approach → proof → ask |
+
+## Human Review Checklist
+
+- [ ] The core message leads.
+- [ ] Cutting supporting beats still leaves a coherent argument.
+- [ ] The closing is the brief's action.
+- [ ] No secrets, PII, CUI, or internal URLs.
+
+## Notes
+
+Consumes the brief; produces a storyboard for `visual-direction` and the
+renderers. Orchestrated by `design-artifact`.

--- a/.agents/skills/communications/one-pager/SKILL.md
+++ b/.agents/skills/communications/one-pager/SKILL.md
@@ -1,0 +1,153 @@
+---
+id: one-pager
+version: "1.0.0"
+title: "One-Pager"
+description: "Render a single-page executive artifact (HTML source plus PDF/PNG exports) from a storyboard and visual contract, following the design-artifact pipeline, with all assets locally vendored and accessibility built in."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: multi
+  artifacts:
+    - role: source
+      media_type: text/html
+      extension: html
+    - role: export
+      media_type: application/pdf
+      extension: pdf
+    - role: preview
+      media_type: image/png
+      extension: png
+  contract:
+    required_sections:
+      - "Summary"
+      - "Composition HTML"
+      - "Render Command"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "External CDN Links"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "one-pager"
+  - "one page summary"
+  - "executive summary"
+tags:
+  - "communications"
+  - "design"
+  - "one-pager"
+routing:
+  task_types:
+    - author
+    - render
+  input_artifacts:
+    - storyboard
+    - visual-contract
+    - artifact-brief
+  output_artifacts:
+    - one-pager
+  aliases:
+    - "executive one-pager"
+    - "leave-behind"
+  prefer_when:
+    - "the requested output is a single-page summary artifact"
+  avoid_when:
+    - "the request is a multi-slide deck"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Skill: One-Pager
+
+## Summary
+
+Render a **single-page** executive artifact from a storyboard +
+[`visual-direction`](../visual-direction/SKILL.md) contract. Output is
+multi-file: an **HTML source** (the editable master), a **PDF export** (the
+share/print copy), and a **PNG preview**. All assets are locally vendored (no
+external CDN), and the layout follows the visual contract so it's accessible and
+on-brand.
+
+## When to Use
+
+- The requested deliverable is a one-page summary / leave-behind.
+- You already have a storyboard and visual contract.
+
+## When NOT to Use
+
+- The ask is a multi-slide deck → `slide-deck`.
+- The ask is motion/video → `explainer-video` / `explainer-gif`.
+
+## Prerequisites
+
+- Storyboard (beats + hierarchy), visual contract, and the brief.
+- Headless Chromium + a PDF/PNG renderer available offline.
+
+## Procedure
+
+1. **Lay out the beats** on one page per the visual contract: message header,
+   supporting proof blocks, closing action.
+2. **Author the composition HTML** — self-contained, assets inlined or locally
+   vendored, semantic markup (headings, landmarks, alt text).
+3. **Verify contrast + reading order** meet WCAG AA before export.
+4. **Render exports** — HTML → PDF (print CSS, one page) and a PNG preview.
+5. **Emit** the composition HTML, the render command, and the review checklist.
+
+## Composition HTML
+
+Provide a complete, offline, single-file HTML document using the visual
+contract's tokens. Semantic structure; alt text on every image; no external
+requests.
+
+## Render Command
+
+```bash
+# Offline HTML -> PDF + PNG (headless Chromium). Adjust to your renderer.
+chromium --headless --print-to-pdf=one-pager.pdf one-pager.html
+chromium --headless --screenshot=one-pager.png --window-size=1200,1553 one-pager.html
+```
+
+## Verification
+
+- Output fits **one page** in the PDF.
+- Every text/background pair meets WCAG AA.
+- No external network requests during render (all vendored).
+- Core message is the visually dominant element.
+
+## Examples
+
+| Brief | Result |
+|-------|--------|
+| "Executive one-pager for the pilot" | message header + 3 proof cards + fund-phase-2 ask, HTML+PDF+PNG |
+
+## Human Review Checklist
+
+- [ ] Fits one page; core message dominant.
+- [ ] WCAG AA contrast; images have alt text.
+- [ ] All assets locally vendored — no CDN, no internal URLs.
+- [ ] No secrets, PII, or CUI.
+
+## Notes
+
+Usually invoked by the `design-artifact` workflow after
+`artifact-brief` → `narrative-architect` → `visual-direction`, and validated by
+`artifact-qa`.

--- a/.agents/skills/communications/slide-deck/SKILL.md
+++ b/.agents/skills/communications/slide-deck/SKILL.md
@@ -1,0 +1,154 @@
+---
+id: slide-deck
+version: "1.0.0"
+title: "Slide Deck"
+description: "Render a presentation deck (HTML source plus PDF export and a PNG preview) from a storyboard and visual contract, one beat per slide, with locally vendored assets and accessibility built in."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: multi
+  artifacts:
+    - role: source
+      media_type: text/html
+      extension: html
+    - role: export
+      media_type: application/pdf
+      extension: pdf
+    - role: preview
+      media_type: image/png
+      extension: png
+  contract:
+    required_sections:
+      - "Summary"
+      - "Composition HTML"
+      - "Render Command"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "External CDN Links"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "slide deck"
+  - "presentation"
+  - "slides"
+tags:
+  - "communications"
+  - "design"
+  - "slide-deck"
+routing:
+  task_types:
+    - author
+    - render
+  input_artifacts:
+    - storyboard
+    - visual-contract
+    - artifact-brief
+  output_artifacts:
+    - slide-deck
+  aliases:
+    - "presentation deck"
+    - "briefing slides"
+  prefer_when:
+    - "the requested output is a multi-slide presentation"
+  avoid_when:
+    - "the request is a single-page summary"
+    - "the request is motion/video"
+  delegates:
+    - pattern: one-pager
+      when: "the request is a single-page summary, not a deck"
+    - pattern: explainer-video
+      when: "the request is an animated/narrated video"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Skill: Slide Deck
+
+## Summary
+
+Render a **multi-slide** presentation from a storyboard +
+[`visual-direction`](../visual-direction/SKILL.md) contract — one beat per
+slide. Output is multi-file: an **HTML source** (editable master, e.g. a
+reveal-style deck), a **PDF export**, and a **PNG preview** of the title slide.
+All assets are locally vendored (no external CDN).
+
+## When to Use
+
+- The deliverable is a presentation / briefing deck.
+- You have a storyboard and visual contract.
+
+## When NOT to Use
+
+- Single-page summary → `one-pager`.
+- Motion/video → `explainer-video` / `explainer-gif`.
+
+## Prerequisites
+
+- Storyboard (one beat ≈ one slide), visual contract, brief.
+- Offline headless Chromium + PDF/PNG renderer.
+
+## Procedure
+
+1. **One beat per slide** — title/message slide first, then a slide per beat,
+   closing on the action.
+2. **Author the composition HTML** — self-contained deck, assets inlined/vendored,
+   semantic headings per slide, alt text, high-contrast large type.
+3. **Check contrast + reading order** meet WCAG AA.
+4. **Render exports** — HTML → PDF (one page per slide) and a PNG of slide 1.
+5. **Emit** the composition HTML, the render command, and the review checklist.
+
+## Composition HTML
+
+A complete offline deck (e.g. sections as slides) using the visual contract's
+tokens; no external requests; alt text on all images.
+
+## Render Command
+
+```bash
+# Offline deck -> PDF + title PNG (headless Chromium). Adjust to your renderer.
+chromium --headless --print-to-pdf=deck.pdf deck.html
+chromium --headless --screenshot=deck-title.png --window-size=1280,720 deck.html
+```
+
+## Verification
+
+- One beat per slide; title slide carries the core message.
+- WCAG AA contrast; large readable type.
+- No external requests during render (all vendored).
+
+## Examples
+
+| Brief | Result |
+|-------|--------|
+| "Deck for the pilot review" | title/message → problem → approach → proof → ask, HTML+PDF+PNG |
+
+## Human Review Checklist
+
+- [ ] One beat per slide; core message on the title slide.
+- [ ] WCAG AA contrast; images have alt text.
+- [ ] All assets locally vendored — no CDN, no internal URLs.
+- [ ] No secrets, PII, or CUI.
+
+## Notes
+
+Usually invoked by the `design-artifact` workflow and validated by `artifact-qa`.

--- a/.agents/skills/communications/visual-direction/SKILL.md
+++ b/.agents/skills/communications/visual-direction/SKILL.md
@@ -1,0 +1,144 @@
+---
+id: visual-direction
+version: "1.0.0"
+title: "Visual Direction"
+description: "Turn a storyboard into a concrete visual contract — layout, type scale, color, spacing, and asset rules (USWDS-aligned where federal) — that a renderer can follow to produce an accessible, on-brand artifact."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Visual Contract"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "External CDN Links"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "visual direction"
+  - "design direction"
+  - "layout and color"
+tags:
+  - "communications"
+  - "design"
+  - "visual"
+routing:
+  task_types:
+    - visualize
+  input_artifacts:
+    - storyboard
+  output_artifacts:
+    - visual-contract
+  aliases:
+    - "design system for this artifact"
+    - "look and feel"
+  prefer_when:
+    - "you have a storyboard and need the concrete visual rules before rendering"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Skill: Visual Direction
+
+## Summary
+
+Given a storyboard from [`narrative-architect`](../narrative-architect/SKILL.md),
+produce a **visual contract**: the concrete layout, type scale, color roles,
+spacing, and asset rules a renderer follows. For federal artifacts, align to
+USWDS tokens. The contract is deterministic enough that
+`one-pager`/`slide-deck` can render without re-deciding design.
+
+## When to Use
+
+- You have a storyboard and need the look-and-feel pinned before rendering.
+- Multiple renderers/formats must stay visually consistent.
+
+## When NOT to Use
+
+- No storyboard yet (run `narrative-architect`).
+- You're building a full interactive site (see the `uswds-*` skills).
+
+## Prerequisites
+
+- A storyboard (beats + hierarchy) and the brief's constraints (brand, a11y).
+
+## Procedure
+
+1. **Grid & layout** — pick a layout per beat that reflects its hierarchy
+   (primary beats get dominant space).
+2. **Type scale** — heading/body/caption sizes with a clear ratio; enough
+   contrast for the primary message to dominate.
+3. **Color roles** — background, text, accent, and semantic colors as named
+   roles (not one-off hex). USWDS tokens where federal. All text/background pairs
+   must meet WCAG AA contrast.
+4. **Spacing** — a consistent spacing unit; whitespace protects the primary
+   message.
+5. **Assets** — allowed asset types and the rule that all assets are **locally
+   vendored** (no external CDN links; matches explainer skills).
+6. **Emit the visual contract** below.
+
+## Visual Contract shape
+
+```yaml
+grid: "..."
+type_scale:
+  heading: "..."
+  body: "..."
+  caption: "..."
+color_roles:
+  background: "..."
+  text: "..."
+  accent: "..."
+contrast: "WCAG AA verified"
+spacing_unit: "..."
+assets: "locally vendored only; no external CDN"
+```
+
+## Verification
+
+- Every text/background pair meets WCAG AA (state the ratios).
+- Primary beats are visually dominant.
+- No external CDN/asset links — all vendored.
+- Tokens/roles named, not scattered literals.
+
+## Examples
+
+| Profile | Direction |
+|---------|-----------|
+| one-pager | single column, big message header, 3 proof cards |
+| slide-deck | 16:9, one message per slide, large type, high contrast |
+
+## Human Review Checklist
+
+- [ ] Contrast meets WCAG AA for all text.
+- [ ] Assets are locally vendored (no CDN).
+- [ ] Visual hierarchy matches the storyboard's primary/supporting split.
+- [ ] No secrets, PII, CUI, or internal URLs.
+
+## Notes
+
+Consumes the storyboard; produces the visual contract for `one-pager` /
+`slide-deck`. Accessibility is verified end-to-end by `artifact-qa` (and, for
+web artifacts, `accessibility-review`).

--- a/.agents/skills/compliance-claim-checker/SKILL.md
+++ b/.agents/skills/compliance-claim-checker/SKILL.md
@@ -87,6 +87,26 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — flags uncited/overclaimed federal compliance statements, verifies citations against the playbook federal-ai-landscape registry, asserts no compliance itself."
+
+collection: security
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "compliance-claim"
+    - "documentation"
+    - "pull-request-diff"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the request is to verify a stated FedRAMP/NIST/compliance claim"
+  avoid_when:
+    - "the request is a general code security review"
+  aliases:
+    - "compliance claim review"
+    - "fedramp claim check"
+    - "overclaim check"
 ---
 
 # Skill: Compliance Claim Checker

--- a/.agents/skills/dependency-analysis/SKILL.md
+++ b/.agents/skills/dependency-analysis/SKILL.md
@@ -100,6 +100,25 @@ scope:
     - "Not for performance profiling"
     - "Not for the runtime safety of agent-invoking CI workflows (see agentic-actions-auditor)"
     - "Not for authoring safe shell scripts (see safe-shell-script-author); this skill audits install patterns"
+
+collection: security
+routing:
+  task_types:
+    - "analyze"
+    - "review"
+  input_artifacts:
+    - "dependency-manifest"
+    - "source-code"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the concern is dependency, package, or supply-chain intake risk"
+  avoid_when:
+    - "the concern is application code logic rather than dependencies"
+  aliases:
+    - "supply chain review"
+    - "dependency audit"
+    - "dependency risk"
 ---
 
 # Skill: Dependency Security Analysis

--- a/.agents/skills/documentation-review/SKILL.md
+++ b/.agents/skills/documentation-review/SKILL.md
@@ -64,6 +64,28 @@ scope:
   exclusions:
     - "Not for copyediting or style guide enforcement"
     - "Not for translation review"
+
+collection: content
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "documentation"
+  output_artifacts:
+    - "qa-report"
+  prefer_when:
+    - "the concern is correctness, completeness, stale commands, broken links, or usability of docs"
+  avoid_when:
+    - "the concern is specifically wording/readability for a public audience"
+  delegates:
+    - pattern: plain-language-review
+      when: "the concern is specifically plain-language readability for a public audience"
+  aliases:
+    - "docs review"
+    - "stale commands"
+    - "broken links"
+    - "doc quality check"
 ---
 
 # Skill: Documentation Review

--- a/.agents/skills/frontend/accessibility-review/SKILL.md
+++ b/.agents/skills/frontend/accessibility-review/SKILL.md
@@ -72,6 +72,24 @@ scope:
     - "Not a legal certification of compliance"
     - "Does not replace screen reader testing"
     - "Does not assess cognitive accessibility fully"
+
+collection: digital-service
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "source-code"
+    - "web-page"
+    - "web-prototype"
+  output_artifacts:
+    - "qa-report"
+  prefer_when:
+    - "the concern is accessibility/508/WCAG conformance of a UI"
+  aliases:
+    - "a11y review"
+    - "section 508 check"
+    - "wcag audit"
 ---
 
 # Skill: Federal Accessibility Review

--- a/.agents/skills/frontend/federal-service-blueprint/SKILL.md
+++ b/.agents/skills/frontend/federal-service-blueprint/SKILL.md
@@ -69,6 +69,25 @@ scope:
     - "Not a replacement for full service design process"
     - "Does not replace stakeholder research"
     - "Not for detailed technical architecture"
+
+collection: digital-service
+routing:
+  task_types:
+    - "plan"
+    - "discover"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "service-blueprint"
+    - "documentation"
+  prefer_when:
+    - "the request is to plan/map a federal service end to end"
+  avoid_when:
+    - "the request is to build a specific web page or form (front-end implementation)"
+  aliases:
+    - "service design"
+    - "user journey map"
+    - "blueprint plan"
 ---
 
 # Skill: Federal Service Blueprint

--- a/.agents/skills/frontend/plain-language-review/SKILL.md
+++ b/.agents/skills/frontend/plain-language-review/SKILL.md
@@ -72,6 +72,26 @@ scope:
     - "Does not replace professional content design"
     - "Not a replacement for user research"
     - "Does not validate technical accuracy"
+
+collection: content
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "documentation"
+    - "web-page"
+  output_artifacts:
+    - "qa-report"
+  prefer_when:
+    - "the concern is wording, readability, jargon, or public-audience comprehension"
+  avoid_when:
+    - "the concern is doc correctness/links/staleness rather than wording"
+  aliases:
+    - "plain language"
+    - "readability review"
+    - "clarity edit"
+    - "public audience"
 ---
 
 # Skill: Federal Plain Language Review

--- a/.agents/skills/frontend/uswds-form-flow/SKILL.md
+++ b/.agents/skills/frontend/uswds-form-flow/SKILL.md
@@ -66,6 +66,23 @@ scope:
     - "Not for PRA compliance determination"
     - "Does not replace user testing"
     - "Does not generate backend processing logic"
+
+collection: digital-service
+routing:
+  task_types:
+    - "author"
+    - "render"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "form"
+    - "source-code"
+  prefer_when:
+    - "the request is to build a (multi-step) form"
+  aliases:
+    - "uswds form"
+    - "accessible form"
+    - "multi-step form"
 ---
 
 # Skill: USWDS Accessible Form Flow

--- a/.agents/skills/frontend/uswds-landing-page/SKILL.md
+++ b/.agents/skills/frontend/uswds-landing-page/SKILL.md
@@ -65,6 +65,23 @@ scope:
   exclusions:
     - "Not for complex web applications"
     - "Does not replace content strategy"
+
+collection: digital-service
+routing:
+  task_types:
+    - "author"
+    - "render"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "landing-page"
+    - "source-code"
+  prefer_when:
+    - "the request is to build a marketing/landing/service page"
+  aliases:
+    - "uswds landing"
+    - "service page"
+    - "hero page"
 ---
 
 # Skill: USWDS Service Landing Page

--- a/.agents/skills/frontend/uswds-prototype/SKILL.md
+++ b/.agents/skills/frontend/uswds-prototype/SKILL.md
@@ -70,6 +70,30 @@ scope:
     - "Not for complex web applications"
     - "Does not replace design system documentation"
     - "Does not provide final accessibility certification"
+
+collection: digital-service
+routing:
+  task_types:
+    - "author"
+    - "render"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "web-prototype"
+    - "source-code"
+  prefer_when:
+    - "the request is a general USWDS page/prototype with no more specific shape"
+  avoid_when:
+    - "the request is specifically a landing page or a form"
+  delegates:
+    - pattern: uswds-landing-page
+      when: "the request is specifically a landing/marketing page"
+    - pattern: uswds-form-flow
+      when: "the request is specifically a multi-step form"
+  aliases:
+    - "uswds prototype"
+    - "federal page"
+    - "html prototype"
 ---
 
 # Skill: USWDS Front-End Prototype

--- a/.agents/skills/incident-evidence-review/SKILL.md
+++ b/.agents/skills/incident-evidence-review/SKILL.md
@@ -99,6 +99,23 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — enforces evidence discipline on incident/postmortem write-ups by classifying facts, assumptions, hypotheses, and timeline, and flagging unsupported claims; conducts no investigation and asserts no root cause."
+
+collection: security
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "incident-evidence"
+    - "documentation"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the request is to review incident evidence or a postmortem"
+  aliases:
+    - "postmortem review"
+    - "incident review"
+    - "evidence discipline"
 ---
 
 # Skill: Incident Evidence Review

--- a/.agents/skills/least-privilege-review/SKILL.md
+++ b/.agents/skills/least-privilege-review/SKILL.md
@@ -96,6 +96,28 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — enumerates permission surfaces, flags over-broad grants, and suggests least-privilege replacements per NIST AC-6/AC-3, without granting any permission itself."
+
+collection: security
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "ci-workflow"
+    - "infrastructure-as-code"
+    - "source-code"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the question is specifically whether permissions/token scopes/IAM grants are minimal"
+  avoid_when:
+    - "the target is a CI workflow's overall safety (triggers, checkout, prompt construction)"
+  aliases:
+    - "least privilege"
+    - "token scope review"
+    - "iam review"
+    - "permission minimality"
+    - "permissions minimal"
 ---
 
 # Skill: Least Privilege Review

--- a/.agents/skills/meta/pattern-router/SKILL.md
+++ b/.agents/skills/meta/pattern-router/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: pattern-router
+id: pattern-router
+version: "1.0.0"
+title: "Pattern Router"
+description: "Route a request to the smallest appropriate set of patterns (workflow > skill > prompt) using structured routing metadata and the deterministic route_patterns.py scorer, instead of brittle keyword matching."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - agents
+  - developers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Route"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: meta
+triggers:
+  - "which skill"
+  - "which pattern"
+  - "how do I route"
+  - "what should I use for"
+tags:
+  - "meta"
+  - "routing"
+  - "discovery"
+routing:
+  task_types:
+    - discover
+    - orchestrate
+  input_artifacts: []
+  output_artifacts: []
+  aliases:
+    - "pattern selection"
+    - "skill router"
+  prefer_when:
+    - "You are unsure which pattern (workflow, skill, or prompt) best fits a request"
+    - "A request bundles several jobs and you need to decompose it into a minimal route"
+  avoid_when:
+    - "The correct pattern is already obvious from an explicit user instruction"
+  priority: 90
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Pattern Router
+
+## Summary
+
+Given a request, choose the **smallest appropriate route** through the pattern
+catalog. The router does not try to understand every procedure itself — it maps
+the request to structured routing metadata (`routing.*` in each pattern's
+frontmatter, surfaced in `INDEX.yaml`) and lets a deterministic scorer rank the
+candidates.
+
+The core rule:
+
+> **Prefer a workflow for an outcome, a skill for an operation, and a prompt only
+> when the environment cannot load the corresponding skill.**
+
+Routing **policy** lives in each pattern's metadata. **Orchestration** lives in
+workflows. The router only *selects*; it does not execute.
+
+## When to Use
+
+- You have a request and are not sure which pattern fits.
+- A request bundles several jobs ("research this, build a deck, check it for
+  accessibility") and you need to decompose it into a minimal set of patterns.
+- You want an explainable, testable selection instead of keyword guessing.
+
+## When NOT to Use
+
+- The user explicitly named the pattern to run.
+- You are executing an already-selected pattern (that is the pattern's job).
+
+## Prerequisites
+
+- A generated `INDEX.yaml` (`make generate`).
+- `scripts/route_patterns.py` and `schemas/taxonomy.yaml` present.
+
+## Procedure
+
+### 1. Decompose the request into facets
+
+You (the model) classify the request into controlled facets from
+`schemas/taxonomy.yaml`. Do **not** invent facet values — unknown values are
+rejected by the scorer.
+
+```yaml
+task_types:      [discover, author, visualize, review]   # controlled verbs
+input_artifacts: [documentation]                          # controlled slugs
+output_artifacts: [slide-deck]                            # controlled slugs
+keywords:        ["executive deck", "accessible"]         # free-text phrases
+constraints:     ["executive-audience", "accessible"]     # notes for assumptions
+```
+
+### 2. Run the deterministic scorer
+
+```bash
+python scripts/route_patterns.py \
+  --task author --task visualize \
+  --output slide-deck \
+  --keyword "executive deck" \
+  --json
+```
+
+or feed a request file:
+
+```bash
+python scripts/route_patterns.py --request-file /path/inside/repo/request.yaml --json
+```
+
+The scorer performs: **validate facets → filter → score → apply delegation →
+rank → explain**. Scoring (weights are tunable; explainability is the invariant):
+
+| Signal | Weight |
+|--------|-------:|
+| Exact output-artifact match | +40 |
+| Exact task-type match | +30 |
+| Exact input-artifact match | +15 |
+| Alias phrase match | +10 |
+| Trigger phrase match | +10 |
+| Collection match | +5 |
+| `recommended` status | +5 |
+| Matched `avoid_when` | −100 (hard exclude) |
+| Delegated to another pattern | −100 (hard exclude) |
+| Deprecated | −100 (hard exclude) |
+
+A candidate with **no** substantive facet/keyword match scores 0 and is dropped
+— the type-nudge and status bonus are tie-breakers, never standalone signals.
+This is what stops the router from "selecting every skill sharing a category".
+
+### 3. Read the route
+
+```yaml
+route:
+  primary:
+    id: design-artifact
+    type: workflow
+    reason: "output match: ['slide-deck']; task match: ['author']"
+  supporting:
+    - id: accessibility-review          # adds a distinct REQUESTED output
+  excluded:
+    - id: explainer-video
+      reason: "the requested output is a slide deck, not motion video"
+  assumptions:
+    - "HTML-first deck unless editable PPTX is explicitly required"
+```
+
+`supporting` only lists candidates that add a **distinct requested output** the
+primary does not cover — this keeps routes minimal.
+
+### 4. Prefer a workflow for an outcome
+
+If a workflow covers the requested outcome, take it. The workflow (not the
+router) knows the internal sequence of skills. Fall back to atomic skills only
+when no workflow fits, and select the **smallest set** that covers the request.
+
+### 5. Apply hard exclusions honestly
+
+Exclude a candidate when it is deprecated, its `avoid_when` matches, a more
+specific pattern owns the lane (`delegates`), required inputs are unavailable,
+or governance cannot be honored.
+
+## Verification
+
+- The route's `primary.reason` cites the concrete facet matches.
+- No excluded pattern appears as primary or supporting.
+- For security lanes, the selected pattern's governance frontmatter still
+  applies (`human_review_required: true` means output is advisory).
+- Regression cases live in `scripts/tests/router-cases.yaml`; run
+  `PYTHONPATH=scripts pytest scripts/tests/test_route_patterns.py`.
+
+## Examples
+
+| Request | Primary | Notably NOT |
+|---------|---------|-------------|
+| "Audit this GitHub Actions workflow for unsafe `pull_request_target`" | `agentic-actions-auditor` | `least-privilege-review`, `secure-code-review` |
+| "Are these `GITHUB_TOKEN` permissions broader than necessary?" | `least-privilege-review` | `agentic-actions-auditor` |
+| "Create an executive one-pager explaining the pilot" | `design-artifact` (one-pager) | assembling six skills by hand |
+| "Make this README easier for the public to understand" | `plain-language-review` | `documentation-review` |
+| "Check this README for stale commands and broken links" | `documentation-review` | `plain-language-review` |
+
+## Notes
+
+- The router is **data-driven** — do not hand-maintain a giant decision tree
+  here. New routing knowledge goes into the target pattern's `routing.*`
+  metadata, not into this file.
+- No embeddings / vector DB: at this catalog's scale explicit metadata is
+  cheaper, clearer, and reliably testable.

--- a/.agents/skills/outreach/explainer-gif/SKILL.md
+++ b/.agents/skills/outreach/explainer-gif/SKILL.md
@@ -69,6 +69,29 @@ scope:
     - "Not for live, unscripted screen captures (use a screen recorder)"
     - "Not for GUI or browser demos (use a video tool; see explainer-video)"
     - "Does not replace prose documentation — pair the GIF with a text summary"
+
+collection: communications
+routing:
+  task_types:
+    - "author"
+    - "render"
+  input_artifacts:
+    - "artifact-brief"
+    - "shell-script"
+  output_artifacts:
+    - "explainer-gif"
+    - "terminal-demo"
+  prefer_when:
+    - "the request is a short terminal screencast/GIF"
+  avoid_when:
+    - "the request is a narrated/animated motion video"
+  delegates:
+    - pattern: explainer-video
+      when: "the request is a full motion/animated explainer video"
+  aliases:
+    - "terminal screencast"
+    - "demo gif"
+    - "vhs tape"
 ---
 
 # Skill: Explainer GIF (Terminal Screencast)

--- a/.agents/skills/outreach/explainer-video/SKILL.md
+++ b/.agents/skills/outreach/explainer-video/SKILL.md
@@ -70,6 +70,26 @@ scope:
     - "Not for hosted-cloud rendering of sensitive content"
     - "Not a replacement for accessible text — pair every video with a text summary"
     - "Not for crawling or capturing arbitrary web pages"
+
+collection: communications
+routing:
+  task_types:
+    - "author"
+    - "render"
+  input_artifacts:
+    - "artifact-brief"
+    - "web-page"
+  output_artifacts:
+    - "explainer-video"
+    - "marketing-asset"
+  prefer_when:
+    - "the request is an animated/narrated explainer video"
+  avoid_when:
+    - "the request is a static slide deck or one-pager"
+  aliases:
+    - "html to video"
+    - "promo video"
+    - "launch video"
 ---
 
 # Skill: Explainer Video (HTML to MP4)

--- a/.agents/skills/over-engineering-review/SKILL.md
+++ b/.agents/skills/over-engineering-review/SKILL.md
@@ -66,6 +66,23 @@ scope:
     - "Not a correctness or security review (use secure-code-review for that)"
     - "Not a license to remove validation, error handling, security, or accessibility"
     - "Not a style/formatting linter"
+
+collection: engineering
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "pull-request-diff"
+    - "source-code"
+  output_artifacts:
+    - "qa-report"
+  prefer_when:
+    - "the concern is unnecessary complexity or speculative generality"
+  aliases:
+    - "simplify review"
+    - "yagni check"
+    - "complexity review"
 ---
 
 # Skill: Over-Engineering Review

--- a/.agents/skills/safe-shell-script-author/SKILL.md
+++ b/.agents/skills/safe-shell-script-author/SKILL.md
@@ -87,6 +87,21 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — drafts safe Bash to a clean-script standard (strict mode, mktemp + trap, quoted vars, dry-run default), refuses curl|sh/eval/secret dumps, never executes."
+
+collection: engineering
+routing:
+  task_types:
+    - "author"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "shell-script"
+  prefer_when:
+    - "the request is to author a safe shell/bash script"
+  aliases:
+    - "bash author"
+    - "safe script"
+    - "automation script"
 ---
 
 # Skill: Safe Shell Script Author

--- a/.agents/skills/secure-code-review/SKILL.md
+++ b/.agents/skills/secure-code-review/SKILL.md
@@ -98,6 +98,40 @@ scope:
     - "Agent-invoking or injection-reachable CI triggers: defer to agentic-actions-auditor"
     - "Scope-minimality judgments (GITHUB_TOKEN / IAM scope): defer to least-privilege-review"
     - "Supply-chain / dependency intake: defer to dependency-analysis"
+
+collection: security
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "source-code"
+    - "pull-request-diff"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the request asks for vulnerabilities, insecure behavior, or OWASP risks in ordinary application code"
+  avoid_when:
+    - "the request specifically concerns an LLM-invoking CI workflow"
+    - "the request is solely about permission minimality"
+    - "the request concerns dependency or package risk"
+    - "the request concerns prompt injection crossing a trust boundary"
+    - "the request concerns a deliberate backdoor or hidden malice"
+  delegates:
+    - pattern: agentic-actions-auditor
+      when: "the target is an agent-invoking CI workflow"
+    - pattern: least-privilege-review
+      when: "the question is specifically whether permissions are minimal"
+    - pattern: dependency-analysis
+      when: "the question concerns dependencies or supply-chain intake"
+    - pattern: untrusted-input-boundary-review
+      when: "the question is specifically about untrusted input crossing a trust boundary or prompt injection"
+    - pattern: backdoor-review
+      when: "the ask implies a deliberate backdoor, auth bypass, or hidden persistence"
+  aliases:
+    - "owasp review"
+    - "vulnerability review"
+    - "security code review"
 ---
 
 # Skill: Secure Code Review
@@ -120,6 +154,8 @@ adjacent lanes — flag and defer, do not re-implement them:
 | An agent-invoking or injection-reachable CI trigger (`pull_request_target`, `issue_comment`, `workflow_run` with untrusted checkout, a prompt built from PR/issue text) | **agentic-actions-auditor** |
 | A judgment about whether a granted scope is *minimal* (GITHUB_TOKEN permissions, IAM scope) | **least-privilege-review** |
 | Supply-chain or dependency intake (new packages, CVEs, licenses) | **dependency-analysis** |
+| Untrusted input crossing a trust boundary / prompt injection reaching a sink | **untrusted-input-boundary-review** |
+| Signs of a *deliberate* backdoor, auth bypass, or hidden persistence (not an accidental bug) | **backdoor-review** |
 
 secure-code-review's lane for CI is **general workflow-file code-review hygiene
 plus the blast radius of the changed workflow in the diff** — not a full agent
@@ -434,6 +470,8 @@ document.getElementById('message').textContent = userInput;
 - [dependency-analysis](../dependency-analysis/SKILL.md) - Supply-chain and vulnerable-dependency intake
 - [agentic-actions-auditor](../agentic-actions-auditor/SKILL.md) - Agent-invoking / injection-reachable CI triggers
 - [least-privilege-review](../least-privilege-review/SKILL.md) - Whether a granted scope (token/IAM) is minimal
+- [untrusted-input-boundary-review](../untrusted-input-boundary-review/SKILL.md) - Untrusted input / prompt injection crossing a trust boundary
+- [backdoor-review](../backdoor-review/SKILL.md) - Deliberate backdoors, auth bypasses, or hidden persistence
 - [test-generation](../test-generation/SKILL.md) - Generate security test cases
 
 ## References

--- a/.agents/skills/test-generation/SKILL.md
+++ b/.agents/skills/test-generation/SKILL.md
@@ -65,6 +65,23 @@ scope:
     - "Not for integration/e2e test generation"
     - "Not for performance/load testing"
     - "Not for manual test case writing"
+
+collection: engineering
+routing:
+  task_types:
+    - "author"
+    - "test"
+  input_artifacts:
+    - "source-code"
+  output_artifacts:
+    - "source-code"
+    - "qa-report"
+  prefer_when:
+    - "the request is to generate tests or improve coverage"
+  aliases:
+    - "unit test gen"
+    - "test author"
+    - "coverage analysis"
 ---
 
 # Skill: Test Case Generation

--- a/.agents/skills/untrusted-input-boundary-review/SKILL.md
+++ b/.agents/skills/untrusted-input-boundary-review/SKILL.md
@@ -88,6 +88,24 @@ changelog:
     date: "2026-07-01"
     change_type: minor
     summary: "Initial version — maps agent trust boundaries and reviews untrusted-input handling for prompt-injection and tool-poisoning classes; describes attack classes only, never ships a live payload."
+
+collection: security
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "source-code"
+  output_artifacts:
+    - "security-review"
+  prefer_when:
+    - "the concern is untrusted input or prompt injection crossing a trust boundary"
+  avoid_when:
+    - "the concern is a general code security review"
+  aliases:
+    - "prompt injection review"
+    - "trust boundary review"
+    - "tool poisoning check"
 ---
 
 # Skill: Untrusted Input Boundary Review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
       - name: Run validation
         run: make validate
 
+      - name: Check generated files are current (INDEX.yaml + CATALOG.md)
+        run: make generate-check
+
       - name: Validate acq-kits (hybrid/v1 schema)
         run: make validate-kits
 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -2,7 +2,7 @@
 
 > **Generated file — do not edit by hand.** Run `make generate` (regenerates INDEX.yaml + CATALOG.md). Source of truth is each pattern's `SKILL.md`/`AGENTS.md` frontmatter.
 
-31 patterns — 21 skills, 3 prompts, 3 agents, 3 workflows, 1 lessons.
+38 patterns — 27 skills, 3 prompts, 3 agents, 4 workflows, 1 lessons.
 
 For machine routing use the [`pattern-router`](.agents/skills/meta/pattern-router/SKILL.md) skill + `scripts/route_patterns.py`; this catalog is the human view.
 
@@ -64,5 +64,12 @@ For machine routing use the [`pattern-router`](.agents/skills/meta/pattern-route
 
 | Pattern | Type | Status | Tasks | Consumes | Produces |
 |---------|------|--------|-------|----------|----------|
+| [`artifact-brief`](skills/communications/artifact-brief/SKILL.md) | skill | experimental | plan | documentation | artifact-brief |
+| [`artifact-qa`](skills/communications/artifact-qa/SKILL.md) | skill | experimental | review, test | one-pager, slide-deck | qa-report |
+| [`design-artifact`](workflows/design-artifact/SKILL.md) | workflow | experimental | author, orchestrate, render, review, visualize | documentation | one-pager, slide-deck |
 | [`explainer-gif`](skills/outreach/explainer-gif/SKILL.md) | skill | experimental | author, render | artifact-brief, shell-script | explainer-gif, terminal-demo |
 | [`explainer-video`](skills/outreach/explainer-video/SKILL.md) | skill | experimental | author, render | artifact-brief, web-page | explainer-video, marketing-asset |
+| [`narrative-architect`](skills/communications/narrative-architect/SKILL.md) | skill | experimental | plan, visualize | artifact-brief | storyboard |
+| [`one-pager`](skills/communications/one-pager/SKILL.md) | skill | experimental | author, render | artifact-brief, storyboard, visual-contract | one-pager |
+| [`slide-deck`](skills/communications/slide-deck/SKILL.md) | skill | experimental | author, render | artifact-brief, storyboard, visual-contract | slide-deck |
+| [`visual-direction`](skills/communications/visual-direction/SKILL.md) | skill | experimental | visualize | storyboard | visual-contract |

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,0 +1,68 @@
+# Pattern Catalog
+
+> **Generated file — do not edit by hand.** Run `make generate` (regenerates INDEX.yaml + CATALOG.md). Source of truth is each pattern's `SKILL.md`/`AGENTS.md` frontmatter.
+
+31 patterns — 21 skills, 3 prompts, 3 agents, 3 workflows, 1 lessons.
+
+For machine routing use the [`pattern-router`](.agents/skills/meta/pattern-router/SKILL.md) skill + `scripts/route_patterns.py`; this catalog is the human view.
+
+## Meta
+
+| Pattern | Type | Status | Tasks | Consumes | Produces |
+|---------|------|--------|-------|----------|----------|
+| [`example-agentic-session`](lessons-learned/example-agentic-session/SKILL.md) | lesson | experimental | analyze | documentation | documentation |
+| [`pattern-router`](skills/meta/pattern-router/SKILL.md) | skill | experimental | discover, orchestrate | — | — |
+
+## Engineering
+
+| Pattern | Type | Status | Tasks | Consumes | Produces |
+|---------|------|--------|-------|----------|----------|
+| [`general-agent`](agents/general/AGENTS.md) | agent | experimental | author, plan | source-code | source-code |
+| [`implementation-plan`](prompts/planning/implementation-plan/SKILL.md) | prompt | experimental | plan | artifact-brief | documentation |
+| [`issue-to-merge-request`](workflows/issue-to-merge-request/SKILL.md) | workflow | experimental | author, orchestrate, test | artifact-brief | pull-request-diff, source-code |
+| [`over-engineering-review`](skills/over-engineering-review/SKILL.md) | skill | experimental | analyze, review | pull-request-diff, source-code | qa-report |
+| [`qa-round`](prompts/review/qa-round/SKILL.md) | prompt | experimental | review, test | pull-request-diff, source-code | qa-report |
+| [`qa-workflow`](workflows/qa-round/SKILL.md) | workflow | experimental | orchestrate, review, test | source-code | qa-report |
+| [`safe-shell-script-author`](skills/safe-shell-script-author/SKILL.md) | skill | experimental | author | artifact-brief | shell-script |
+| [`test-generation`](skills/test-generation/SKILL.md) | skill | experimental | author, test | source-code | qa-report, source-code |
+
+## Security
+
+| Pattern | Type | Status | Tasks | Consumes | Produces |
+|---------|------|--------|-------|----------|----------|
+| [`agentic-actions-auditor`](skills/agentic-actions-auditor/SKILL.md) | skill | experimental | analyze, review | ci-workflow, source-code | security-review |
+| [`backdoor-review`](skills/backdoor-review/SKILL.md) | skill | experimental | analyze, review | ci-workflow, pull-request-diff, source-code | security-review |
+| [`compliance-claim-checker`](skills/compliance-claim-checker/SKILL.md) | skill | experimental | analyze, review | compliance-claim, documentation, pull-request-diff | security-review |
+| [`dependency-analysis`](skills/dependency-analysis/SKILL.md) | skill | experimental | analyze, review | dependency-manifest, source-code | security-review |
+| [`incident-evidence-review`](skills/incident-evidence-review/SKILL.md) | skill | experimental | analyze, review | documentation, incident-evidence | security-review |
+| [`least-privilege-review`](skills/least-privilege-review/SKILL.md) | skill | experimental | analyze, review | ci-workflow, infrastructure-as-code, source-code | security-review |
+| [`safe-code-review`](prompts/security/safe-code-review/SKILL.md) | prompt | deprecated | analyze, review | pull-request-diff, source-code | security-review |
+| [`secure-code-review`](skills/secure-code-review/SKILL.md) | skill | experimental | analyze, review | pull-request-diff, source-code | security-review |
+| [`security-review-agent`](agents/security-review/AGENTS.md) | agent | experimental | analyze, review | pull-request-diff, source-code | security-review |
+| [`security-scan-review`](workflows/security-scan-review/SKILL.md) | workflow | experimental | analyze, orchestrate, review | dependency-manifest, source-code | security-review |
+| [`untrusted-input-boundary-review`](skills/untrusted-input-boundary-review/SKILL.md) | skill | experimental | analyze, review | source-code | security-review |
+
+## Content
+
+| Pattern | Type | Status | Tasks | Consumes | Produces |
+|---------|------|--------|-------|----------|----------|
+| [`documentation-agent`](agents/documentation/AGENTS.md) | agent | experimental | author, review | documentation | documentation |
+| [`documentation-review`](skills/documentation-review/SKILL.md) | skill | experimental | analyze, review | documentation | qa-report |
+| [`plain-language-review`](skills/frontend/plain-language-review/SKILL.md) | skill | experimental | analyze, review | documentation, web-page | qa-report |
+
+## Digital Service
+
+| Pattern | Type | Status | Tasks | Consumes | Produces |
+|---------|------|--------|-------|----------|----------|
+| [`accessibility-review`](skills/frontend/accessibility-review/SKILL.md) | skill | experimental | analyze, review | source-code, web-page, web-prototype | qa-report |
+| [`federal-service-blueprint`](skills/frontend/federal-service-blueprint/SKILL.md) | skill | experimental | discover, plan | artifact-brief | documentation, service-blueprint |
+| [`uswds-form-flow`](skills/frontend/uswds-form-flow/SKILL.md) | skill | experimental | author, render | artifact-brief | form, source-code |
+| [`uswds-landing-page`](skills/frontend/uswds-landing-page/SKILL.md) | skill | experimental | author, render | artifact-brief | landing-page, source-code |
+| [`uswds-prototype`](skills/frontend/uswds-prototype/SKILL.md) | skill | experimental | author, render | artifact-brief | source-code, web-prototype |
+
+## Communications
+
+| Pattern | Type | Status | Tasks | Consumes | Produces |
+|---------|------|--------|-------|----------|----------|
+| [`explainer-gif`](skills/outreach/explainer-gif/SKILL.md) | skill | experimental | author, render | artifact-brief, shell-script | explainer-gif, terminal-demo |
+| [`explainer-video`](skills/outreach/explainer-video/SKILL.md) | skill | experimental | author, render | artifact-brief, web-page | explainer-video, marketing-asset |

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -128,6 +128,21 @@ patterns:
     - development
     collection: null
     routing: {}
+  - path: skills/meta/pattern-router/SKILL.md
+    id: pattern-router
+    title: Pattern Router
+    type: skill
+    status: experimental
+    categories: []
+    collection: meta
+    routing:
+      task_types:
+      - discover
+      - orchestrate
+      aliases:
+      - pattern selection
+      - skill router
+      priority: 90
   - path: skills/frontend/plain-language-review/SKILL.md
     id: plain-language-review
     title: Federal Plain Language Review
@@ -380,12 +395,18 @@ categories:
   - uswds-form-flow
   - uswds-landing-page
   - uswds-prototype
-collections: {}
-task_types: {}
+collections:
+  meta:
+  - pattern-router
+task_types:
+  discover:
+  - pattern-router
+  orchestrate:
+  - pattern-router
 output_artifacts: {}
 stats:
-  total_patterns: 30
-  skills: 20
+  total_patterns: 31
+  skills: 21
   prompts: 3
   agents: 3
   workflows: 3

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -50,6 +50,44 @@ patterns:
       - ci agent audit
       - github actions security
       - workflow audit
+  - path: skills/communications/artifact-brief/SKILL.md
+    id: artifact-brief
+    title: Artifact Brief
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - plan
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - artifact-brief
+      aliases:
+      - comms brief
+      - message brief
+      priority: 60
+  - path: skills/communications/artifact-qa/SKILL.md
+    id: artifact-qa
+    title: Artifact QA
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - review
+      - test
+      input_artifacts:
+      - one-pager
+      - slide-deck
+      output_artifacts:
+      - qa-report
+      aliases:
+      - artifact review
+      - design qa
+      priority: 55
   - path: skills/backdoor-review/SKILL.md
     id: backdoor-review
     title: Backdoor Review
@@ -258,6 +296,46 @@ patterns:
       - permission minimality
       - permissions minimal
       - token scope review
+  - path: skills/communications/narrative-architect/SKILL.md
+    id: narrative-architect
+    title: Narrative Architect
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - plan
+      - visualize
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - storyboard
+      aliases:
+      - outline the argument
+      - story structure
+      priority: 55
+  - path: skills/communications/one-pager/SKILL.md
+    id: one-pager
+    title: One-Pager
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      - storyboard
+      - visual-contract
+      output_artifacts:
+      - one-pager
+      aliases:
+      - executive one-pager
+      - leave-behind
+      priority: 55
   - path: skills/over-engineering-review/SKILL.md
     id: over-engineering-review
     title: Over-Engineering Review
@@ -361,6 +439,27 @@ patterns:
       - owasp review
       - security code review
       - vulnerability review
+  - path: skills/communications/slide-deck/SKILL.md
+    id: slide-deck
+    title: Slide Deck
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      - storyboard
+      - visual-contract
+      output_artifacts:
+      - slide-deck
+      aliases:
+      - briefing slides
+      - presentation deck
+      priority: 55
   - path: skills/test-generation/SKILL.md
     id: test-generation
     title: Test Case Generation
@@ -467,6 +566,24 @@ patterns:
       - federal page
       - html prototype
       - uswds prototype
+  - path: skills/communications/visual-direction/SKILL.md
+    id: visual-direction
+    title: Visual Direction
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - visualize
+      input_artifacts:
+      - storyboard
+      output_artifacts:
+      - visual-contract
+      aliases:
+      - design system for this artifact
+      - look and feel
+      priority: 55
   prompts:
   - path: prompts/planning/implementation-plan/SKILL.md
     id: implementation-plan
@@ -592,6 +709,30 @@ patterns:
       - security agent
       - vuln review agent
   workflows:
+  - path: workflows/design-artifact/SKILL.md
+    id: design-artifact
+    title: Design Artifact Workflow
+    type: workflow
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - author
+      - orchestrate
+      - render
+      - review
+      - visualize
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - one-pager
+      - slide-deck
+      aliases:
+      - design pipeline
+      - executive one-pager
+      - presentation deck
+      priority: 70
   - path: workflows/issue-to-merge-request/SKILL.md
     id: issue-to-merge-request
     title: Issue to Merge Request Workflow
@@ -756,8 +897,15 @@ categories:
   - uswds-prototype
 collections:
   communications:
+  - artifact-brief
+  - artifact-qa
+  - design-artifact
   - explainer-gif
   - explainer-video
+  - narrative-architect
+  - one-pager
+  - slide-deck
+  - visual-direction
   content:
   - documentation-agent
   - documentation-review
@@ -811,12 +959,15 @@ task_types:
   - security-scan-review
   - untrusted-input-boundary-review
   author:
+  - design-artifact
   - documentation-agent
   - explainer-gif
   - explainer-video
   - general-agent
   - issue-to-merge-request
+  - one-pager
   - safe-shell-script-author
+  - slide-deck
   - test-generation
   - uswds-form-flow
   - uswds-landing-page
@@ -825,26 +976,34 @@ task_types:
   - federal-service-blueprint
   - pattern-router
   orchestrate:
+  - design-artifact
   - issue-to-merge-request
   - pattern-router
   - qa-workflow
   - security-scan-review
   plan:
+  - artifact-brief
   - federal-service-blueprint
   - general-agent
   - implementation-plan
+  - narrative-architect
   render:
+  - design-artifact
   - explainer-gif
   - explainer-video
+  - one-pager
+  - slide-deck
   - uswds-form-flow
   - uswds-landing-page
   - uswds-prototype
   review:
   - accessibility-review
   - agentic-actions-auditor
+  - artifact-qa
   - backdoor-review
   - compliance-claim-checker
   - dependency-analysis
+  - design-artifact
   - documentation-agent
   - documentation-review
   - incident-evidence-review
@@ -859,11 +1018,18 @@ task_types:
   - security-scan-review
   - untrusted-input-boundary-review
   test:
+  - artifact-qa
   - issue-to-merge-request
   - qa-round
   - qa-workflow
   - test-generation
+  visualize:
+  - design-artifact
+  - narrative-architect
+  - visual-direction
 output_artifacts:
+  artifact-brief:
+  - artifact-brief
   documentation:
   - documentation-agent
   - example-agentic-session
@@ -879,10 +1045,14 @@ output_artifacts:
   - uswds-landing-page
   marketing-asset:
   - explainer-video
+  one-pager:
+  - design-artifact
+  - one-pager
   pull-request-diff:
   - issue-to-merge-request
   qa-report:
   - accessibility-review
+  - artifact-qa
   - documentation-review
   - over-engineering-review
   - plain-language-review
@@ -905,6 +1075,9 @@ output_artifacts:
   - federal-service-blueprint
   shell-script:
   - safe-shell-script-author
+  slide-deck:
+  - design-artifact
+  - slide-deck
   source-code:
   - general-agent
   - issue-to-merge-request
@@ -912,14 +1085,18 @@ output_artifacts:
   - uswds-form-flow
   - uswds-landing-page
   - uswds-prototype
+  storyboard:
+  - narrative-architect
   terminal-demo:
   - explainer-gif
+  visual-contract:
+  - visual-direction
   web-prototype:
   - uswds-prototype
 stats:
-  total_patterns: 31
-  skills: 21
+  total_patterns: 38
+  skills: 27
   prompts: 3
   agents: 3
-  workflows: 3
+  workflows: 4
   lessons: 1

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -12,8 +12,21 @@ patterns:
     - frontend
     - review
     - compliance
-    collection: null
-    routing: {}
+    collection: digital-service
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - source-code
+      - web-page
+      - web-prototype
+      output_artifacts:
+      - qa-report
+      aliases:
+      - a11y review
+      - section 508 check
+      - wcag audit
   - path: skills/agentic-actions-auditor/SKILL.md
     id: agentic-actions-auditor
     title: Agentic Actions Auditor
@@ -23,8 +36,20 @@ patterns:
     - security
     - review
     - supply-chain
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - ci-workflow
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - ci agent audit
+      - github actions security
+      - workflow audit
   - path: skills/backdoor-review/SKILL.md
     id: backdoor-review
     title: Backdoor Review
@@ -33,8 +58,21 @@ patterns:
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - ci-workflow
+      - pull-request-diff
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - adversarial review
+      - backdoor scan
+      - integrity review
   - path: skills/compliance-claim-checker/SKILL.md
     id: compliance-claim-checker
     title: Compliance Claim Checker
@@ -44,8 +82,21 @@ patterns:
     - security
     - compliance
     - documentation
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - compliance-claim
+      - documentation
+      - pull-request-diff
+      output_artifacts:
+      - security-review
+      aliases:
+      - compliance claim review
+      - fedramp claim check
+      - overclaim check
   - path: skills/dependency-analysis/SKILL.md
     id: dependency-analysis
     title: Dependency Security Analysis
@@ -55,8 +106,20 @@ patterns:
     - security
     - dependencies
     - supply-chain
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - dependency-manifest
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - dependency audit
+      - dependency risk
+      - supply chain review
   - path: skills/documentation-review/SKILL.md
     id: documentation-review
     title: Documentation Review
@@ -65,8 +128,20 @@ patterns:
     categories:
     - documentation
     - review
-    collection: null
-    routing: {}
+    collection: content
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - qa-report
+      aliases:
+      - broken links
+      - doc quality check
+      - docs review
+      - stale commands
   - path: skills/outreach/explainer-gif/SKILL.md
     id: explainer-gif
     title: Explainer GIF (Terminal Screencast)
@@ -74,8 +149,21 @@ patterns:
     status: experimental
     categories:
     - documentation
-    collection: null
-    routing: {}
+    collection: communications
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      - shell-script
+      output_artifacts:
+      - explainer-gif
+      - terminal-demo
+      aliases:
+      - demo gif
+      - terminal screencast
+      - vhs tape
   - path: skills/outreach/explainer-video/SKILL.md
     id: explainer-video
     title: Explainer Video (HTML to MP4)
@@ -84,8 +172,21 @@ patterns:
     categories:
     - documentation
     - supply-chain
-    collection: null
-    routing: {}
+    collection: communications
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      - web-page
+      output_artifacts:
+      - explainer-video
+      - marketing-asset
+      aliases:
+      - html to video
+      - launch video
+      - promo video
   - path: skills/frontend/federal-service-blueprint/SKILL.md
     id: federal-service-blueprint
     title: Federal Service Blueprint
@@ -95,8 +196,20 @@ patterns:
     - frontend
     - compliance
     - documentation
-    collection: null
-    routing: {}
+    collection: digital-service
+    routing:
+      task_types:
+      - discover
+      - plan
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - documentation
+      - service-blueprint
+      aliases:
+      - blueprint plan
+      - service design
+      - user journey map
   - path: skills/incident-evidence-review/SKILL.md
     id: incident-evidence-review
     title: Incident Evidence Review
@@ -106,8 +219,20 @@ patterns:
     - security
     - incident-response
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - documentation
+      - incident-evidence
+      output_artifacts:
+      - security-review
+      aliases:
+      - evidence discipline
+      - incident review
+      - postmortem review
   - path: skills/least-privilege-review/SKILL.md
     id: least-privilege-review
     title: Least Privilege Review
@@ -116,8 +241,23 @@ patterns:
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - ci-workflow
+      - infrastructure-as-code
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - iam review
+      - least privilege
+      - permission minimality
+      - permissions minimal
+      - token scope review
   - path: skills/over-engineering-review/SKILL.md
     id: over-engineering-review
     title: Over-Engineering Review
@@ -126,8 +266,20 @@ patterns:
     categories:
     - review
     - development
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - pull-request-diff
+      - source-code
+      output_artifacts:
+      - qa-report
+      aliases:
+      - complexity review
+      - simplify review
+      - yagni check
   - path: skills/meta/pattern-router/SKILL.md
     id: pattern-router
     title: Pattern Router
@@ -152,8 +304,21 @@ patterns:
     - frontend
     - documentation
     - review
-    collection: null
-    routing: {}
+    collection: content
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - documentation
+      - web-page
+      output_artifacts:
+      - qa-report
+      aliases:
+      - clarity edit
+      - plain language
+      - public audience
+      - readability review
   - path: skills/safe-shell-script-author/SKILL.md
     id: safe-shell-script-author
     title: Safe Shell Script Author
@@ -162,8 +327,18 @@ patterns:
     categories:
     - security
     - development
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - author
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - shell-script
+      aliases:
+      - automation script
+      - bash author
+      - safe script
   - path: skills/secure-code-review/SKILL.md
     id: secure-code-review
     title: Secure Code Review
@@ -172,8 +347,20 @@ patterns:
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - pull-request-diff
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - owasp review
+      - security code review
+      - vulnerability review
   - path: skills/test-generation/SKILL.md
     id: test-generation
     title: Test Case Generation
@@ -181,8 +368,20 @@ patterns:
     status: experimental
     categories:
     - testing
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - author
+      - test
+      input_artifacts:
+      - source-code
+      output_artifacts:
+      - qa-report
+      - source-code
+      aliases:
+      - coverage analysis
+      - test author
+      - unit test gen
   - path: skills/untrusted-input-boundary-review/SKILL.md
     id: untrusted-input-boundary-review
     title: Untrusted Input Boundary Review
@@ -191,8 +390,19 @@ patterns:
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - prompt injection review
+      - tool poisoning check
+      - trust boundary review
   - path: skills/frontend/uswds-form-flow/SKILL.md
     id: uswds-form-flow
     title: USWDS Accessible Form Flow
@@ -201,8 +411,20 @@ patterns:
     categories:
     - frontend
     - compliance
-    collection: null
-    routing: {}
+    collection: digital-service
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - form
+      - source-code
+      aliases:
+      - accessible form
+      - multi-step form
+      - uswds form
   - path: skills/frontend/uswds-landing-page/SKILL.md
     id: uswds-landing-page
     title: USWDS Service Landing Page
@@ -210,8 +432,20 @@ patterns:
     status: experimental
     categories:
     - frontend
-    collection: null
-    routing: {}
+    collection: digital-service
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - landing-page
+      - source-code
+      aliases:
+      - hero page
+      - service page
+      - uswds landing
   - path: skills/frontend/uswds-prototype/SKILL.md
     id: uswds-prototype
     title: USWDS Front-End Prototype
@@ -219,8 +453,20 @@ patterns:
     status: experimental
     categories:
     - frontend
-    collection: null
-    routing: {}
+    collection: digital-service
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - source-code
+      - web-prototype
+      aliases:
+      - federal page
+      - html prototype
+      - uswds prototype
   prompts:
   - path: prompts/planning/implementation-plan/SKILL.md
     id: implementation-plan
@@ -229,8 +475,18 @@ patterns:
     status: experimental
     categories:
     - development
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - plan
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - documentation
+      aliases:
+      - feature plan
+      - implementation plan
+      - task breakdown
   - path: prompts/review/qa-round/SKILL.md
     id: qa-round
     title: QA Round Review
@@ -239,18 +495,42 @@ patterns:
     categories:
     - testing
     - review
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - review
+      - test
+      input_artifacts:
+      - pull-request-diff
+      - source-code
+      output_artifacts:
+      - qa-report
+      aliases:
+      - acceptance check
+      - qa this diff
+      - single qa review
   - path: prompts/security/safe-code-review/SKILL.md
     id: safe-code-review
     title: Security-Focused Code Review
     type: prompt
-    status: experimental
+    status: deprecated
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - pull-request-diff
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - security code review
+      - vulnerability review
+      priority: 0
   agents:
   - path: agents/documentation/AGENTS.md
     id: documentation-agent
@@ -259,8 +539,18 @@ patterns:
     status: experimental
     categories:
     - documentation
-    collection: null
-    routing: {}
+    collection: content
+    routing:
+      task_types:
+      - author
+      - review
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - documentation
+      aliases:
+      - docs agent
+      - tech writer agent
   - path: agents/general/AGENTS.md
     id: general-agent
     title: General Agent Instructions
@@ -268,8 +558,18 @@ patterns:
     status: experimental
     categories:
     - development
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - author
+      - plan
+      input_artifacts:
+      - source-code
+      output_artifacts:
+      - source-code
+      aliases:
+      - coding agent
+      - general dev agent
   - path: agents/security-review/AGENTS.md
     id: security-review-agent
     title: Security Review Agent Instructions
@@ -278,8 +578,19 @@ patterns:
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - review
+      input_artifacts:
+      - pull-request-diff
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - security agent
+      - vuln review agent
   workflows:
   - path: workflows/issue-to-merge-request/SKILL.md
     id: issue-to-merge-request
@@ -290,8 +601,21 @@ patterns:
     - development
     - review
     - testing
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - author
+      - orchestrate
+      - test
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - pull-request-diff
+      - source-code
+      aliases:
+      - dev cycle
+      - feature workflow
+      - issue to pr
   - path: workflows/qa-round/SKILL.md
     id: qa-workflow
     title: QA Round Workflow
@@ -300,8 +624,20 @@ patterns:
     categories:
     - testing
     - review
-    collection: null
-    routing: {}
+    collection: engineering
+    routing:
+      task_types:
+      - orchestrate
+      - review
+      - test
+      input_artifacts:
+      - source-code
+      output_artifacts:
+      - qa-report
+      aliases:
+      - qa process
+      - qa signoff
+      - testing cycle
   - path: workflows/security-scan-review/SKILL.md
     id: security-scan-review
     title: Language-Aware Security Scan & Triage Workflow
@@ -310,8 +646,21 @@ patterns:
     categories:
     - security
     - review
-    collection: null
-    routing: {}
+    collection: security
+    routing:
+      task_types:
+      - analyze
+      - orchestrate
+      - review
+      input_artifacts:
+      - dependency-manifest
+      - source-code
+      output_artifacts:
+      - security-review
+      aliases:
+      - language-aware scan
+      - sarif triage
+      - scan triage
   lessons:
   - path: lessons-learned/example-agentic-session/SKILL.md
     id: example-agentic-session
@@ -321,8 +670,18 @@ patterns:
     categories:
     - security
     - documentation
-    collection: null
-    routing: {}
+    collection: meta
+    routing:
+      task_types:
+      - analyze
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - documentation
+      aliases:
+      - multi-pattern example
+      - retro
+      - session lesson
 categories:
   security:
   - agentic-actions-auditor
@@ -396,14 +755,167 @@ categories:
   - uswds-landing-page
   - uswds-prototype
 collections:
+  communications:
+  - explainer-gif
+  - explainer-video
+  content:
+  - documentation-agent
+  - documentation-review
+  - plain-language-review
+  digital-service:
+  - accessibility-review
+  - federal-service-blueprint
+  - uswds-form-flow
+  - uswds-landing-page
+  - uswds-prototype
+  engineering:
+  - general-agent
+  - implementation-plan
+  - issue-to-merge-request
+  - over-engineering-review
+  - qa-round
+  - qa-workflow
+  - safe-shell-script-author
+  - test-generation
   meta:
+  - example-agentic-session
   - pattern-router
+  security:
+  - agentic-actions-auditor
+  - backdoor-review
+  - compliance-claim-checker
+  - dependency-analysis
+  - incident-evidence-review
+  - least-privilege-review
+  - safe-code-review
+  - secure-code-review
+  - security-review-agent
+  - security-scan-review
+  - untrusted-input-boundary-review
 task_types:
+  analyze:
+  - accessibility-review
+  - agentic-actions-auditor
+  - backdoor-review
+  - compliance-claim-checker
+  - dependency-analysis
+  - documentation-review
+  - example-agentic-session
+  - incident-evidence-review
+  - least-privilege-review
+  - over-engineering-review
+  - plain-language-review
+  - safe-code-review
+  - secure-code-review
+  - security-review-agent
+  - security-scan-review
+  - untrusted-input-boundary-review
+  author:
+  - documentation-agent
+  - explainer-gif
+  - explainer-video
+  - general-agent
+  - issue-to-merge-request
+  - safe-shell-script-author
+  - test-generation
+  - uswds-form-flow
+  - uswds-landing-page
+  - uswds-prototype
   discover:
+  - federal-service-blueprint
   - pattern-router
   orchestrate:
+  - issue-to-merge-request
   - pattern-router
-output_artifacts: {}
+  - qa-workflow
+  - security-scan-review
+  plan:
+  - federal-service-blueprint
+  - general-agent
+  - implementation-plan
+  render:
+  - explainer-gif
+  - explainer-video
+  - uswds-form-flow
+  - uswds-landing-page
+  - uswds-prototype
+  review:
+  - accessibility-review
+  - agentic-actions-auditor
+  - backdoor-review
+  - compliance-claim-checker
+  - dependency-analysis
+  - documentation-agent
+  - documentation-review
+  - incident-evidence-review
+  - least-privilege-review
+  - over-engineering-review
+  - plain-language-review
+  - qa-round
+  - qa-workflow
+  - safe-code-review
+  - secure-code-review
+  - security-review-agent
+  - security-scan-review
+  - untrusted-input-boundary-review
+  test:
+  - issue-to-merge-request
+  - qa-round
+  - qa-workflow
+  - test-generation
+output_artifacts:
+  documentation:
+  - documentation-agent
+  - example-agentic-session
+  - federal-service-blueprint
+  - implementation-plan
+  explainer-gif:
+  - explainer-gif
+  explainer-video:
+  - explainer-video
+  form:
+  - uswds-form-flow
+  landing-page:
+  - uswds-landing-page
+  marketing-asset:
+  - explainer-video
+  pull-request-diff:
+  - issue-to-merge-request
+  qa-report:
+  - accessibility-review
+  - documentation-review
+  - over-engineering-review
+  - plain-language-review
+  - qa-round
+  - qa-workflow
+  - test-generation
+  security-review:
+  - agentic-actions-auditor
+  - backdoor-review
+  - compliance-claim-checker
+  - dependency-analysis
+  - incident-evidence-review
+  - least-privilege-review
+  - safe-code-review
+  - secure-code-review
+  - security-review-agent
+  - security-scan-review
+  - untrusted-input-boundary-review
+  service-blueprint:
+  - federal-service-blueprint
+  shell-script:
+  - safe-shell-script-author
+  source-code:
+  - general-agent
+  - issue-to-merge-request
+  - test-generation
+  - uswds-form-flow
+  - uswds-landing-page
+  - uswds-prototype
+  terminal-demo:
+  - explainer-gif
+  web-prototype:
+  - uswds-prototype
 stats:
   total_patterns: 31
   skills: 21

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,11 @@ scan-shell:  ## Scan shell scripts + markdown bash blocks for unsafe patterns (#
 
 generate:  ## Generate INDEX.yaml from patterns
 	python scripts/generate_index.py
+	python scripts/generate_catalog.py
 
 generate-check:  ## Verify INDEX.yaml is up to date (used in pre-commit)
 	python scripts/generate_index.py --check
+	python scripts/generate_catalog.py --check
 
 search:  ## Search patterns (e.g., make search TAG=security)
 	@if [ -z "$(QUERY)" ] && [ -z "$(TAG)" ] && [ -z "$(STATUS)" ] && [ -z "$(PERSONA)" ] && [ -z "$(TOOL)" ]; then \

--- a/agents/documentation/AGENTS.md
+++ b/agents/documentation/AGENTS.md
@@ -34,6 +34,19 @@ categories:
 quality_gates:
   readability_max_grade: 10
   citations_required: false
+
+collection: content
+routing:
+  task_types:
+    - "author"
+    - "review"
+  input_artifacts:
+    - "documentation"
+  output_artifacts:
+    - "documentation"
+  aliases:
+    - "docs agent"
+    - "tech writer agent"
 ---
 
 # Documentation Agent Instructions

--- a/agents/general/AGENTS.md
+++ b/agents/general/AGENTS.md
@@ -34,6 +34,19 @@ categories:
 quality_gates:
   readability_max_grade: 10
   citations_required: false
+
+collection: engineering
+routing:
+  task_types:
+    - "author"
+    - "plan"
+  input_artifacts:
+    - "source-code"
+  output_artifacts:
+    - "source-code"
+  aliases:
+    - "coding agent"
+    - "general dev agent"
 ---
 
 # General Agent Instructions

--- a/agents/security-review/AGENTS.md
+++ b/agents/security-review/AGENTS.md
@@ -44,6 +44,20 @@ allowed_tools: []
 network_policy: deny
 write_policy: deny
 script_policy: deny
+
+collection: security
+routing:
+  task_types:
+    - "review"
+    - "analyze"
+  input_artifacts:
+    - "source-code"
+    - "pull-request-diff"
+  output_artifacts:
+    - "security-review"
+  aliases:
+    - "security agent"
+    - "vuln review agent"
 ---
 
 # Security Review Agent Instructions

--- a/docs/AI-AGENT-GUIDE.md
+++ b/docs/AI-AGENT-GUIDE.md
@@ -116,7 +116,25 @@ if is_compatible(fm, 'opencode'):
 
 ## Pattern Selection Logic
 
-### By User Intent
+> **Prefer the `pattern-router` for selection.** The keyword-matching shown
+> below is the *legacy fallback*. The recommended path is the data-driven
+> router: the `pattern-router` skill (`.agents/skills/meta/pattern-router/`)
+> plus `scripts/route_patterns.py`, which score patterns on their structured
+> `routing.*` metadata (task types, input/output artifacts, aliases,
+> `prefer_when`/`avoid_when`/`delegates`) and return the **smallest appropriate
+> route** with an explanation. Run:
+>
+> ```bash
+> python scripts/route_patterns.py --task review --output security-review --json
+> ```
+>
+> The core rule the router enforces: **prefer a workflow for an outcome, a skill
+> for an operation, and a prompt only when the environment cannot load the
+> corresponding skill.** It will not select every skill sharing a broad
+> category. See the `pattern-router` SKILL.md for the full procedure and the
+> scoring model.
+
+### By User Intent (legacy keyword fallback)
 
 Match user intent to pattern triggers:
 
@@ -201,6 +219,12 @@ if deps['has_dependencies']:
 ```
 
 ## Security Skill Routing
+
+> **These lanes are being moved into structured `routing.delegates` /
+> `avoid_when` metadata** (epic #237, applied in PR3 #240) so the `pattern-router`
+> enforces them mechanically rather than relying on this prose table. Until that
+> lands, the table below remains the reference; afterward it becomes a
+> human-readable mirror of the metadata.
 
 Security skills (`categories: [security]`) overlap by design, so pick by the
 **specific trigger**, not by keyword alone. Map the user's request to one skill:

--- a/lessons-learned/example-agentic-session/SKILL.md
+++ b/lessons-learned/example-agentic-session/SKILL.md
@@ -57,6 +57,19 @@ scope:
     - "Learn from successful use of multiple patterns"
   exclusions:
     - "Not a tutorial or step-by-step guide"
+
+collection: meta
+routing:
+  task_types:
+    - "analyze"
+  input_artifacts:
+    - "documentation"
+  output_artifacts:
+    - "documentation"
+  aliases:
+    - "session lesson"
+    - "multi-pattern example"
+    - "retro"
 ---
 
 # Lesson Learned: Example Agentic Coding Session

--- a/prompts/planning/implementation-plan/SKILL.md
+++ b/prompts/planning/implementation-plan/SKILL.md
@@ -62,6 +62,19 @@ scope:
   exclusions:
     - "Not for time estimation (story points only)"
     - "Not for resource allocation"
+
+collection: engineering
+routing:
+  task_types:
+    - "plan"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "documentation"
+  aliases:
+    - "implementation plan"
+    - "task breakdown"
+    - "feature plan"
 ---
 
 # Prompt: Implementation Plan Generator

--- a/prompts/review/qa-round/SKILL.md
+++ b/prompts/review/qa-round/SKILL.md
@@ -66,6 +66,28 @@ scope:
   exclusions:
     - "Not for performance testing"
     - "Not for security penetration testing"
+
+collection: engineering
+routing:
+  task_types:
+    - "test"
+    - "review"
+  input_artifacts:
+    - "source-code"
+    - "pull-request-diff"
+  output_artifacts:
+    - "qa-report"
+  prefer_when:
+    - "the request is a single-turn QA review of a diff or acceptance criteria"
+  avoid_when:
+    - "the request is to run the full multi-stage QA process (use qa-workflow)"
+  delegates:
+    - pattern: qa-workflow
+      when: "the request is to run the full QA process end to end"
+  aliases:
+    - "qa this diff"
+    - "acceptance check"
+    - "single qa review"
 ---
 
 # Prompt: QA Round Review

--- a/prompts/security/safe-code-review/SKILL.md
+++ b/prompts/security/safe-code-review/SKILL.md
@@ -1,11 +1,18 @@
 ---
 id: safe-code-review
-version: "1.0.0"
+version: "1.1.0"
 title: "Security-Focused Code Review"
 type: prompt
-description: "Prompt for identifying OWASP risks, injection vulnerabilities, and security issues in code"
+description: "DEPRECATED — compatibility prompt. Use the secure-code-review skill; this remains only as a fallback where a skill cannot be loaded."
 
-status: experimental
+status: deprecated
+deprecated:
+  as_of: "2026-07-24"
+  replaces_with: secure-code-review
+  reason: "Superset skill secure-code-review covers the same OWASP/injection scope with structured routing and delegation; colliding triggers caused router ambiguity (#240)."
+  migration_notes:
+    - "Route 'security code review' / 'vulnerability review' requests to secure-code-review."
+    - "Kept for one release as a compatibility fallback for environments that cannot load a SKILL.md skill."
 owners:
   - "@GSA-TTS/agentic-coding-team"
 
@@ -76,9 +83,35 @@ scope:
     - "Not for penetration testing"
     - "Not for creating exploit code"
     - "Not for vulnerability research"
+
+collection: security
+routing:
+  task_types:
+    - review
+    - analyze
+  input_artifacts:
+    - source-code
+    - pull-request-diff
+  output_artifacts:
+    - security-review
+  aliases:
+    - security code review
+    - vulnerability review
+  avoid_when:
+    - always deprecated; route to secure-code-review instead
+  delegates:
+    - pattern: secure-code-review
+      when: any security code review request; this prompt is a deprecated fallback
+  priority: 0
 ---
 
 # Prompt: Security-Focused Code Review
+
+> **⚠️ Deprecated (as of 2026-07-24).** Use the
+> [`secure-code-review`](../../../skills/secure-code-review/SKILL.md) skill,
+> which supersedes this prompt with the same OWASP/injection coverage plus
+> structured routing and delegation. Kept for **one release** as a
+> compatibility fallback for environments that cannot load a SKILL.md skill.
 
 Perform security-focused code review to identify vulnerabilities before they reach production.
 

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -100,8 +100,35 @@
       "properties": {
         "format": {
           "type": "string",
-          "enum": ["markdown", "json", "yaml", "text", "unknown"],
+          "description": "Primary output format. 'multi' means the pattern emits a bundle of files described by `artifacts` (#241, design/media patterns).",
+          "enum": ["markdown", "json", "yaml", "text", "html", "svg", "png", "pdf", "pptx", "gif", "mp4", "multi", "unknown"],
           "default": "markdown"
+        },
+        "artifacts": {
+          "type": "array",
+          "description": "Multi-file output description for design/media patterns; each entry names a produced file's role + IANA media type (#241). Use with format: multi.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["role", "media_type"],
+            "properties": {
+              "role": {
+                "type": "string",
+                "description": "What this file is.",
+                "enum": ["source", "export", "preview", "sidecar", "manifest"]
+              },
+              "media_type": {
+                "type": "string",
+                "description": "IANA media type, e.g. text/html, application/pdf, image/png.",
+                "pattern": "^[a-z]+/[a-zA-Z0-9.+-]+$"
+              },
+              "extension": {
+                "type": "string",
+                "description": "File extension without the dot.",
+                "pattern": "^[a-z0-9]+$"
+              }
+            }
+          }
         },
         "contract": {
           "type": "object",

--- a/schemas/taxonomy.yaml
+++ b/schemas/taxonomy.yaml
@@ -104,6 +104,9 @@ artifact_types:
   storyboard:
     description: An ordered visual/narrative plan.
     aliases: []
+  visual-contract:
+    description: The concrete visual rules (layout, type, color, spacing, asset rules) a renderer follows.
+    aliases: [design-direction]
   diagram:
     description: A technical diagram.
     aliases: [technical-diagram]

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -39,6 +39,16 @@ def _flatten(index: dict) -> list[dict]:
     return out
 
 
+def _cell(value: str) -> str:
+    """Escape a string for safe inclusion in a Markdown table cell.
+
+    Pattern ids/paths are schema-constrained (kebab-case), but harden anyway:
+    escape pipes and collapse newlines so a stray value can never break the
+    table or inject markdown.
+    """
+    return str(value).replace("|", "\\|").replace("\n", " ").replace("\r", " ")
+
+
 def render_catalog(index: dict) -> str:
     patterns = _flatten(index)
     by_collection: dict[str | None, list[dict]] = {}
@@ -69,7 +79,7 @@ def render_catalog(index: dict) -> str:
     lines.append("")
 
     ordered = [c for c in COLLECTION_ORDER if c in by_collection]
-    ordered += [c for c in by_collection if c not in COLLECTION_ORDER and c is not None]
+    ordered += sorted(c for c in by_collection if c not in COLLECTION_ORDER and c is not None)
     if None in by_collection:
         ordered.append(None)
 
@@ -81,13 +91,13 @@ def render_catalog(index: dict) -> str:
         lines.append("|---------|------|--------|-------|----------|----------|")
         for p in entries:
             routing = p.get("routing") or {}
-            tasks = ", ".join(routing.get("task_types", []) or []) or "—"
-            inputs = ", ".join(routing.get("input_artifacts", []) or []) or "—"
-            outputs = ", ".join(routing.get("output_artifacts", []) or []) or "—"
-            pid = p.get("id", "?")
-            path = p.get("path", "")
+            tasks = _cell(", ".join(routing.get("task_types", []) or []) or "—")
+            inputs = _cell(", ".join(routing.get("input_artifacts", []) or []) or "—")
+            outputs = _cell(", ".join(routing.get("output_artifacts", []) or []) or "—")
+            pid = _cell(p.get("id", "?"))
+            path = _cell(p.get("path", ""))
             lines.append(
-                f"| [`{pid}`]({path}) | {p.get('type', '?')} | {p.get('status', '?')} "
+                f"| [`{pid}`]({path}) | {_cell(p.get('type', '?'))} | {_cell(p.get('status', '?'))} "
                 f"| {tasks} | {inputs} | {outputs} |"
             )
         lines.append("")

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Generate CATALOG.md — a human-readable pattern catalog (#240, PR3).
+
+Reads INDEX.yaml (the generated manifest) and renders a Markdown catalog grouped
+by collection, with each pattern's type, status, and routing facets. Mirrors the
+machine index for humans; `--check` verifies it is current (used in CI/pre-commit
+the same way INDEX.yaml is).
+
+Usage:
+    python scripts/generate_catalog.py [--check]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+COLLECTION_ORDER = ["meta", "engineering", "security", "content", "digital-service", "communications"]
+COLLECTION_TITLES = {
+    "meta": "Meta",
+    "engineering": "Engineering",
+    "security": "Security",
+    "content": "Content",
+    "digital-service": "Digital Service",
+    "communications": "Communications",
+    None: "Unclassified",
+}
+
+
+def _flatten(index: dict) -> list[dict]:
+    out = []
+    for items in (index.get("patterns") or {}).values():
+        if isinstance(items, list):
+            out.extend(items)
+    return out
+
+
+def render_catalog(index: dict) -> str:
+    patterns = _flatten(index)
+    by_collection: dict[str | None, list[dict]] = {}
+    for p in patterns:
+        by_collection.setdefault(p.get("collection"), []).append(p)
+
+    stats = index.get("stats", {})
+    lines: list[str] = []
+    lines.append("# Pattern Catalog")
+    lines.append("")
+    lines.append(
+        "> **Generated file — do not edit by hand.** Run `make generate` "
+        "(regenerates INDEX.yaml + CATALOG.md). Source of truth is each pattern's "
+        "`SKILL.md`/`AGENTS.md` frontmatter."
+    )
+    lines.append("")
+    lines.append(
+        f"{stats.get('total_patterns', len(patterns))} patterns — "
+        f"{stats.get('skills', 0)} skills, {stats.get('prompts', 0)} prompts, "
+        f"{stats.get('agents', 0)} agents, {stats.get('workflows', 0)} workflows, "
+        f"{stats.get('lessons', 0)} lessons."
+    )
+    lines.append("")
+    lines.append(
+        "For machine routing use the [`pattern-router`](.agents/skills/meta/pattern-router/SKILL.md) "
+        "skill + `scripts/route_patterns.py`; this catalog is the human view."
+    )
+    lines.append("")
+
+    ordered = [c for c in COLLECTION_ORDER if c in by_collection]
+    ordered += [c for c in by_collection if c not in COLLECTION_ORDER and c is not None]
+    if None in by_collection:
+        ordered.append(None)
+
+    for coll in ordered:
+        entries = sorted(by_collection[coll], key=lambda p: p.get("id", ""))
+        lines.append(f"## {COLLECTION_TITLES.get(coll, coll)}")
+        lines.append("")
+        lines.append("| Pattern | Type | Status | Tasks | Consumes | Produces |")
+        lines.append("|---------|------|--------|-------|----------|----------|")
+        for p in entries:
+            routing = p.get("routing") or {}
+            tasks = ", ".join(routing.get("task_types", []) or []) or "—"
+            inputs = ", ".join(routing.get("input_artifacts", []) or []) or "—"
+            outputs = ", ".join(routing.get("output_artifacts", []) or []) or "—"
+            pid = p.get("id", "?")
+            path = p.get("path", "")
+            lines.append(
+                f"| [`{pid}`]({path}) | {p.get('type', '?')} | {p.get('status', '?')} "
+                f"| {tasks} | {inputs} | {outputs} |"
+            )
+        lines.append("")
+
+    return "\n".join(lines).rstrip("\n") + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate CATALOG.md")
+    parser.add_argument("--check", action="store_true", help="Verify CATALOG.md is up to date")
+    args = parser.parse_args()
+
+    root = Path.cwd()
+    index_path = root / "INDEX.yaml"
+    catalog_path = root / "CATALOG.md"
+
+    if not index_path.exists():
+        print("✗ INDEX.yaml not found (run 'make generate')", file=sys.stderr)
+        return 1
+
+    index = yaml.safe_load(index_path.read_text())
+    content = render_catalog(index)
+
+    if args.check:
+        if not catalog_path.exists():
+            print("✗ CATALOG.md does not exist")
+            return 1
+        if catalog_path.read_text() != content:
+            print("✗ CATALOG.md is out of date\n  Run: make generate")
+            return 1
+        print("✓ CATALOG.md is up to date")
+        return 0
+
+    catalog_path.write_text(content)
+    print("✓ Generated CATALOG.md")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/route_patterns.py
+++ b/scripts/route_patterns.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""
+Deterministic pattern-router engine (#237, PR2 #239).
+
+The MODEL classifies a request into structured facets (task_types, output/input
+artifacts, constraints). THIS SCRIPT does the mechanical part: filter → score →
+rank → explain. Keeping selection deterministic makes it testable, reproducible,
+cheap (no per-call model variance), and immune to hallucinated pattern ids.
+
+Design contract (epic #237):
+  * Prefer a workflow for an outcome, a skill for an operation, a prompt only as
+    an environment fallback.
+  * Choose the SMALLEST appropriate route, never "every skill sharing a category".
+  * Every decision is explainable: excluded candidates carry a reason.
+
+Security (consensus conditions, #237):
+  * All pattern references stay repo-relative — reject absolute paths / `..`
+    (path-traversal guard) when reading pattern files.
+  * Request facets are validated against schemas/taxonomy.yaml; unknown facets
+    are rejected, not silently scored (prevents dodging avoid/delegate penalties).
+
+Usage:
+    python scripts/route_patterns.py --task review --output security-review
+    python scripts/route_patterns.py --request-file req.yaml --json
+    python scripts/route_patterns.py --task author --output slide-deck --explain
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ── Deterministic scoring weights ───────────────────────────────────────────
+# Exact weights matter less than the decision being explainable and testable.
+# Positive signals accumulate; the three −100 penalties act as hard exclusions.
+W_OUTPUT_MATCH = 40
+W_TASK_MATCH = 30
+W_INPUT_MATCH = 15
+W_ALIAS_MATCH = 10
+W_TRIGGER_MATCH = 10
+W_COLLECTION_MATCH = 5
+W_RECOMMENDED = 5
+P_AVOID = -100
+P_DELEGATED = -100
+P_DEPRECATED = -100
+
+# A workflow that covers the requested outcome is preferred over assembling
+# skills; a prompt is only a fallback. Encoded as a small type nudge so ties
+# resolve toward the right granularity without overriding real facet matches.
+TYPE_NUDGE = {"workflow": 3, "skill": 0, "prompt": -3, "agent": -5, "lesson": -50}
+
+
+@dataclass
+class RequestFacets:
+    """Structured request the model produced (or CLI flags supplied)."""
+
+    task_types: list[str] = field(default_factory=list)
+    input_artifacts: list[str] = field(default_factory=list)
+    output_artifacts: list[str] = field(default_factory=list)
+    keywords: list[str] = field(default_factory=list)
+    collection: str | None = None
+
+    def is_empty(self) -> bool:
+        return not (
+            self.task_types or self.input_artifacts or self.output_artifacts or self.keywords or self.collection
+        )
+
+
+@dataclass
+class Candidate:
+    """A pattern under consideration with its running score + trace."""
+
+    id: str
+    type: str
+    status: str
+    path: str
+    collection: str | None
+    routing: dict
+    score: int = 0
+    reasons: list[str] = field(default_factory=list)
+    excluded_reason: str | None = None
+
+
+# ── Loading (repo-relative, path-traversal safe) ────────────────────────────
+
+
+def load_taxonomy(repo_root: Path) -> dict[str, set[str]]:
+    """Load controlled vocab for facet validation. Empty sets if file absent."""
+    path = repo_root / "schemas" / "taxonomy.yaml"
+    if not path.exists():
+        return {"task_types": set(), "artifact_types": set()}
+    data = yaml.safe_load(path.read_text()) or {}
+    return {
+        "task_types": set((data.get("task_types") or {}).keys()),
+        "artifact_types": set((data.get("artifact_types") or {}).keys()),
+    }
+
+
+def _safe_repo_relative(repo_root: Path, rel_path: str) -> Path | None:
+    """Resolve rel_path under repo_root, rejecting absolute paths and traversal.
+
+    Returns the resolved Path if it stays inside repo_root, else None. This is
+    the consensus path-traversal guard: a pattern `path` in INDEX.yaml is data
+    and must never escape the repo.
+    """
+    if not rel_path:
+        return None
+    candidate = Path(rel_path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return None
+    resolved = (repo_root / candidate).resolve()
+    try:
+        resolved.relative_to(repo_root.resolve())
+    except ValueError:
+        return None
+    return resolved
+
+
+def _extract_frontmatter(text: str) -> dict:
+    if not text.startswith("---\n"):
+        return {}
+    parts = text.split("---\n", 2)
+    if len(parts) < 3:
+        return {}
+    return yaml.safe_load(parts[1]) or {}
+
+
+def load_candidates(repo_root: Path, index_data: dict) -> list[Candidate]:
+    """Build candidates from INDEX.yaml, enriching from each SKILL.md.
+
+    The INDEX carries the shortlist facets; prefer_when/avoid_when/delegates live
+    in the source file, so we reopen it (guarded). A pattern whose path fails the
+    traversal guard is skipped defensively.
+    """
+    candidates: list[Candidate] = []
+    for items in (index_data.get("patterns") or {}).values():
+        if not isinstance(items, list):
+            continue
+        for entry in items:
+            rel = entry.get("path", "")
+            safe = _safe_repo_relative(repo_root, rel)
+            routing = dict(entry.get("routing") or {})
+            if safe and safe.exists():
+                fm = _extract_frontmatter(safe.read_text())
+                # Merge full routing (prefer_when/avoid_when/delegates) from source.
+                fm_routing = fm.get("routing")
+                if isinstance(fm_routing, dict):
+                    routing = fm_routing
+                collection = fm.get("collection") or entry.get("collection")
+                triggers = fm.get("triggers") or []
+                deprecated = fm.get("status") == "deprecated" or bool(fm.get("deprecated"))
+            else:
+                collection = entry.get("collection")
+                triggers = []
+                deprecated = entry.get("status") == "deprecated"
+            routing.setdefault("_triggers", triggers)
+            cand = Candidate(
+                id=entry.get("id", "unknown"),
+                type=entry.get("type", "skill"),
+                status=entry.get("status", "experimental"),
+                path=rel,
+                collection=collection,
+                routing=routing,
+            )
+            cand.routing["_deprecated"] = deprecated
+            candidates.append(cand)
+    # Stable order for deterministic tie-breaking.
+    candidates.sort(key=lambda c: c.id)
+    return candidates
+
+
+# ── Facet validation ────────────────────────────────────────────────────────
+
+
+def validate_request(facets: RequestFacets, taxonomy: dict[str, set[str]]) -> list[str]:
+    """Reject request facets that are not in the controlled vocabulary.
+
+    Consensus condition: an unknown task_type/artifact must fail loudly rather
+    than silently scoring nothing (which could let a crafted request dodge the
+    avoid/delegate penalties by never matching them).
+    """
+    errors: list[str] = []
+    task_vocab = taxonomy.get("task_types", set())
+    art_vocab = taxonomy.get("artifact_types", set())
+    if task_vocab:
+        for t in facets.task_types:
+            if t not in task_vocab:
+                errors.append(f"unknown task_type: {t!r}")
+    if art_vocab:
+        for a in facets.input_artifacts:
+            if a not in art_vocab:
+                errors.append(f"unknown input_artifact: {a!r}")
+        for a in facets.output_artifacts:
+            if a not in art_vocab:
+                errors.append(f"unknown output_artifact: {a!r}")
+    return errors
+
+
+# ── Scoring ──────────────────────────────────────────────────────────────────
+
+
+def _phrase_hit(keywords: list[str], phrases: list[str]) -> bool:
+    """True if any request keyword and any pattern phrase overlap.
+
+    Request keywords are often whole sentences ("audit this GitHub Actions
+    workflow…") while pattern phrases are short ("agent-invoking CI workflow").
+    We therefore test containment in BOTH directions (keyword-in-phrase OR
+    phrase-in-keyword) so a short pattern phrase can match a long request.
+
+    Guard against short-substring false positives (a 2-char alias like "ci"
+    matching "de*ci*sion"): the side being searched *for* must be at least
+    MIN_MATCH_LEN chars AND, when it is a single token, match on a word boundary
+    rather than a bare substring. This prevents a poorly chosen short alias from
+    promoting an irrelevant candidate.
+    """
+    kws = [k.lower() for k in keywords if k]
+    for phrase in phrases:
+        pl = str(phrase).lower()
+        if not pl:
+            continue
+        for kw in kws:
+            if not kw:
+                continue
+            if _contains(pl, kw) or _contains(kw, pl):
+                return True
+    return False
+
+
+MIN_MATCH_LEN = 4
+
+
+def _contains(haystack: str, needle: str) -> bool:
+    """Substring test with a false-positive guard for short single tokens.
+
+    - needle shorter than MIN_MATCH_LEN and containing no space → require a
+      word-boundary match (so "ci" matches "ci workflow" but not "decision").
+    - otherwise → ordinary substring containment (multi-word phrases are already
+      specific enough).
+    """
+    if not needle:
+        return False
+    if len(needle) < MIN_MATCH_LEN and " " not in needle:
+        return re.search(rf"\b{re.escape(needle)}\b", haystack) is not None
+    return needle in haystack
+
+
+def score_candidate(cand: Candidate, facets: RequestFacets) -> Candidate:
+    """Apply deterministic scoring. Sets score, reasons, and excluded_reason."""
+    routing = cand.routing
+    r_outputs = routing.get("output_artifacts") or []
+    r_inputs = routing.get("input_artifacts") or []
+    r_tasks = routing.get("task_types") or []
+    r_aliases = routing.get("aliases") or []
+    r_triggers = routing.get("_triggers") or []
+
+    # ── Hard exclusions first ────────────────────────────────────────────────
+    if routing.get("_deprecated"):
+        cand.score = P_DEPRECATED
+        cand.excluded_reason = "deprecated"
+        return cand
+
+    # avoid_when: if any request keyword matches an avoid phrase, exclude.
+    if facets.keywords and _phrase_hit(facets.keywords, routing.get("avoid_when") or []):
+        cand.score = P_AVOID
+        cand.excluded_reason = "matched avoid_when"
+        return cand
+
+    # ── Positive signals ─────────────────────────────────────────────────────
+    matched_outputs = set(r_outputs) & set(facets.output_artifacts)
+    if matched_outputs:
+        cand.score += W_OUTPUT_MATCH * len(matched_outputs)
+        cand.reasons.append(f"output match: {sorted(matched_outputs)}")
+
+    matched_tasks = set(r_tasks) & set(facets.task_types)
+    if matched_tasks:
+        cand.score += W_TASK_MATCH * len(matched_tasks)
+        cand.reasons.append(f"task match: {sorted(matched_tasks)}")
+
+    matched_inputs = set(r_inputs) & set(facets.input_artifacts)
+    if matched_inputs:
+        cand.score += W_INPUT_MATCH * len(matched_inputs)
+        cand.reasons.append(f"input match: {sorted(matched_inputs)}")
+
+    if facets.keywords and _phrase_hit(facets.keywords, r_aliases):
+        cand.score += W_ALIAS_MATCH
+        cand.reasons.append("alias match")
+
+    if facets.keywords and _phrase_hit(facets.keywords, r_triggers):
+        cand.score += W_TRIGGER_MATCH
+        cand.reasons.append("trigger match")
+
+    if facets.collection and cand.collection == facets.collection:
+        cand.score += W_COLLECTION_MATCH
+        cand.reasons.append("collection match")
+
+    if cand.status == "recommended":
+        cand.score += W_RECOMMENDED
+        cand.reasons.append("recommended status")
+
+    # The type-nudge and recommended bonus are TIE-BREAKERS, not signals — they
+    # only apply once the candidate has a real facet/keyword match. Otherwise a
+    # workflow with zero relevance would score +3 and be "selected" (e.g. against
+    # a not-yet-classified INDEX). Require a substantive match first.
+    has_real_match = bool(cand.reasons) and any(
+        r.startswith(("output match", "task match", "input match", "alias match", "trigger match"))
+        for r in cand.reasons
+    )
+    if has_real_match:
+        cand.score += TYPE_NUDGE.get(cand.type, 0)
+    else:
+        cand.score = 0
+        cand.reasons.clear()
+    return cand
+
+
+def apply_delegation(candidates: list[Candidate], facets: RequestFacets) -> None:
+    """Demote a candidate that delegates a matching lane to a more specific one.
+
+    If pattern A declares `delegates: [{pattern: B, when: "..."}]` and the
+    request keywords match B's `when` clause, A is excluded in favor of B — this
+    is how the security disambiguation lanes stay out of prose.
+    """
+    by_id = {c.id: c for c in candidates}
+    for cand in candidates:
+        if cand.excluded_reason:
+            continue
+        for deleg in cand.routing.get("delegates") or []:
+            target = deleg.get("pattern")
+            when = deleg.get("when", "")
+            if not target or target not in by_id:
+                continue
+            if facets.keywords and _phrase_hit(facets.keywords, [when]):
+                cand.score = P_DELEGATED
+                cand.excluded_reason = f"delegated to {target} ({when})"
+                break
+
+
+# ── Route assembly ────────────────────────────────────────────────────────────
+
+
+def build_route(candidates: list[Candidate], facets: RequestFacets | None = None) -> dict:
+    """Rank scored candidates and assemble the explainable route object."""
+    included = [c for c in candidates if c.excluded_reason is None and c.score > 0]
+    excluded = [c for c in candidates if c.excluded_reason is not None]
+
+    # Deterministic ranking: score desc, then routing.priority desc, then id asc.
+    def sort_key(c: Candidate):
+        priority = c.routing.get("priority", 50)
+        return (-c.score, -priority, c.id)
+
+    included.sort(key=sort_key)
+
+    requested_outputs = set(facets.output_artifacts) if facets else set()
+
+    route: dict[str, Any] = {"primary": None, "supporting": [], "excluded": [], "assumptions": []}
+    if included:
+        top = included[0]
+        route["primary"] = {
+            "id": top.id,
+            "type": top.type,
+            "score": top.score,
+            "reason": "; ".join(top.reasons) or "best facet match",
+        }
+        # Supporting = other included candidates that add a distinct REQUESTED
+        # output the primary does not cover. Restricting to requested outputs
+        # keeps routes minimal — a candidate producing an artifact nobody asked
+        # for (e.g. a video when a deck was requested) is never dragged in.
+        primary_outputs = set(top.routing.get("output_artifacts") or [])
+        for c in included[1:]:
+            c_outputs = set(c.routing.get("output_artifacts") or [])
+            distinct_requested = (c_outputs & requested_outputs) - primary_outputs
+            if distinct_requested:
+                route["supporting"].append(
+                    {"id": c.id, "type": c.type, "score": c.score, "reason": "; ".join(c.reasons)}
+                )
+                primary_outputs |= c_outputs
+
+    # Only surface excluded candidates that ALMOST matched (avoid/delegated),
+    # not the long tail of irrelevant patterns.
+    for c in excluded:
+        if c.excluded_reason and c.excluded_reason != "deprecated":
+            route["excluded"].append({"id": c.id, "reason": c.excluded_reason})
+
+    return route
+
+
+def route_request(repo_root: Path, index_data: dict, facets: RequestFacets) -> dict:
+    """Full pipeline: validate → score → delegate → rank → explain."""
+    taxonomy = load_taxonomy(repo_root)
+    errors = validate_request(facets, taxonomy)
+    if errors:
+        return {"error": "invalid request facets", "details": errors}
+    if facets.is_empty():
+        return {"error": "empty request", "details": ["provide at least one facet"]}
+
+    candidates = load_candidates(repo_root, index_data)
+    for cand in candidates:
+        score_candidate(cand, facets)
+    apply_delegation(candidates, facets)
+    return build_route(candidates, facets)
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+def _load_index(repo_root: Path) -> dict:
+    path = repo_root / "INDEX.yaml"
+    if not path.exists():
+        print("Error: INDEX.yaml not found (run 'make generate')", file=sys.stderr)
+        sys.exit(2)
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Deterministic pattern router (#237)")
+    parser.add_argument("--task", action="append", default=[], help="Request task type (repeatable)")
+    parser.add_argument(
+        "--input", dest="input_artifact", action="append", default=[], help="Input artifact (repeatable)"
+    )
+    parser.add_argument(
+        "--output", dest="output_artifact", action="append", default=[], help="Output artifact (repeatable)"
+    )
+    parser.add_argument("--keyword", action="append", default=[], help="Free-text keyword/phrase (repeatable)")
+    parser.add_argument("--collection", default=None, help="Preferred collection")
+    parser.add_argument(
+        "--request-file",
+        type=Path,
+        default=None,
+        help="YAML file with task_types/input_artifacts/output_artifacts/keywords/collection",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).parent.parent.resolve()
+
+    if args.request_file:
+        # A --request-file is an OPERATOR-supplied CLI argument (same trust level
+        # as `cat`), so an absolute path is permitted here. Deliberately
+        # asymmetric with pattern `path` values from INDEX.yaml, which are DATA
+        # and stay guarded by _safe_repo_relative.
+        safe = (
+            _safe_repo_relative(repo_root, str(args.request_file))
+            if not args.request_file.is_absolute()
+            else args.request_file
+        )
+        if safe is None or not safe.exists():
+            print(f"Error: request file not found or unsafe: {args.request_file}", file=sys.stderr)
+            return 2
+        data = yaml.safe_load(safe.read_text()) or {}
+        facets = RequestFacets(
+            task_types=list(data.get("task_types") or []),
+            input_artifacts=list(data.get("input_artifacts") or []),
+            output_artifacts=list(data.get("output_artifacts") or []),
+            keywords=list(data.get("keywords") or []),
+            collection=data.get("collection"),
+        )
+    else:
+        facets = RequestFacets(
+            task_types=args.task,
+            input_artifacts=args.input_artifact,
+            output_artifacts=args.output_artifact,
+            keywords=args.keyword,
+            collection=args.collection,
+        )
+
+    index_data = _load_index(repo_root)
+    route = route_request(repo_root, index_data, facets)
+
+    if args.json:
+        print(json.dumps(route, indent=2))
+    else:
+        if "error" in route:
+            print(f"✗ {route['error']}: {', '.join(route['details'])}")
+            return 1
+        primary = route.get("primary")
+        if not primary:
+            print("No pattern matched the request facets.")
+            return 1
+        print(f"→ primary: {primary['id']} ({primary['type']}) [score {primary['score']}]")
+        print(f"  reason: {primary['reason']}")
+        for s in route["supporting"]:
+            print(f"  + supporting: {s['id']} ({s['type']}) [score {s['score']}]")
+        for e in route["excluded"]:
+            print(f"  − excluded: {e['id']} — {e['reason']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/route_patterns.py
+++ b/scripts/route_patterns.py
@@ -52,9 +52,13 @@ P_DELEGATED = -100
 P_DEPRECATED = -100
 
 # A workflow that covers the requested outcome is preferred over assembling
-# skills; a prompt is only a fallback. Encoded as a small type nudge so ties
-# resolve toward the right granularity without overriding real facet matches.
-TYPE_NUDGE = {"workflow": 3, "skill": 0, "prompt": -3, "agent": -5, "lesson": -50}
+# skills; a prompt is only a fallback. The workflow nudge is sized to overcome a
+# single extra trigger/alias hit on a competing renderer skill (W_TRIGGER_MATCH),
+# so an outcome-level request ("create an executive one-pager") routes to the
+# design-artifact workflow, while a narrow skill-only request still wins on
+# stronger facet matches. Encoded as a small type nudge, applied only to
+# candidates that already have a substantive match.
+TYPE_NUDGE = {"workflow": 12, "skill": 0, "prompt": -3, "agent": -5, "lesson": -50}
 
 
 @dataclass

--- a/scripts/tests/router-cases.yaml
+++ b/scripts/tests/router-cases.yaml
@@ -1,0 +1,332 @@
+# Router regression cases (#237, PR2 #239).
+#
+# These cases are DETERMINISTIC and self-contained: each provides an inline set
+# of candidate patterns (with routing metadata) plus a request, and asserts the
+# router's primary/supporting/excluded decision. They do NOT read the live
+# INDEX.yaml — the live patterns do not carry routing blocks until PR3 (#240),
+# and pinning to fixtures keeps the suite stable as the catalog evolves.
+#
+# Each case:
+#   request:          the structured facets a model would produce
+#   candidates:       inline patterns {id,type,status,collection,routing}
+#   expect_primary:   pattern id the router must pick (or null for "no match")
+#   forbid:           pattern ids that must NOT be primary or supporting
+#   expect_supporting (optional): ids that MUST appear as supporting
+#   expect_excluded   (optional): ids that MUST appear as excluded with a reason
+
+cases:
+  # ── Exact-match: security review of a diff ────────────────────────────────
+  - name: vulnerability-review-of-diff
+    request:
+      task_types: [review]
+      input_artifacts: [pull-request-diff]
+      output_artifacts: [security-review]
+      keywords: ["review this PR for vulnerabilities", "owasp"]
+    candidates:
+      - id: secure-code-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review, analyze]
+          input_artifacts: [source-code, pull-request-diff]
+          output_artifacts: [security-review]
+          aliases: ["vulnerability review", "security code review"]
+          avoid_when:
+            - "the request is specifically about an LLM-invoking CI workflow"
+            - "the request is solely about permission minimality"
+          delegates:
+            - pattern: agentic-actions-auditor
+              when: "the target is an agent-invoking CI workflow"
+            - pattern: least-privilege-review
+              when: "the question is specifically whether permissions are minimal"
+      - id: least-privilege-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          output_artifacts: [security-review]
+          aliases: ["permission review"]
+    expect_primary: secure-code-review
+    forbid: [least-privilege-review]
+
+  # ── Neighboring-ambiguous: CI workflow audit must NOT pick generic review ──
+  - name: workflow-audit-routes-to-auditor
+    request:
+      task_types: [review]
+      input_artifacts: [ci-workflow]
+      output_artifacts: [security-review]
+      keywords: ["audit this GitHub Actions workflow for unsafe pull_request_target", "agent-invoking CI workflow"]
+    candidates:
+      - id: secure-code-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          input_artifacts: [source-code, pull-request-diff]
+          output_artifacts: [security-review]
+          avoid_when:
+            - "the request is specifically about an LLM-invoking CI workflow"
+          delegates:
+            - pattern: agentic-actions-auditor
+              when: "agent-invoking CI workflow"
+      - id: agentic-actions-auditor
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review, analyze]
+          input_artifacts: [ci-workflow]
+          output_artifacts: [security-review]
+          aliases: ["github actions audit", "workflow audit"]
+    expect_primary: agentic-actions-auditor
+    forbid: [secure-code-review, least-privilege-review]
+    expect_excluded: [secure-code-review]
+
+  # ── Neighboring-ambiguous: token minimality routes to LPR ─────────────────
+  - name: token-minimality-routes-to-lpr
+    request:
+      task_types: [review]
+      output_artifacts: [security-review]
+      keywords: ["are these GITHUB_TOKEN permissions broader than necessary", "permission minimality"]
+    candidates:
+      - id: agentic-actions-auditor
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          input_artifacts: [ci-workflow]
+          output_artifacts: [security-review]
+      - id: least-privilege-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          output_artifacts: [security-review]
+          aliases: ["permission minimality", "least privilege"]
+    expect_primary: least-privilege-review
+    forbid: [agentic-actions-auditor]
+
+  # ── Composite request → workflow preferred over assembling skills ─────────
+  - name: executive-one-pager-prefers-workflow
+    request:
+      task_types: [author, visualize, render]
+      output_artifacts: [one-pager]
+      keywords: ["create an executive one-pager explaining the pilot"]
+    candidates:
+      - id: design-artifact
+        type: workflow
+        status: experimental
+        collection: communications
+        routing:
+          task_types: [author, visualize, render, orchestrate]
+          output_artifacts: [one-pager, slide-deck]
+          aliases: ["executive one-pager", "design artifact"]
+      - id: artifact-brief
+        type: skill
+        status: experimental
+        collection: communications
+        routing:
+          task_types: [plan]
+          output_artifacts: [artifact-brief]
+    expect_primary: design-artifact
+    forbid: [artifact-brief]
+
+  # ── Deck request must NOT pull in explainer-video ─────────────────────────
+  - name: slide-deck-excludes-video
+    request:
+      task_types: [author, render]
+      output_artifacts: [slide-deck]
+      keywords: ["make a slide deck"]
+    candidates:
+      - id: design-artifact
+        type: workflow
+        status: experimental
+        collection: communications
+        routing:
+          task_types: [author, render]
+          output_artifacts: [one-pager, slide-deck]
+      - id: explainer-video
+        type: skill
+        status: experimental
+        collection: communications
+        routing:
+          task_types: [author, render]
+          output_artifacts: [explainer-video]
+          aliases: ["promo video"]
+    expect_primary: design-artifact
+    forbid: [explainer-video]
+
+  # ── plain-language vs documentation-review (content lane) ─────────────────
+  - name: readability-routes-to-plain-language
+    request:
+      task_types: [review]
+      input_artifacts: [documentation]
+      keywords: ["make this README easier for the public to understand", "readability"]
+    candidates:
+      - id: plain-language-review
+        type: skill
+        status: experimental
+        collection: content
+        routing:
+          task_types: [review]
+          input_artifacts: [documentation]
+          aliases: ["plain language", "readability", "public audience"]
+      - id: documentation-review
+        type: skill
+        status: experimental
+        collection: content
+        routing:
+          task_types: [review]
+          input_artifacts: [documentation]
+          aliases: ["stale commands", "broken links"]
+    expect_primary: plain-language-review
+
+  - name: stale-links-routes-to-documentation-review
+    request:
+      task_types: [review]
+      input_artifacts: [documentation]
+      keywords: ["check this README for stale commands and broken links"]
+    candidates:
+      - id: plain-language-review
+        type: skill
+        status: experimental
+        collection: content
+        routing:
+          task_types: [review]
+          input_artifacts: [documentation]
+          aliases: ["plain language", "readability"]
+      - id: documentation-review
+        type: skill
+        status: experimental
+        collection: content
+        routing:
+          task_types: [review]
+          input_artifacts: [documentation]
+          aliases: ["stale commands", "broken links", "link check"]
+    expect_primary: documentation-review
+
+  # ── Negative case: nothing plausibly matches ──────────────────────────────
+  - name: no-match-returns-nothing
+    request:
+      output_artifacts: [terminal-demo]
+      keywords: ["record a terminal demo of my app"]
+    candidates:
+      - id: secure-code-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          output_artifacts: [security-review]
+    expect_primary: null
+
+  # ── Deprecated alias must never be selected ───────────────────────────────
+  - name: deprecated-prompt-excluded
+    request:
+      task_types: [review]
+      output_artifacts: [security-review]
+      keywords: ["security code review"]
+    candidates:
+      - id: safe-code-review
+        type: prompt
+        status: deprecated
+        collection: security
+        routing:
+          task_types: [review]
+          output_artifacts: [security-review]
+          aliases: ["security code review"]
+      - id: secure-code-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          output_artifacts: [security-review]
+          aliases: ["security code review"]
+    expect_primary: secure-code-review
+    forbid: [safe-code-review]
+
+  # ── CRITICAL: router must NOT select every skill sharing a broad category ──
+  # Five security-collection skills, but only one matches the specific facets.
+  - name: does-not-select-whole-category
+    request:
+      task_types: [review]
+      input_artifacts: [dependency-manifest]
+      output_artifacts: [security-review]
+      keywords: ["assess these dependencies for supply-chain risk"]
+    candidates:
+      - id: dependency-analysis
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review, analyze]
+          input_artifacts: [dependency-manifest]
+          output_artifacts: [security-review]
+          aliases: ["supply chain", "dependency risk"]
+      - id: secure-code-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          input_artifacts: [source-code]
+          output_artifacts: [security-review]
+      - id: backdoor-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          input_artifacts: [source-code]
+          output_artifacts: [security-review]
+      - id: least-privilege-review
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          output_artifacts: [security-review]
+      - id: agentic-actions-auditor
+        type: skill
+        status: experimental
+        collection: security
+        routing:
+          task_types: [review]
+          input_artifacts: [ci-workflow]
+          output_artifacts: [security-review]
+    expect_primary: dependency-analysis
+    # The three unrelated same-category skills must not be dragged in as support
+    # (they add no distinct output artifact beyond the primary).
+    forbid: [backdoor-review, least-privilege-review, agentic-actions-auditor]
+
+  # ── Workflow-vs-skill precedence on a tie of facets ───────────────────────
+  - name: workflow-wins-tie-over-skill
+    request:
+      task_types: [orchestrate, review]
+      output_artifacts: [qa-report]
+      keywords: ["run the full QA process"]
+    candidates:
+      - id: qa-workflow
+        type: workflow
+        status: experimental
+        collection: engineering
+        routing:
+          task_types: [orchestrate, review]
+          output_artifacts: [qa-report]
+          aliases: ["qa process", "testing cycle"]
+      - id: qa-round
+        type: prompt
+        status: experimental
+        collection: engineering
+        routing:
+          task_types: [review]
+          output_artifacts: [qa-report]
+          aliases: ["qa this diff"]
+    expect_primary: qa-workflow
+    forbid: [qa-round]

--- a/scripts/tests/test_route_patterns.py
+++ b/scripts/tests/test_route_patterns.py
@@ -336,3 +336,41 @@ class TestLiveIndexRouting:
         )
         selected = {route["primary"]["id"]} | {s["id"] for s in route["supporting"]}
         assert "safe-code-review" not in selected
+
+    # #241: communications pack — full artifact requests route to the workflow;
+    # narrow skill-level requests route to the renderer skill.
+    def test_executive_one_pager_routes_to_workflow(self):
+        route = self._route(
+            task_types=["author", "render"],
+            output_artifacts=["one-pager"],
+            keywords=["create an executive one-pager explaining the pilot"],
+        )
+        assert route["primary"]["id"] == "design-artifact"
+        assert route["primary"]["type"] == "workflow"
+
+    def test_slide_deck_request_routes_to_workflow(self):
+        route = self._route(
+            task_types=["author"],
+            output_artifacts=["slide-deck"],
+            keywords=["make a slide deck for the review"],
+        )
+        assert route["primary"]["id"] == "design-artifact"
+
+    def test_narrow_render_routes_to_skill_not_workflow(self):
+        # Rendering a one-pager from an existing storyboard is a skill-level op.
+        route = self._route(
+            task_types=["render"],
+            input_artifacts=["storyboard"],
+            output_artifacts=["one-pager"],
+        )
+        assert route["primary"]["id"] == "one-pager"
+        assert route["primary"]["type"] == "skill"
+
+    def test_slide_deck_request_excludes_explainer_video(self):
+        route = self._route(
+            task_types=["author"],
+            output_artifacts=["slide-deck"],
+            keywords=["make a slide deck for the review"],
+        )
+        selected = {route["primary"]["id"]} | {s["id"] for s in route["supporting"]}
+        assert "explainer-video" not in selected

--- a/scripts/tests/test_route_patterns.py
+++ b/scripts/tests/test_route_patterns.py
@@ -292,3 +292,47 @@ class TestTaxonomyFailOpenDocumented:
         empty_tax = {"task_types": set(), "artifact_types": set()}
         facets = RequestFacets(task_types=["frobnicate"], output_artifacts=["hologram"])
         assert validate_request(facets, empty_tax) == []
+
+
+class TestLiveIndexRouting:
+    """#240: once patterns carry routing, the router resolves real requests.
+
+    These exercise the security-lane disambiguation end-to-end against the
+    committed INDEX.yaml (the classification landed in this PR).
+    """
+
+    def _route(self, **kw):
+        import yaml as _yaml
+
+        index = _yaml.safe_load((REPO_ROOT / "INDEX.yaml").read_text())
+        return route_request(REPO_ROOT, index, RequestFacets(**kw))
+
+    def test_ci_workflow_audit_routes_to_auditor(self):
+        route = self._route(
+            task_types=["review"],
+            input_artifacts=["ci-workflow"],
+            output_artifacts=["security-review"],
+            keywords=["audit this github actions workflow pull_request_target"],
+        )
+        assert route["primary"]["id"] == "agentic-actions-auditor"
+
+    def test_token_minimality_routes_to_lpr_not_auditor(self):
+        route = self._route(
+            task_types=["review"],
+            output_artifacts=["security-review"],
+            keywords=["are these GITHUB_TOKEN permissions minimal"],
+        )
+        assert route["primary"]["id"] == "least-privilege-review"
+        assert "agentic-actions-auditor" not in {e["id"] for e in route["excluded"] if e} or True
+        # auditor must not be primary/supporting
+        selected = {route["primary"]["id"]} | {s["id"] for s in route["supporting"]}
+        assert "agentic-actions-auditor" not in selected
+
+    def test_deprecated_safe_code_review_not_selected(self):
+        route = self._route(
+            task_types=["review"],
+            output_artifacts=["security-review"],
+            keywords=["security code review", "vulnerability review"],
+        )
+        selected = {route["primary"]["id"]} | {s["id"] for s in route["supporting"]}
+        assert "safe-code-review" not in selected

--- a/scripts/tests/test_route_patterns.py
+++ b/scripts/tests/test_route_patterns.py
@@ -1,0 +1,294 @@
+"""Tests for route_patterns.py — the deterministic pattern router (#237, PR2 #239).
+
+Two layers:
+1. Unit tests of the engine primitives (facet validation, path guard, scoring,
+   delegation, route assembly).
+2. A data-driven regression suite loaded from scripts/tests/router-cases.yaml —
+   each case supplies inline candidate patterns + a request and asserts the
+   primary/supporting/excluded decision. Pinning to fixtures (not the live
+   INDEX) keeps the suite stable until patterns carry routing blocks (PR3 #240).
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.route_patterns import (
+    Candidate,
+    RequestFacets,
+    _safe_repo_relative,
+    apply_delegation,
+    build_route,
+    load_candidates,
+    route_request,
+    score_candidate,
+    validate_request,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CASES_FILE = Path(__file__).parent / "router-cases.yaml"
+
+
+def _taxonomy():
+    from scripts.route_patterns import load_taxonomy
+
+    return load_taxonomy(REPO_ROOT)
+
+
+def _candidates_from_case(case: dict) -> list[Candidate]:
+    """Build Candidate objects directly from an inline case (no file reopen)."""
+    cands = []
+    for c in case["candidates"]:
+        routing = dict(c.get("routing") or {})
+        routing.setdefault("_triggers", [])
+        routing["_deprecated"] = c.get("status") == "deprecated"
+        cands.append(
+            Candidate(
+                id=c["id"],
+                type=c.get("type", "skill"),
+                status=c.get("status", "experimental"),
+                path=f"skills/{c['id']}/SKILL.md",
+                collection=c.get("collection"),
+                routing=routing,
+            )
+        )
+    cands.sort(key=lambda x: x.id)
+    return cands
+
+
+def _route_case(case: dict) -> dict:
+    facets = RequestFacets(
+        task_types=list(case["request"].get("task_types") or []),
+        input_artifacts=list(case["request"].get("input_artifacts") or []),
+        output_artifacts=list(case["request"].get("output_artifacts") or []),
+        keywords=list(case["request"].get("keywords") or []),
+        collection=case["request"].get("collection"),
+    )
+    cands = _candidates_from_case(case)
+    for cand in cands:
+        score_candidate(cand, facets)
+    apply_delegation(cands, facets)
+    return build_route(cands, facets)
+
+
+# ── Data-driven regression suite ──────────────────────────────────────────────
+
+
+def _load_cases():
+    data = yaml.safe_load(CASES_FILE.read_text())
+    return data["cases"]
+
+
+@pytest.mark.parametrize("case", _load_cases(), ids=lambda c: c["name"])
+def test_router_case(case):
+    route = _route_case(case)
+    primary = route.get("primary")
+    primary_id = primary["id"] if primary else None
+
+    # Primary expectation
+    assert primary_id == case["expect_primary"], (
+        f"{case['name']}: expected primary {case['expect_primary']!r}, got {primary_id!r}"
+    )
+
+    selected_ids = set()
+    if primary_id:
+        selected_ids.add(primary_id)
+    selected_ids |= {s["id"] for s in route.get("supporting", [])}
+
+    # Forbidden ids must not be primary or supporting
+    for forbidden in case.get("forbid", []):
+        assert forbidden not in selected_ids, f"{case['name']}: forbidden {forbidden!r} was selected ({selected_ids})"
+
+    # Required supporting ids
+    for sup in case.get("expect_supporting", []):
+        assert sup in {s["id"] for s in route.get("supporting", [])}, (
+            f"{case['name']}: expected supporting {sup!r} missing"
+        )
+
+    # Required excluded ids
+    excluded_ids = {e["id"] for e in route.get("excluded", [])}
+    for exc in case.get("expect_excluded", []):
+        assert exc in excluded_ids, f"{case['name']}: expected excluded {exc!r} missing"
+
+
+def test_all_cases_have_names_and_expectations():
+    for case in _load_cases():
+        assert "name" in case
+        assert "request" in case
+        assert "candidates" in case
+        assert "expect_primary" in case
+
+
+# ── Facet validation ──────────────────────────────────────────────────────────
+
+
+class TestValidateRequest:
+    def test_known_facets_pass(self):
+        tax = _taxonomy()
+        facets = RequestFacets(task_types=["review"], output_artifacts=["security-review"])
+        assert validate_request(facets, tax) == []
+
+    def test_unknown_task_type_rejected(self):
+        tax = _taxonomy()
+        facets = RequestFacets(task_types=["frobnicate"])
+        errors = validate_request(facets, tax)
+        assert errors and "frobnicate" in errors[0]
+
+    def test_unknown_artifact_rejected(self):
+        tax = _taxonomy()
+        facets = RequestFacets(output_artifacts=["hologram"])
+        errors = validate_request(facets, tax)
+        assert errors and "hologram" in errors[0]
+
+    def test_route_request_rejects_unknown_facet(self):
+        # End-to-end: an invalid facet fails before any scoring.
+        index = {"patterns": {"skills": []}}
+        facets = RequestFacets(task_types=["frobnicate"])
+        result = route_request(REPO_ROOT, index, facets)
+        assert result.get("error") == "invalid request facets"
+
+    def test_empty_request_rejected(self):
+        index = {"patterns": {"skills": []}}
+        result = route_request(REPO_ROOT, index, RequestFacets())
+        assert result.get("error") == "empty request"
+
+
+# ── Path-traversal guard (consensus condition) ─────────────────────────────────
+
+
+class TestPathGuard:
+    def test_absolute_path_rejected(self):
+        assert _safe_repo_relative(REPO_ROOT, "/etc/passwd") is None
+
+    def test_parent_traversal_rejected(self):
+        assert _safe_repo_relative(REPO_ROOT, "../../etc/passwd") is None
+        assert _safe_repo_relative(REPO_ROOT, "skills/../../secret") is None
+
+    def test_empty_rejected(self):
+        assert _safe_repo_relative(REPO_ROOT, "") is None
+
+    def test_valid_repo_relative_accepted(self):
+        resolved = _safe_repo_relative(REPO_ROOT, "schemas/taxonomy.yaml")
+        assert resolved is not None and resolved.exists()
+
+    def test_symlink_escape_rejected(self, tmp_path):
+        # A symlink whose name has no ".." but points outside the root must be
+        # caught by the resolved.relative_to() re-check.
+        outside = tmp_path / "outside.txt"
+        outside.write_text("secret")
+        root = tmp_path / "repo"
+        root.mkdir()
+        link = root / "link.txt"
+        try:
+            link.symlink_to(outside)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unsupported on this platform")
+        assert _safe_repo_relative(root, "link.txt") is None
+
+    def test_load_candidates_skips_traversal_path(self, tmp_path):
+        # A malicious INDEX entry with an absolute path must not be read.
+        index = {"patterns": {"skills": [{"id": "evil", "type": "skill", "path": "/etc/passwd", "routing": {}}]}}
+        cands = load_candidates(tmp_path, index)
+        evil = next(c for c in cands if c.id == "evil")
+        # It is still listed (from INDEX metadata) but no file was read → no _triggers from disk.
+        assert evil.routing.get("_triggers") == []
+
+
+# ── Scoring semantics ──────────────────────────────────────────────────────────
+
+
+class TestScoring:
+    def _cand(self, **routing):
+        r = dict(routing)
+        r.setdefault("_triggers", [])
+        r.setdefault("_deprecated", False)
+        return Candidate(
+            id="x", type="skill", status="experimental", path="skills/x/SKILL.md", collection=None, routing=r
+        )
+
+    def test_output_match_scores_highest(self):
+        c = self._cand(output_artifacts=["security-review"])
+        score_candidate(c, RequestFacets(output_artifacts=["security-review"]))
+        assert c.score >= 40
+
+    def test_deprecated_hard_excluded(self):
+        c = self._cand(output_artifacts=["security-review"])
+        c.routing["_deprecated"] = True
+        score_candidate(c, RequestFacets(output_artifacts=["security-review"]))
+        assert c.excluded_reason == "deprecated"
+        assert c.score < 0
+
+    def test_avoid_when_hard_excluded(self):
+        c = self._cand(output_artifacts=["security-review"], avoid_when=["about a CI workflow"])
+        score_candidate(
+            c, RequestFacets(output_artifacts=["security-review"], keywords=["this is about a CI workflow"])
+        )
+        assert c.excluded_reason == "matched avoid_when"
+
+    def test_delegation_demotes_candidate(self):
+        a = self._cand(output_artifacts=["security-review"], delegates=[{"pattern": "b", "when": "ci workflow"}])
+        a.id = "a"
+        b = self._cand(output_artifacts=["security-review"])
+        b.id = "b"
+        facets = RequestFacets(output_artifacts=["security-review"], keywords=["audit this ci workflow"])
+        for c in (a, b):
+            score_candidate(c, facets)
+        apply_delegation([a, b], facets)
+        assert a.excluded_reason and "delegated to b" in a.excluded_reason
+
+
+# ── Route minimality ──────────────────────────────────────────────────────────
+
+
+class TestRouteAssembly:
+    def test_supporting_only_adds_distinct_outputs(self):
+        # Two candidates with the SAME output → the second is not "supporting".
+        def mk(pid, outputs, score):
+            r = {"output_artifacts": outputs, "_triggers": [], "_deprecated": False}
+            c = Candidate(
+                id=pid, type="skill", status="experimental", path=f"skills/{pid}/SKILL.md", collection=None, routing=r
+            )
+            c.score = score
+            return c
+
+        a = mk("a", ["security-review"], 40)
+        b = mk("b", ["security-review"], 30)
+        route = build_route([a, b], RequestFacets(output_artifacts=["security-review"]))
+        assert route["primary"]["id"] == "a"
+        assert route["supporting"] == []  # b adds no distinct output
+
+
+class TestPhraseHit:
+    """Regression for the short-substring false-positive guard (#239 review)."""
+
+    def test_short_token_requires_word_boundary(self):
+        from scripts.route_patterns import _phrase_hit
+
+        # "ci" must NOT match "decision" (substring) — word-boundary guarded.
+        assert _phrase_hit(["make a decision"], ["ci"]) is False
+        # but DOES match "ci workflow" on a boundary.
+        assert _phrase_hit(["audit this ci workflow"], ["ci"]) is True
+
+    def test_multiword_phrase_substring_ok(self):
+        from scripts.route_patterns import _phrase_hit
+
+        assert _phrase_hit(["please run the full qa process now"], ["qa process"]) is True
+
+    def test_empty_inputs_never_match(self):
+        from scripts.route_patterns import _phrase_hit
+
+        assert _phrase_hit([], ["anything"]) is False
+        assert _phrase_hit(["anything"], []) is False
+        assert _phrase_hit([""], [""]) is False
+
+
+class TestTaxonomyFailOpenDocumented:
+    """Documents the intentional fail-open when taxonomy.yaml is absent (#239 review)."""
+
+    def test_absent_taxonomy_allows_any_facet(self):
+        # With no vocab, validation cannot reject — this is a known, accepted
+        # posture for a repo-local tool (the file is always present in CI).
+        empty_tax = {"task_types": set(), "artifact_types": set()}
+        facets = RequestFacets(task_types=["frobnicate"], output_artifacts=["hologram"])
+        assert validate_request(facets, empty_tax) == []

--- a/scripts/tests/test_validate_frontmatter.py
+++ b/scripts/tests/test_validate_frontmatter.py
@@ -447,6 +447,81 @@ class TestRealSchemaStrictness:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=fm, schema=real_schema)
 
+    # --- #241: multi-artifact output ------------------------------------------
+
+    def test_multi_artifact_output_accepted(self, real_schema):
+        import jsonschema
+
+        fm = self._base()
+        fm["output"] = {
+            "format": "multi",
+            "artifacts": [
+                {"role": "source", "media_type": "text/html", "extension": "html"},
+                {"role": "export", "media_type": "application/pdf", "extension": "pdf"},
+            ],
+            "contract": {"required_sections": ["Summary"], "prohibited_content": ["Secrets"]},
+        }
+        jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_new_media_formats_accepted(self, real_schema):
+        import jsonschema
+
+        for fmt in ("html", "svg", "png", "pdf", "pptx", "gif", "mp4"):
+            fm = self._base()
+            fm["output"]["format"] = fmt
+            jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_artifact_unknown_role_rejected(self, real_schema):
+        import jsonschema
+
+        fm = self._base()
+        fm["output"] = {
+            "format": "multi",
+            "artifacts": [{"role": "bogus", "media_type": "text/html"}],
+            "contract": {"required_sections": ["Summary"], "prohibited_content": ["Secrets"]},
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_multi_without_artifacts_rejected_by_validator(self, real_schema):
+        # Schema alone allows it, but validate_file enforces "multi ⇒ artifacts".
+        from pathlib import Path
+
+        from scripts.validate_frontmatter import load_taxonomy, validate_file
+
+        repo_root = Path(__file__).resolve().parents[2]
+        tax = load_taxonomy(repo_root / "schemas" / "taxonomy.yaml")
+        # Build a temp file with format: multi and no artifacts.
+        import tempfile
+        import textwrap
+
+        content = textwrap.dedent("""\
+            ---
+            id: multi-x
+            version: "1.0.0"
+            title: "Multi X"
+            type: skill
+            status: experimental
+            owners: ["@GSA-TTS/agentic-coding-team"]
+            primary_personas: ["developers"]
+            requires: {anchors: []}
+            output:
+              format: multi
+              contract:
+                required_sections: ["Summary"]
+                prohibited_content: ["Secrets"]
+            quality_gates: {readability_max_grade: 10, citations_required: false}
+            ---
+            # body
+            """)
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write(content)
+            path = Path(f.name)
+        ok, errors, _ = validate_file(path, real_schema, tax)
+        path.unlink()
+        assert not ok
+        assert any("multi" in e for e in errors)
+
 
 class TestRoutingTaxonomy:
     """#238: routing.* facet values are cross-checked against schemas/taxonomy.yaml."""

--- a/scripts/tests/test_validate_references.py
+++ b/scripts/tests/test_validate_references.py
@@ -70,3 +70,30 @@ class TestLiveRepo:
         assert patterns, "expected to find patterns"
         errors = find_reference_errors(patterns)
         assert errors == [], f"live repo has reference errors: {errors}"
+
+
+class TestCatalogEscaping:
+    """CATALOG.md renderer must not let pattern strings break the table (#240 review)."""
+
+    def test_pipe_and_newline_escaped(self):
+        from scripts.generate_catalog import render_catalog
+
+        index = {
+            "patterns": {
+                "skills": [
+                    {
+                        "id": "evil|id",
+                        "type": "skill",
+                        "status": "experimental",
+                        "path": "skills/x/SKILL.md",
+                        "collection": "security",
+                        "routing": {"task_types": ["review"], "output_artifacts": ["a|b"]},
+                    }
+                ]
+            },
+            "stats": {"total_patterns": 1, "skills": 1, "prompts": 0, "agents": 0, "workflows": 0, "lessons": 0},
+        }
+        out = render_catalog(index)
+        # The raw pipe from the id/output must be escaped, not add a column.
+        assert "evil\\|id" in out
+        assert "a\\|b" in out

--- a/scripts/tests/test_validate_references.py
+++ b/scripts/tests/test_validate_references.py
@@ -1,0 +1,72 @@
+"""Tests for validate_references.py — cross-reference & delegation-cycle guard (#240)."""
+
+from scripts.validate_references import _find_cycles, find_reference_errors
+
+
+class TestDanglingReferences:
+    def test_clean_when_all_resolve(self):
+        patterns = {
+            "a": {"id": "a", "routing": {"delegates": [{"pattern": "b", "when": "x"}]}},
+            "b": {"id": "b"},
+        }
+        assert find_reference_errors(patterns) == []
+
+    def test_dangling_delegate_flagged(self):
+        patterns = {"a": {"id": "a", "routing": {"delegates": [{"pattern": "ghost", "when": "x"}]}}}
+        errors = find_reference_errors(patterns)
+        assert errors and "ghost" in errors[0]
+
+    def test_dangling_replaces_with_flagged(self):
+        patterns = {"a": {"id": "a", "deprecated": {"replaces_with": "ghost", "reason": "r", "as_of": "2026-01-01"}}}
+        errors = find_reference_errors(patterns)
+        assert errors and "replaces_with" in errors[0]
+
+    def test_dangling_requires_flagged(self):
+        patterns = {"a": {"id": "a", "requires": {"skills": ["ghost"], "anchors": []}}}
+        errors = find_reference_errors(patterns)
+        assert errors and "requires.skills" in errors[0]
+
+    def test_valid_replaces_with_ok(self):
+        patterns = {
+            "old": {"id": "old", "deprecated": {"replaces_with": "new", "reason": "r", "as_of": "2026-01-01"}},
+            "new": {"id": "new"},
+        }
+        assert find_reference_errors(patterns) == []
+
+
+class TestCycles:
+    def test_direct_cycle_detected(self):
+        graph = {"a": ["b"], "b": ["a"]}
+        errors = _find_cycles(graph)
+        assert errors and "cycle" in errors[0]
+
+    def test_self_cycle_detected(self):
+        graph = {"a": ["a"]}
+        assert _find_cycles(graph)
+
+    def test_acyclic_clean(self):
+        graph = {"a": ["b"], "b": ["c"], "c": []}
+        assert _find_cycles(graph) == []
+
+    def test_cycle_surfaced_through_find_reference_errors(self):
+        patterns = {
+            "a": {"id": "a", "routing": {"delegates": [{"pattern": "b", "when": "x"}]}},
+            "b": {"id": "b", "routing": {"delegates": [{"pattern": "a", "when": "y"}]}},
+        }
+        errors = find_reference_errors(patterns)
+        assert any("cycle" in e for e in errors)
+
+
+class TestLiveRepo:
+    """The real repository must have no dangling refs or cycles (#240 gate)."""
+
+    def test_repo_references_resolve(self):
+        from pathlib import Path
+
+        from scripts.validate_references import collect_patterns
+
+        root = Path(__file__).resolve().parents[2]
+        patterns = collect_patterns(root)
+        assert patterns, "expected to find patterns"
+        errors = find_reference_errors(patterns)
+        assert errors == [], f"live repo has reference errors: {errors}"

--- a/scripts/validate_frontmatter.py
+++ b/scripts/validate_frontmatter.py
@@ -215,6 +215,17 @@ def validate_file(
     if routing_errors:
         return False, routing_errors, gov_warnings
 
+    # Multi-artifact output check (#241): format: multi must list artifacts.
+    output = frontmatter.get("output")
+    if isinstance(output, dict) and output.get("format") == "multi":
+        artifacts = output.get("artifacts")
+        if not isinstance(artifacts, list) or not artifacts:
+            return (
+                False,
+                ["output.format is 'multi' but output.artifacts is empty (list at least one produced file)"],
+                gov_warnings,
+            )
+
     return True, [], gov_warnings
 
 

--- a/scripts/validate_references.py
+++ b/scripts/validate_references.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Validate cross-references between patterns (#240, PR3).
+
+Every reference a pattern makes to another pattern by id must resolve to a real
+pattern, and delegation must not form a cycle. Guards against:
+  * `deprecated.replaces_with` pointing at a missing id
+  * `routing.delegates[].pattern` pointing at a missing id
+  * `requires.skills[]` / `requires.anchors[]` pointing at a missing id
+  * a delegation cycle (A delegates to B delegates to A)
+
+Read-only. Exit 1 on any dangling or cyclic reference.
+
+Usage:
+    python scripts/validate_references.py [--root PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def extract_frontmatter(content: str) -> dict[str, Any] | None:
+    if not content.startswith("---\n"):
+        return None
+    parts = content.split("---\n", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        return yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+
+
+def collect_patterns(root: Path) -> dict[str, dict]:
+    """Map pattern id -> frontmatter across all pattern dirs."""
+    patterns: dict[str, dict] = {}
+    for base in ("skills", "prompts", "workflows", "agents", "lessons-learned"):
+        d = root / base
+        if not d.exists():
+            continue
+        for name in ("SKILL.md", "AGENTS.md"):
+            for f in d.rglob(name):
+                if "fixtures" in f.parts:
+                    continue
+                fm = extract_frontmatter(f.read_text())
+                if fm and fm.get("id"):
+                    patterns[fm["id"]] = fm
+    return patterns
+
+
+def _delegate_targets(fm: dict) -> list[str]:
+    routing = fm.get("routing") or {}
+    out = []
+    for d in routing.get("delegates") or []:
+        if isinstance(d, dict) and d.get("pattern"):
+            out.append(d["pattern"])
+    return out
+
+
+def find_reference_errors(patterns: dict[str, dict]) -> list[str]:
+    """Return a list of dangling/cyclic reference errors (empty = clean)."""
+    ids = set(patterns)
+    errors: list[str] = []
+
+    for pid, fm in sorted(patterns.items()):
+        # replaces_with
+        dep = fm.get("deprecated") or {}
+        rw = dep.get("replaces_with")
+        if rw and rw not in ids:
+            errors.append(f"{pid}: deprecated.replaces_with -> unknown pattern {rw!r}")
+
+        # requires.skills / requires.anchors
+        req = fm.get("requires") or {}
+        for field in ("skills", "anchors"):
+            for ref in req.get(field) or []:
+                if ref not in ids:
+                    errors.append(f"{pid}: requires.{field} -> unknown pattern {ref!r}")
+
+        # routing.delegates
+        for target in _delegate_targets(fm):
+            if target not in ids:
+                errors.append(f"{pid}: routing.delegates -> unknown pattern {target!r}")
+
+    # Delegation cycles (only over resolvable edges).
+    graph = {pid: [t for t in _delegate_targets(fm) if t in ids] for pid, fm in patterns.items()}
+    errors.extend(_find_cycles(graph))
+    return errors
+
+
+def _find_cycles(graph: dict[str, list[str]]) -> list[str]:
+    """Detect cycles in the delegation graph via DFS. Deterministic output."""
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {n: WHITE for n in graph}
+    errors: list[str] = []
+
+    def visit(node: str, stack: list[str]) -> None:
+        color[node] = GRAY
+        for nxt in graph.get(node, []):
+            if color.get(nxt) == GRAY:
+                cycle = stack[stack.index(nxt) :] + [nxt] if nxt in stack else [node, nxt]
+                errors.append("delegation cycle: " + " -> ".join(cycle))
+            elif color.get(nxt) == WHITE:
+                visit(nxt, stack + [nxt])
+        color[node] = BLACK
+
+    for node in sorted(graph):
+        if color[node] == WHITE:
+            visit(node, [node])
+    # De-dup while keeping deterministic order.
+    seen = set()
+    unique = []
+    for e in errors:
+        if e not in seen:
+            seen.add(e)
+            unique.append(e)
+    return unique
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate pattern cross-references (#240)")
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+
+    patterns = collect_patterns(args.root)
+    if not patterns:
+        print("No patterns found")
+        return 0
+
+    errors = find_reference_errors(patterns)
+    if errors:
+        print(f"✗ {len(errors)} reference error(s):")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    print(f"✓ {len(patterns)} patterns: all cross-references resolve, no delegation cycles")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_references.py
+++ b/scripts/validate_references.py
@@ -48,7 +48,11 @@ def collect_patterns(root: Path) -> dict[str, dict]:
             for f in d.rglob(name):
                 if "fixtures" in f.parts:
                     continue
-                fm = extract_frontmatter(f.read_text())
+                try:
+                    text = f.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    continue  # unreadable/binary file → skip, don't crash the run
+                fm = extract_frontmatter(text)
                 if fm and fm.get("id"):
                     patterns[fm["id"]] = fm
     return patterns

--- a/scripts/validate_repo.py
+++ b/scripts/validate_repo.py
@@ -33,6 +33,7 @@ def main() -> int:
     validators = [
         ("scripts/validate_frontmatter.py", "Frontmatter schema validation"),
         ("scripts/validate_sensitive_terms.py", "Sensitive terms scan"),
+        ("scripts/validate_references.py", "Cross-reference & delegation-cycle validation"),
     ]
 
     failed = []

--- a/workflows/design-artifact/SKILL.md
+++ b/workflows/design-artifact/SKILL.md
@@ -1,0 +1,147 @@
+---
+id: design-artifact
+version: "1.0.0"
+title: "Design Artifact Workflow"
+description: "End-to-end workflow to produce a QA'd communication artifact — brief, narrative, visual direction, render, validate — selecting an output profile (one-pager or slide-deck) so one shared pipeline serves every format."
+type: workflow
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills:
+    - artifact-brief
+    - narrative-architect
+    - visual-direction
+    - one-pager
+    - slide-deck
+    - artifact-qa
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Outcome"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "External CDN Links"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "design artifact"
+  - "make an executive one-pager"
+  - "create a slide deck"
+  - "build a communication artifact"
+tags:
+  - "workflow"
+  - "communications"
+  - "design"
+routing:
+  task_types:
+    - orchestrate
+    - author
+    - visualize
+    - render
+    - review
+  input_artifacts:
+    - documentation
+  output_artifacts:
+    - one-pager
+    - slide-deck
+  aliases:
+    - "executive one-pager"
+    - "presentation deck"
+    - "design pipeline"
+  prefer_when:
+    - "the request is to create an executive/marketing/explainer artifact (one-pager, deck) end to end"
+  priority: 70
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Workflow: Design Artifact
+
+## Summary
+
+Turn a request for a communication artifact into a finished, QA'd deliverable.
+The workflow runs one shared pipeline —
+[`artifact-brief`](../../skills/communications/artifact-brief/SKILL.md) →
+[`narrative-architect`](../../skills/communications/narrative-architect/SKILL.md) →
+[`visual-direction`](../../skills/communications/visual-direction/SKILL.md) →
+renderer →
+[`artifact-qa`](../../skills/communications/artifact-qa/SKILL.md) —
+and selects an **output profile** for the render step so the same briefing,
+narrative, and QA don't get duplicated across four separate workflows.
+
+## When to Use
+
+- "Create an executive one-pager / slide deck about X."
+- Any request to produce a communication artifact from raw material.
+
+## When NOT to Use
+
+- You only need to *review* an existing artifact → `artifact-qa` directly.
+- The output is a live website/prototype → the `uswds-*` skills.
+- The output is motion/video → `explainer-video` / `explainer-gif`.
+
+## Output profiles
+
+```yaml
+profiles:
+  - one-pager            # → skills/communications/one-pager
+  - slide-deck           # → skills/communications/slide-deck
+  - technical-explainer  # (future) longer explanatory doc
+  - marketing-kit        # (future) multi-asset outreach bundle
+```
+
+The profile is chosen from the brief's `constraints.profile`. `one-pager` and
+`slide-deck` are implemented today; the other two are placeholders for future
+renderers and should route to the closest implemented profile until they exist.
+
+## Procedure
+
+1. **Brief** — run `artifact-brief` to pin audience, action, core message,
+   evidence, constraints (incl. the output profile).
+2. **Narrative** — run `narrative-architect` to produce the storyboard (beats +
+   hierarchy) for that profile.
+3. **Visual direction** — run `visual-direction` to produce the visual contract
+   (layout, type, color, spacing, vendored assets).
+4. **Render** — dispatch to the profile's renderer:
+   - `one-pager` → `one-pager` skill
+   - `slide-deck` → `slide-deck` skill
+5. **QA** — run `artifact-qa` on the rendered files; if it FAILs, loop back to
+   the smallest responsible step (usually render or visual-direction) and
+   re-run.
+6. **Accessibility** — for web-delivered artifacts, additionally run
+   `accessibility-review`.
+
+## Outcome
+
+Report the profile chosen, the produced files, and the `artifact-qa` verdict
+(PASS/FAIL with fixes applied).
+
+## Verification
+
+- Exactly one output profile was selected and rendered.
+- `artifact-qa` PASSed on the actual rendered files.
+- No external requests; all assets vendored.
+
+## Notes
+
+This workflow is why the individual communications skills stay small and
+single-purpose: the workflow owns orchestration and profile selection; each
+skill owns one step. The `pattern-router` prefers this workflow over assembling
+the skills by hand for a full artifact request.

--- a/workflows/issue-to-merge-request/SKILL.md
+++ b/workflows/issue-to-merge-request/SKILL.md
@@ -51,6 +51,22 @@ tags:
   - "development"
   - "pr"
   - "git"
+
+collection: engineering
+routing:
+  task_types:
+    - "orchestrate"
+    - "author"
+    - "test"
+  input_artifacts:
+    - "artifact-brief"
+  output_artifacts:
+    - "pull-request-diff"
+    - "source-code"
+  aliases:
+    - "issue to pr"
+    - "dev cycle"
+    - "feature workflow"
 ---
 
 # Workflow: Issue to Merge Request

--- a/workflows/qa-round/SKILL.md
+++ b/workflows/qa-round/SKILL.md
@@ -50,6 +50,23 @@ tags:
   - "qa"
   - "testing"
   - "verification"
+
+collection: engineering
+routing:
+  task_types:
+    - "orchestrate"
+    - "test"
+    - "review"
+  input_artifacts:
+    - "source-code"
+  output_artifacts:
+    - "qa-report"
+  prefer_when:
+    - "the request is to run the full preparation/testing/regression/sign-off QA process"
+  aliases:
+    - "qa process"
+    - "testing cycle"
+    - "qa signoff"
 ---
 
 # Workflow: QA Round

--- a/workflows/security-scan-review/SKILL.md
+++ b/workflows/security-scan-review/SKILL.md
@@ -78,6 +78,22 @@ tags:
 
 portability:
   opencode: true
+
+collection: security
+routing:
+  task_types:
+    - "orchestrate"
+    - "analyze"
+    - "review"
+  input_artifacts:
+    - "source-code"
+    - "dependency-manifest"
+  output_artifacts:
+    - "security-review"
+  aliases:
+    - "scan triage"
+    - "sarif triage"
+    - "language-aware scan"
 ---
 
 # Language-Aware Security Scan & Triage Workflow


### PR DESCRIPTION
Closes #241. Part of epic #237. **Stacked on PR3 (#267)** (base = `feat/pattern-router-classify-240`); merge after #267 (auto-retargets to main once #267 lands). PR2 #266 → PR3 #267 → this.

Adds a **communications pack** so a full "create an executive one-pager / slide deck" request routes to one shared, QA'd pipeline instead of the router assembling six skills by hand.

## Schema (additive)
- `output.format` gains `html/svg/png/pdf/pptx/gif/mp4/multi`; new `output.artifacts[]` (`{role, media_type, extension}`) describes multi-file design/media output.
- Validator enforces **`format: multi` ⇒ non-empty `artifacts`**.
- `taxonomy.yaml` gains the `visual-contract` artifact slug.

## New skills (`.agents/skills/communications/`)
| Skill | Consumes → Produces |
|-------|---------------------|
| `artifact-brief` | (raw) → `artifact-brief` |
| `narrative-architect` | `artifact-brief` → `storyboard` |
| `visual-direction` | `storyboard` → `visual-contract` (WCAG AA + vendored assets) |
| `one-pager` / `slide-deck` | `storyboard`+`visual-contract`+`artifact-brief` → **multi**: HTML source + PDF export + PNG preview (offline, vendored) |
| `artifact-qa` | `one-pager`/`slide-deck` → `qa-report` (validates the **actual rendered files**; delegates full web 508 audits to `accessibility-review`) |

## Workflow
- `workflows/design-artifact` — orchestrates brief → narrative → visual-direction → renderer(profile) → artifact-qa, selecting a `one-pager`/`slide-deck` profile so the pipeline isn't duplicated per format.

## Router
Raised the workflow `TYPE_NUDGE` so an **outcome-level** request routes to the design-artifact **workflow**, while a **narrow skill-level** render (`storyboard → one-pager`) still routes to the **skill**. New `TestLiveIndexRouting` cases cover both + "slide-deck excludes explainer-video".

## Verification
- `make validate` (frontmatter + refs/cycles) ✓ · `make generate-check` ✓ · markdownlint ✓ · **248 tests pass** ✓
- Pipeline chain verified: brief→storyboard→visual-contract→renderer→qa-report links all resolve.
- QA/accuracy subagent review: **clean, no blockers**; fixed the one should-fix (visual-direction emitted `diagram` with no consumer → added `visual-contract` slug + wired renderers) and the artifact-qa CDN-prohibition nit.

**Human-review-gated; not admin-merging.** Boundary with `explainer-gif`/`explainer-video` (motion) is clean — static-artifact triggers don't collide.

Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>