### PR TITLE
fix(playbook-kit): fetch via GitHub REST tarball for cross-backend auth (quickstart#203)

### DIFF
--- a/integrations/isolation/acq-kits/agentic-coding-playbook/README.md
+++ b/integrations/isolation/acq-kits/agentic-coding-playbook/README.md
@@ -13,24 +13,34 @@ the federal `AGENTS.md` rules and the Agent Skills — into a sandbox.
 
 The kit ships one small script. At container **startup** it:
 
-1. clones the playbook at a pinned ref into `~/.agentic-coding-playbook`, then
+1. fetches the playbook at a pinned ref (as a GitHub REST **source tarball**)
+   into `~/.agentic-coding-playbook`, then
 2. symlinks the playbook's `AGENTS.md` and skills into each supported agent's
    search paths.
 
-Clone-at-startup (rather than vendoring the playbook into the kit's `files/`)
+Fetch-at-startup (rather than vendoring the playbook into the kit's `files/`)
 keeps the kit tiny and lets the playbook version be pinned and bumped
 independently. See [Failure behavior](#failure-behavior) for how it degrades
-when the clone can't run.
+when the fetch can't run.
 
 ## Backend parity
 
-All backends use the **same** mechanism: allow-list `github.com` /
-`codeload.github.com` and run the same clone+link script
-(`files/home/playbook-clone.sh`) at startup. No backend shortcut. The GitHub
-token needed while the playbook repo is private is injected by the active
-backend on the outbound clone (see [Prerequisites](#prerequisites)); the kit
-never holds it. Behavioral parity: the playbook's `AGENTS.md` + skills end up
-linked into the agent search paths on every backend.
+All backends use the **same** mechanism: allow-list `api.github.com` /
+`codeload.github.com` and run the same fetch+link script
+(`files/home/playbook-clone.sh`) at startup. No backend shortcut.
+
+The script fetches the repo **source tarball** from the GitHub REST API
+(`https://api.github.com/repos/<owner>/<repo>/tarball/<ref>`, which 302-redirects
+to `codeload.github.com`) with a Bearer token — **not** `git clone`. That matters
+for cross-backend parity: msb does **not** substitute an injected credential for
+git's smart-HTTP transport to `github.com`/`codeload` (the origin of
+[quickstart#203](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/203)),
+but it **does** substitute the `Authorization: Bearer` header for the REST API.
+So the one tarball code path authenticates on both `sbx` and `msb`, needs no
+`.git`, and needs no `gh`. The GitHub token is injected by the active backend to
+`api.github.com` (see [Prerequisites](#prerequisites)); the kit never holds it.
+Behavioral parity: the playbook's `AGENTS.md` + skills end up linked into the
+agent search paths on every backend.
 
 ## Usage
 
@@ -42,9 +52,9 @@ The kit is a `mixin`, so it composes with the other acq-kits.
 
 ## Prerequisites
 
-While the playbook repo is **private**, the clone needs a GitHub token. This kit
+While the playbook repo is **private**, the fetch needs a GitHub token. This kit
 does **not** declare its own `github` credential — the base agent sandbox
-already provides one, and `acq`'s backend injects it on the outbound clone (the
+already provides one, and `acq`'s backend injects it to `api.github.com` (the
 container never sees the real token). Set it once:
 
 ```bash
@@ -52,7 +62,7 @@ acq secret set github
 ```
 
 If you apply this kit on a base agent whose kit doesn't provide `github`, a
-private-repo clone has no credential and will fail — the kit degrades gracefully
+private-repo fetch has no credential and will fail — the kit degrades gracefully
 (warns and continues). Make the playbook repo public or supply a GitHub
 credential via that base. Once the repo is public, no token is needed.
 
@@ -89,32 +99,40 @@ Notes:
 
 The kit pins the playbook with two values passed to the startup script:
 
-- `PLAYBOOK_REF` — a human-legible release tag (e.g. `v0.14.0`), what the clone
-  fetches.
-- `PLAYBOOK_SHA` — the exact commit that tag must resolve to (the integrity pin).
+- `PLAYBOOK_REF` — a human-legible release tag (e.g. `v0.14.0`), what the fetch
+  retrieves.
+- `PLAYBOOK_AGENTS_SHA256` — the integrity pin: a sha256 over the **consumed
+  content** (the extracted `AGENTS.md` plus every file under `.agents/skills`,
+  hashed as a sorted per-file digest manifest).
 
-At startup the script shallow-clones `PLAYBOOK_REF`, then verifies the cloned
-`HEAD` equals `PLAYBOOK_SHA`; on mismatch it removes the clone and starts
-without the playbook rather than linking unexpected content. A tag is a
-**mutable** ref, and (with the sibling CA kit) the clone traverses a Zscaler MITM
-proxy, so a tag match alone is not sufficient integrity — hence the SHA gate.
+A GitHub source tarball is **not** byte-stable (server-side recompression), so
+the archive bytes can't be hash-pinned; and a tag is a **mutable** ref traversing
+a possibly MITM-inspected path — so a successful download alone is not integrity.
+At startup the script fetches `PLAYBOOK_REF`, extracts it, recomputes the content
+digest, and links **only** if it equals `PLAYBOOK_AGENTS_SHA256`; on mismatch it
+removes the tree and starts without the playbook rather than linking unexpected
+content. Hashing the skill files (not just `AGENTS.md`) means tampered skills —
+which are executable agent instructions — are also rejected. Skill entries that
+are symlinks or resolve outside the playbook tree are never linked.
 
 To adopt a newer playbook release, bump **both** `PLAYBOOK_REF` and
-`PLAYBOOK_SHA` together — in `spec.yaml`'s startup command **and** the matching
-fallback defaults in `files/home/playbook-clone.sh` — then recreate sandboxes.
+`PLAYBOOK_AGENTS_SHA256` together — in `spec.yaml`'s startup command **and** the
+matching fallback defaults in `files/home/playbook-clone.sh` — then recreate
+sandboxes. Regenerate the hash with the command in `spec.yaml`'s pinning comment.
 
-> Signed-tag verification (`git verify-tag`) is a possible future hardening;
-> it depends on the playbook signing its releases and is tracked separately.
+> Signed-tag verification is a possible future hardening; it depends on the
+> playbook signing its releases and is tracked separately.
 
 ## Failure behavior
 
 The startup script is **idempotent** and **non-fatal**:
 
-- Clones once (clone-if-missing); no refetch on later starts.
-- On clone failure (offline, missing token, bad ref) it **warns and exits 0** —
-  the sandbox starts **without** the playbook rather than failing to create.
+- Fetches once (fetch-if-missing); no refetch on later starts.
+- On fetch failure (offline, missing token, bad ref) it **warns and exits 0** —
+  the sandbox starts **without** the playbook rather than failing to create. The
+  underlying `curl` error is surfaced in the warning to aid diagnosis.
 - Because startup runs on every container start, a sandbox created offline
-  **self-heals**: the clone is retried on the next start once the network/token
+  **self-heals**: the fetch is retried on the next start once the network/token
   is available.
 
 ## Troubleshooting
@@ -143,5 +161,5 @@ logged in:
 ```
 
 It validates the spec, creates a throwaway sandbox with the kit, and confirms
-the playbook cloned and `AGENTS.md` + skills resolved at the agent paths. Set
+the playbook fetched and `AGENTS.md` + skills resolved at the agent paths. Set
 `KEEP=1` to keep the sandbox for inspection.

--- a/integrations/isolation/acq-kits/agentic-coding-playbook/TROUBLESHOOTING.md
+++ b/integrations/isolation/acq-kits/agentic-coding-playbook/TROUBLESHOOTING.md
@@ -1,30 +1,37 @@
 # Troubleshooting — agentic-coding-playbook kit
 
-These are failure modes specific to the playbook kit, which clones the GSA
-playbook at container startup and links its `AGENTS.md` + skills into each
-agent's search paths.
+These are failure modes specific to the playbook kit, which fetches the GSA
+playbook (a GitHub REST source tarball) at container startup and links its
+`AGENTS.md` + skills into each agent's search paths.
 
 ## No playbook rules or skills in the sandbox
 
 **Symptoms:** `~/.agents/skills` is empty; the agent has no federal `AGENTS.md`;
 `~/.agentic-coding-playbook` is missing.
 
-**Cause:** the startup clone didn't run or failed. The startup command is
+**Cause:** the startup fetch didn't run or failed. The startup command is
 non-fatal — on failure it warns and lets the sandbox start without the playbook.
 
 **Fix / diagnose:**
 
-- Check startup logs for the kit's warning (it names the likely cause).
+- Check startup logs for the kit's warning (it names the likely cause and now
+  includes the underlying `curl` error).
 - **Missing GitHub token (private repo).** While the playbook repo is private the
-  clone needs auth. Set it once: `sbx secret set -g github`. The kit relies on
-  the **opencode base kit's** `github` credential — applying the kit on a base
-  agent that doesn't declare `github` leaves the clone unauthenticated.
-- **Egress blocked.** Confirm `github.com` / `codeload.github.com` were allowed:
-  `sbx policy log <sandbox>`; add blocked hosts to `caps.network.allow`.
+  fetch needs auth. Set it once: `acq secret set -g github`. The kit relies on
+  the base agent kit's `github` credential — applying the kit on a base agent
+  that doesn't declare `github` leaves the fetch unauthenticated.
+- **Egress blocked.** Confirm `api.github.com` (the primary host — the token is
+  substituted there) and `codeload.github.com` (the redirected archive bytes)
+  were allowed: `sbx policy log <sandbox>`; add blocked hosts to
+  `caps.network.allow`.
 - **Bad ref.** Confirm `PLAYBOOK_REF` in `spec.yaml` names a real tag/branch.
-- **Self-heal:** the clone is retried on every container start, so once the
+- **Integrity mismatch.** If the fetch succeeded but the content sha256 didn't
+  match `PLAYBOOK_AGENTS_SHA256`, the kit removes the tree and warns "SECURITY:
+  ... Refusing to link untrusted playbook content." Regenerate the pin (see the
+  README) if you intentionally bumped `PLAYBOOK_REF`.
+- **Self-heal:** the fetch is retried on every container start, so once the
   network/token is fixed, stop/start the sandbox (or `sbx kit add <sandbox>
-  <kit>` then restart) and it will clone.
+  <kit>` then restart) and it will fetch.
 
 ## Skills are present but the agent doesn't use them
 
@@ -39,16 +46,17 @@ lower-confidence — verify in-sandbox and adjust the kit's link targets if need
 
 ## Playbook is pinned to an old version
 
-**Cause:** the kit pins `PLAYBOOK_REF`, and an existing clone is never re-fetched
-(clone-if-missing only).
+**Cause:** the kit pins `PLAYBOOK_REF`, and an existing tree is never re-fetched
+(fetch-if-missing only).
 
-**Fix:** bump `PLAYBOOK_REF` in `spec.yaml`, then recreate the sandbox (or remove
-`~/.agentic-coding-playbook` inside it and restart so the kit re-clones).
+**Fix:** bump `PLAYBOOK_REF` **and** `PLAYBOOK_AGENTS_SHA256` in `spec.yaml`
+(and the script's fallback defaults), then recreate the sandbox (or remove
+`~/.agentic-coding-playbook` inside it and restart so the kit re-fetches).
 
 ## `AGENTS.md` links are dangling
 
-**Cause:** the clone partially failed, or the playbook layout changed.
+**Cause:** the fetch partially failed, or the playbook layout changed.
 
-**Fix:** confirm `~/.agentic-coding-playbook/AGENTS.md` exists; if not, re-clone
+**Fix:** confirm `~/.agentic-coding-playbook/AGENTS.md` exists; if not, re-fetch
 (see the self-heal note above). The kit links best-effort and never fails the
 sandbox start on a missing link target.

--- a/integrations/isolation/acq-kits/agentic-coding-playbook/files/home/playbook-clone.sh
+++ b/integrations/isolation/acq-kits/agentic-coding-playbook/files/home/playbook-clone.sh
@@ -27,10 +27,17 @@
 #   PLAYBOOK_AGENTS_SHA256 — sha256 of the extracted AGENTS.md (integrity pin)
 #
 # INTEGRITY: a GitHub source tarball is NOT byte-stable (server-side
-# recompression), so we cannot pin the archive bytes. Instead we verify the
-# sha256 of the extracted AGENTS.md — stable content the kit actually consumes —
-# and refuse to link on mismatch. Bump PLAYBOOK_REF and PLAYBOOK_AGENTS_SHA256
+# recompression), so we cannot pin the archive bytes. Instead we verify a sha256
+# over the CONSUMED CONTENT — AGENTS.md plus every skill file under
+# .agents/skills — computed from a sorted per-file digest manifest, and refuse to
+# link on mismatch. This covers skills too (they are executable agent
+# instructions), not just AGENTS.md. Bump PLAYBOOK_REF and PLAYBOOK_AGENTS_SHA256
 # together (see the kit spec for how to regenerate the hash).
+#
+# In addition, skill entries are only linked if they are real in-tree directories
+# (not symlinks, and their resolved path stays under the playbook dir), so a
+# tampered/malicious tarball cannot plant a symlink that points an agent's skills
+# root at an arbitrary path outside the verified tree.
 
 set -u
 
@@ -43,9 +50,13 @@ export GIT_ASKPASS=/bin/false
 export SSH_ASKPASS=/bin/false
 
 ref="${PLAYBOOK_REF:-v0.14.0}"
-agents_sha="${PLAYBOOK_AGENTS_SHA256:-5b875f032e021e155faa2a7ee133a65f32aff3f2599b3b7b12384f1124417bba}"
+agents_sha="${PLAYBOOK_AGENTS_SHA256:-a9c438acfe8082ba959fd248be9b667f26f17c10c1c763ca57fdcb2396e43759}"
 owner_repo="GSA-TTS/agentic-coding-playbook"
 api="https://api.github.com/repos/${owner_repo}/tarball/${ref}"
+# HOME may be unset in a bare startup environment; default it rather than let
+# `set -u` abort with a nonzero exit (that would violate the always-warn+exit-0
+# non-fatal contract). The agent user's home is /home/agent by convention.
+HOME="${HOME:-/home/agent}"
 dir="$HOME/.agentic-coding-playbook"
 
 warn() { echo "agentic-coding-playbook: $*" >&2; }
@@ -66,6 +77,33 @@ sha256_of() {
   fi
 }
 
+# sha256_hex: read stdin, echo its sha256 hex digest (tool-agnostic).
+sha256_hex() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum 2>/dev/null | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 2>/dev/null | cut -d' ' -f1
+  fi
+}
+
+# content_digest DIR — a single sha256 over the CONSUMED content surface of the
+# playbook tree: AGENTS.md plus every regular file under .agents/skills. Built by
+# hashing each file, sorting the "<hash>  <relpath>" lines (stable ordering), and
+# hashing that manifest. REGULAR FILES ONLY (`find -type f` does not follow
+# symlinks for the listing, and we hash file contents), so a symlink planted in
+# the tarball cannot smuggle out-of-tree content into the digest. Echoes the hex
+# digest, or nothing if no sha tool is available.
+content_digest() {
+  _cd_dir="$1"
+  { sha256_of "$_cd_dir/AGENTS.md"
+    if [ -d "$_cd_dir/.agents/skills" ]; then
+      find "$_cd_dir/.agents/skills" -type f 2>/dev/null | LC_ALL=C sort | while IFS= read -r _f; do
+        sha256_of "$_f"
+      done
+    fi
+  } | sha256_hex
+}
+
 # 1) Fetch once (fetch-if-missing). Download the pinned-ref tarball via the REST
 #    API and extract it. No refetch on later starts (the dir persists).
 if [ ! -e "$dir/AGENTS.md" ]; then
@@ -76,11 +114,16 @@ if [ ! -e "$dir/AGENTS.md" ]; then
   fi
 
   tgz="$(mktemp "${TMPDIR:-/tmp}/acp-playbook.XXXXXX.tgz" 2>/dev/null)" || tgz="/tmp/acp-playbook.$$.tgz"
-  # -f: fail on HTTP error; -sSL: quiet but show errors, follow redirects.
+  cerr="$(mktemp "${TMPDIR:-/tmp}/acp-playbook-err.XXXXXX" 2>/dev/null)" || cerr="/tmp/acp-playbook-err.$$"
+  # -f: fail on HTTP error; -sSL: quiet but show errors (-S), follow redirects.
   # The Authorization header is passed via a config file read from stdin
   # (curl -K -) rather than an argv flag, so the token never appears in the
   # process argv (ps) — and so a POSIX sh can't word-split a "Bearer <tok>"
   # value. When no token is present, no auth line is written (public/anon fetch).
+  #
+  # curl's stderr is captured (not discarded) so the real cause (403 vs DNS vs
+  # TLS) is surfaced on failure. This is safe: the token lives in the -K config,
+  # never on the URL/argv, so curl's error text cannot contain it.
   #
   # -L follows the api.github.com -> codeload.github.com 302 redirect. curl
   # re-sends the Authorization header to codeload; on msb (which substitutes the
@@ -93,29 +136,33 @@ if [ ! -e "$dir/AGENTS.md" ]; then
       curl -fsSL -K - \
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
-        -o "$tgz" "$api" 2>/dev/null
+        -o "$tgz" "$api" 2>"$cerr"
     _fetch_rc=$?
   else
     curl -fsSL \
       -H "Accept: application/vnd.github+json" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
-      -o "$tgz" "$api" 2>/dev/null
+      -o "$tgz" "$api" 2>"$cerr"
     _fetch_rc=$?
   fi
   if [ "$_fetch_rc" -ne 0 ]; then
-    rm -f "$tgz"
     warn "fetch of ${owner_repo}@${ref} tarball failed (offline, missing/rejected"
     warn "  GitHub token, or bad ref?). Starting WITHOUT playbook rules/skills;"
     warn "  will retry on next start. Fix: ensure the backend injects a github"
     warn "  token to api.github.com and network allows api.github.com + codeload.github.com."
+    [ -s "$cerr" ] && warn "  curl: $(tr '\n' ' ' < "$cerr")"
+    rm -f "$tgz" "$cerr"
     exit 0
   fi
+  rm -f "$cerr"
 
-  # Extract into a fresh dir. The tarball's top-level is a single owner-repo-<sha>
+  # Extract into a FRESH dir. The tarball's top-level is a single owner-repo-<sha>
   # directory; --strip-components=1 drops it so files land directly under $dir.
-  # Distinguish an unwritable target (a mis-provisioned home, e.g. /home/agent not
-  # owned by the agent user) from a corrupt archive — the messages point at very
-  # different fixes.
+  # Remove any partial/stale tree first so a prior aborted run can't leave content
+  # we then extract on top of. Distinguish an unwritable target (a mis-provisioned
+  # home, e.g. /home/agent not owned by the agent user) from a corrupt archive —
+  # the messages point at very different fixes.
+  rm -rf "$dir"
   if ! mkdir -p "$dir" 2>/dev/null; then
     rm -f "$tgz"
     warn "cannot create $dir (is \$HOME writable by this user?). Skipping;"
@@ -140,11 +187,12 @@ if [ ! -f "$agents" ]; then
   exit 0
 fi
 
-# 2) INTEGRITY: verify the extracted AGENTS.md matches the pinned sha256. The ref
-#    is a mutable tag over a possibly MITM-inspected path, so content — not just a
-#    successful download — must be checked. On mismatch, drop the tree and skip
-#    linking rather than trust unexpected content.
-got_sha="$(sha256_of "$agents")"
+# 2) INTEGRITY: verify the CONSUMED content (AGENTS.md + all skill files) matches
+#    the pinned sha256. The ref is a mutable tag over a possibly MITM-inspected
+#    path, so content — not just a successful download — must be checked, and
+#    skills (executable agent instructions) must be covered, not just AGENTS.md.
+#    On mismatch, drop the tree and skip linking rather than trust it.
+got_sha="$(content_digest "$dir")"
 if [ -z "$got_sha" ]; then
   warn "no sha256 tool (sha256sum/shasum) available; cannot verify integrity."
   warn "  Refusing to link unverified playbook content; removing the tree."
@@ -152,7 +200,7 @@ if [ -z "$got_sha" ]; then
   exit 0
 fi
 if [ "$got_sha" != "$agents_sha" ]; then
-  warn "SECURITY: AGENTS.md sha256 is $got_sha, expected $agents_sha."
+  warn "SECURITY: playbook content sha256 is $got_sha, expected $agents_sha."
   warn "  Refusing to link untrusted playbook content; removing the tree."
   warn "  If you intentionally bumped the playbook, update PLAYBOOK_AGENTS_SHA256."
   rm -rf "$dir"
@@ -167,14 +215,30 @@ link_file() {
   ln -sfn "$_s" "$_t" 2>/dev/null || warn "could not link $_t"
 }
 
-# link_skills_into ROOT — symlink each skill subdir under ROOT.
+# link_skills_into ROOT — symlink each skill subdir under ROOT. Only links a
+# skill that is a REAL in-tree directory: skip it if the entry is a symlink, or
+# if its resolved path escapes the verified playbook tree. This prevents a
+# tarball-planted symlink (e.g. skills/evil -> /etc or -> ../../..) from pointing
+# an agent's skills root at attacker-chosen content outside $dir.
 link_skills_into() {
   _root="$1"
   [ -d "$skills" ] || return 0
   mkdir -p "$_root" 2>/dev/null || return 0
   for _sk in "$skills"/*/; do
+    _sk="${_sk%/}"
     [ -d "$_sk" ] || continue
-    ln -sfn "${_sk%/}" "$_root/$(basename "$_sk")" 2>/dev/null \
+    # Reject a symlinked entry outright (the trailing-slash glob would follow it).
+    if [ -L "$_sk" ]; then
+      warn "skipping symlinked skill entry: $_sk"
+      continue
+    fi
+    # Belt-and-suspenders: resolved path must stay under the playbook tree.
+    _real=$(readlink -f "$_sk" 2>/dev/null || printf '%s' "$_sk")
+    case "$_real/" in
+      "$dir"/*) : ;;
+      *) warn "skipping out-of-tree skill entry: $_sk"; continue ;;
+    esac
+    ln -sfn "$_sk" "$_root/$(basename "$_sk")" 2>/dev/null \
       || warn "could not link skill $(basename "$_sk") into $_root"
   done
 }

--- a/integrations/isolation/acq-kits/agentic-coding-playbook/files/home/playbook-clone.sh
+++ b/integrations/isolation/acq-kits/agentic-coding-playbook/files/home/playbook-clone.sh
@@ -81,6 +81,13 @@ if [ ! -e "$dir/AGENTS.md" ]; then
   # (curl -K -) rather than an argv flag, so the token never appears in the
   # process argv (ps) — and so a POSIX sh can't word-split a "Bearer <tok>"
   # value. When no token is present, no auth line is written (public/anon fetch).
+  #
+  # -L follows the api.github.com -> codeload.github.com 302 redirect. curl
+  # re-sends the Authorization header to codeload; on msb (which substitutes the
+  # placeholder ONLY for api.github.com) the literal placeholder reaches codeload
+  # — harmless in practice because the codeload tarball URL is pre-signed and
+  # ignores the header. If GitHub ever required auth at codeload, the msb fetch
+  # would need codeload added to the --secret host list (see quickstart#203).
   if [ -n "$token" ]; then
     printf 'header = "Authorization: Bearer %s"\n' "$token" | \
       curl -fsSL -K - \

--- a/integrations/isolation/acq-kits/agentic-coding-playbook/files/home/playbook-clone.sh
+++ b/integrations/isolation/acq-kits/agentic-coding-playbook/files/home/playbook-clone.sh
@@ -106,10 +106,20 @@ if [ ! -e "$dir/AGENTS.md" ]; then
 
   # Extract into a fresh dir. The tarball's top-level is a single owner-repo-<sha>
   # directory; --strip-components=1 drops it so files land directly under $dir.
-  mkdir -p "$dir"
+  # Distinguish an unwritable target (a mis-provisioned home, e.g. /home/agent not
+  # owned by the agent user) from a corrupt archive — the messages point at very
+  # different fixes.
+  if ! mkdir -p "$dir" 2>/dev/null; then
+    rm -f "$tgz"
+    warn "cannot create $dir (is \$HOME writable by this user?). Skipping;"
+    warn "  will retry on next start. This usually means the sandbox's agent"
+    warn "  home is not owned by the user running this kit."
+    exit 0
+  fi
   if ! tar xzf "$tgz" -C "$dir" --strip-components=1 2>/dev/null; then
     rm -f "$tgz"; rm -rf "$dir"
-    warn "downloaded tarball but extraction failed; skipping. Will retry on next start."
+    warn "downloaded tarball but extraction failed (corrupt archive?); skipping."
+    warn "  Will retry on next start."
     exit 0
   fi
   rm -f "$tgz"

--- a/integrations/isolation/acq-kits/agentic-coding-playbook/files/home/playbook-clone.sh
+++ b/integrations/isolation/acq-kits/agentic-coding-playbook/files/home/playbook-clone.sh
@@ -19,6 +19,21 @@
 
 set -u
 
+# NON-INTERACTIVE: this script runs at sandbox startup with no terminal
+# attached. git MUST NOT prompt — a private clone with no credential would
+# otherwise block on "Username for 'https://github.com':" and hang the whole
+# provision. Force git to fail fast instead of prompting, on every path:
+#   - GIT_TERMINAL_PROMPT=0 disables git's own username/password prompt.
+#   - GIT_ASKPASS / SSH_ASKPASS pointed at a non-interactive false so no helper
+#     can pop a prompt either.
+# When the backend injects a github credential on the wire (sbx proxy / msb
+# header substitution) the clone still succeeds; when it can't, the clone fails
+# fast and the kit degrades gracefully (warns + exit 0) as designed.
+export GIT_TERMINAL_PROMPT=0
+export GIT_ASKPASS=/bin/false
+export SSH_ASKPASS=/bin/false
+: "${GIT_CONFIG_NOSYSTEM:=0}"  # leave system config intact (proxy/CA settings)
+
 ref="${PLAYBOOK_REF:-v0.14.0}"
 sha="${PLAYBOOK_SHA:-cfadbc32b079d85c6328a20d3dadc583faa8aef1}"
 repo="https://github.com/GSA-TTS/agentic-coding-playbook.git"

--- a/integrations/isolation/acq-kits/agentic-coding-playbook/files/home/playbook-clone.sh
+++ b/integrations/isolation/acq-kits/agentic-coding-playbook/files/home/playbook-clone.sh
@@ -1,70 +1,144 @@
 #!/bin/sh
-# playbook-clone.sh — clone the GSA agentic-coding-playbook at a pinned ref and
+# playbook-clone.sh — fetch the GSA agentic-coding-playbook at a pinned ref and
 # link its AGENTS.md + skills into each supported agent's search paths.
 #
 # Extracted (Phase 2) from the former sbx kit's inline startup command into a
-# standalone, testable script per the acq design doc §6. Behavior is unchanged:
-# idempotent (clone-if-missing, no refetch) and NON-FATAL (any failure warns to
-# stderr and exits 0 so the sandbox still starts; it self-heals on a later start
-# once the clone can run).
+# standalone, testable script per the acq design doc §6. It is idempotent
+# (fetch-if-missing, no refetch) and NON-FATAL (any failure warns to stderr and
+# exits 0 so the sandbox still starts; it self-heals on a later start once the
+# fetch can run).
+#
+# WHY A TARBALL, NOT `git clone` (cross-backend parity):
+#   A `git clone` (or `gh repo clone`, which shells out to git) uses git's
+#   smart-HTTP transport to github.com / codeload.github.com. The msb backend's
+#   on-the-wire secret substitution does NOT cover that transport (verified on
+#   msb 0.6.7: git clone of a private repo fails auth / TLS teardown), so a
+#   private clone could not be authenticated there — the origin of quickstart#203.
+#   The GitHub REST API on api.github.com IS substituted correctly (both the sbx
+#   proxy and msb inject the token there). So we fetch the repo TARBALL via the
+#   REST endpoint (api.github.com -> 302 codeload) with a Bearer token. This uses
+#   the one channel both backends authenticate, needs no `.git`, and needs no
+#   `gh` install. When no token is present the fetch simply fails and the kit
+#   degrades gracefully (warns + exit 0).
 #
 # Pins are provided via the environment, with in-script fallback defaults kept
-# in sync with the kit spec's documented pin:
-#   PLAYBOOK_REF — human-legible release tag to clone (default below)
-#   PLAYBOOK_SHA — exact commit the tag must resolve to (integrity pin)
+# in sync with the kit spec's documented pins:
+#   PLAYBOOK_REF          — release tag to fetch (default below)
+#   PLAYBOOK_AGENTS_SHA256 — sha256 of the extracted AGENTS.md (integrity pin)
 #
-# The tag is a MUTABLE ref over a (possibly Zscaler-MITM-inspected) path, so a
-# tag match is not sufficient: after cloning we VERIFY HEAD == PLAYBOOK_SHA and
-# refuse to link on mismatch.
+# INTEGRITY: a GitHub source tarball is NOT byte-stable (server-side
+# recompression), so we cannot pin the archive bytes. Instead we verify the
+# sha256 of the extracted AGENTS.md — stable content the kit actually consumes —
+# and refuse to link on mismatch. Bump PLAYBOOK_REF and PLAYBOOK_AGENTS_SHA256
+# together (see the kit spec for how to regenerate the hash).
 
 set -u
 
 # NON-INTERACTIVE: this script runs at sandbox startup with no terminal
-# attached. git MUST NOT prompt — a private clone with no credential would
-# otherwise block on "Username for 'https://github.com':" and hang the whole
-# provision. Force git to fail fast instead of prompting, on every path:
-#   - GIT_TERMINAL_PROMPT=0 disables git's own username/password prompt.
-#   - GIT_ASKPASS / SSH_ASKPASS pointed at a non-interactive false so no helper
-#     can pop a prompt either.
-# When the backend injects a github credential on the wire (sbx proxy / msb
-# header substitution) the clone still succeeds; when it can't, the clone fails
-# fast and the kit degrades gracefully (warns + exit 0) as designed.
+# attached. Nothing here should ever prompt. curl is non-interactive by default;
+# keep the git guards too (defense-in-depth, in case any git tooling is invoked
+# by a future edit) so a stray git call fails fast instead of hanging provision.
 export GIT_TERMINAL_PROMPT=0
 export GIT_ASKPASS=/bin/false
 export SSH_ASKPASS=/bin/false
-: "${GIT_CONFIG_NOSYSTEM:=0}"  # leave system config intact (proxy/CA settings)
 
 ref="${PLAYBOOK_REF:-v0.14.0}"
-sha="${PLAYBOOK_SHA:-cfadbc32b079d85c6328a20d3dadc583faa8aef1}"
-repo="https://github.com/GSA-TTS/agentic-coding-playbook.git"
+agents_sha="${PLAYBOOK_AGENTS_SHA256:-5b875f032e021e155faa2a7ee133a65f32aff3f2599b3b7b12384f1124417bba}"
+owner_repo="GSA-TTS/agentic-coding-playbook"
+api="https://api.github.com/repos/${owner_repo}/tarball/${ref}"
 dir="$HOME/.agentic-coding-playbook"
 
 warn() { echo "agentic-coding-playbook: $*" >&2; }
 
-# 1) Clone once (clone-if-missing). Shallow-clone the pinned tag, then VERIFY the
-#    checked-out commit equals PLAYBOOK_SHA. On SHA mismatch we drop the clone and
-#    skip linking rather than trust unexpected content. No refetch on later starts.
-if [ ! -e "$dir/.git" ]; then
-  if ! git clone --quiet --depth 1 --branch "$ref" "$repo" "$dir" 2>/dev/null; then
-    warn "clone of $repo@$ref failed (offline, missing GitHub token, or bad ref?);"
+# The backend injects the github token into this env var (msb --secret
+# GITHUB_TOKEN@api.github.com; the sbx proxy for the built-in github service).
+# Accept either GITHUB_TOKEN or GH_TOKEN. Empty is allowed — the fetch will fail
+# and the kit degrades gracefully.
+token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+
+# sha256 helper: prefer sha256sum, fall back to shasum -a 256. Echoes the hex
+# digest of the file named in $1, or nothing if no tool is available.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" 2>/dev/null | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" 2>/dev/null | cut -d' ' -f1
+  fi
+}
+
+# 1) Fetch once (fetch-if-missing). Download the pinned-ref tarball via the REST
+#    API and extract it. No refetch on later starts (the dir persists).
+if [ ! -e "$dir/AGENTS.md" ]; then
+  if ! command -v curl >/dev/null 2>&1; then
+    warn "curl not found in base image; cannot fetch the playbook."
     warn "  starting WITHOUT playbook rules/skills. Will retry on next start."
-    warn "  Fix: ensure the backend has a github credential and network allows github.com."
     exit 0
   fi
-  got="$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo unknown)"
-  if [ "$got" != "$sha" ]; then
-    warn "SECURITY: cloned $ref resolved to $got, expected $sha."
-    warn "  Refusing to link untrusted playbook content; removing the clone."
-    warn "  If you intentionally bumped the playbook, update PLAYBOOK_SHA."
-    rm -rf "$dir"
+
+  tgz="$(mktemp "${TMPDIR:-/tmp}/acp-playbook.XXXXXX.tgz" 2>/dev/null)" || tgz="/tmp/acp-playbook.$$.tgz"
+  # -f: fail on HTTP error; -sSL: quiet but show errors, follow redirects.
+  # The Authorization header is passed via a config file read from stdin
+  # (curl -K -) rather than an argv flag, so the token never appears in the
+  # process argv (ps) — and so a POSIX sh can't word-split a "Bearer <tok>"
+  # value. When no token is present, no auth line is written (public/anon fetch).
+  if [ -n "$token" ]; then
+    printf 'header = "Authorization: Bearer %s"\n' "$token" | \
+      curl -fsSL -K - \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -o "$tgz" "$api" 2>/dev/null
+    _fetch_rc=$?
+  else
+    curl -fsSL \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      -o "$tgz" "$api" 2>/dev/null
+    _fetch_rc=$?
+  fi
+  if [ "$_fetch_rc" -ne 0 ]; then
+    rm -f "$tgz"
+    warn "fetch of ${owner_repo}@${ref} tarball failed (offline, missing/rejected"
+    warn "  GitHub token, or bad ref?). Starting WITHOUT playbook rules/skills;"
+    warn "  will retry on next start. Fix: ensure the backend injects a github"
+    warn "  token to api.github.com and network allows api.github.com + codeload.github.com."
     exit 0
   fi
+
+  # Extract into a fresh dir. The tarball's top-level is a single owner-repo-<sha>
+  # directory; --strip-components=1 drops it so files land directly under $dir.
+  mkdir -p "$dir"
+  if ! tar xzf "$tgz" -C "$dir" --strip-components=1 2>/dev/null; then
+    rm -f "$tgz"; rm -rf "$dir"
+    warn "downloaded tarball but extraction failed; skipping. Will retry on next start."
+    exit 0
+  fi
+  rm -f "$tgz"
 fi
 
 agents="$dir/AGENTS.md"
 skills="$dir/.agents/skills"
 if [ ! -f "$agents" ]; then
-  warn "cloned, but AGENTS.md not found at $agents; skipping linking."
+  warn "fetched, but AGENTS.md not found at $agents; removing and skipping linking."
+  rm -rf "$dir"
+  exit 0
+fi
+
+# 2) INTEGRITY: verify the extracted AGENTS.md matches the pinned sha256. The ref
+#    is a mutable tag over a possibly MITM-inspected path, so content — not just a
+#    successful download — must be checked. On mismatch, drop the tree and skip
+#    linking rather than trust unexpected content.
+got_sha="$(sha256_of "$agents")"
+if [ -z "$got_sha" ]; then
+  warn "no sha256 tool (sha256sum/shasum) available; cannot verify integrity."
+  warn "  Refusing to link unverified playbook content; removing the tree."
+  rm -rf "$dir"
+  exit 0
+fi
+if [ "$got_sha" != "$agents_sha" ]; then
+  warn "SECURITY: AGENTS.md sha256 is $got_sha, expected $agents_sha."
+  warn "  Refusing to link untrusted playbook content; removing the tree."
+  warn "  If you intentionally bumped the playbook, update PLAYBOOK_AGENTS_SHA256."
+  rm -rf "$dir"
   exit 0
 fi
 
@@ -88,7 +162,7 @@ link_skills_into() {
   done
 }
 
-# 2) AGENTS.md per agent. Agents with a known user-level rules path:
+# 3) AGENTS.md per agent. Agents with a known user-level rules path:
 #    OpenCode + Codex + Droid read a literal AGENTS.md; Claude expects CLAUDE.md;
 #    Copilot expects copilot-instructions.md. Cursor, Kiro, and Docker Agent have
 #    no user-level rules FILE convention (rules live in app settings / agent
@@ -99,7 +173,7 @@ link_file "$HOME/.factory/AGENTS.md"                  "$agents"  # Droid (Factor
 link_file "$HOME/.claude/CLAUDE.md"                   "$agents"  # Claude Code
 link_file "$HOME/.copilot/copilot-instructions.md"    "$agents"  # GitHub Copilot CLI
 
-# 3) Skills. ~/.agents/skills is the cross-agent standard root (Codex, OpenCode,
+# 4) Skills. ~/.agents/skills is the cross-agent standard root (Codex, OpenCode,
 #    Docker Agent, Copilot). Per-agent roots follow for agents that only scan
 #    their own dir.
 link_skills_into "$HOME/.agents/skills"      # standard (multi-agent)

--- a/integrations/isolation/acq-kits/agentic-coding-playbook/files/home/playbook-clone.sh
+++ b/integrations/isolation/acq-kits/agentic-coding-playbook/files/home/playbook-clone.sh
@@ -88,11 +88,14 @@ sha256_hex() {
 
 # content_digest DIR — a single sha256 over the CONSUMED content surface of the
 # playbook tree: AGENTS.md plus every regular file under .agents/skills. Built by
-# hashing each file, sorting the "<hash>  <relpath>" lines (stable ordering), and
-# hashing that manifest. REGULAR FILES ONLY (`find -type f` does not follow
-# symlinks for the listing, and we hash file contents), so a symlink planted in
-# the tarball cannot smuggle out-of-tree content into the digest. Echoes the hex
-# digest, or nothing if no sha tool is available.
+# hashing each file, sorting the digest lines (stable ordering via LC_ALL=C), and
+# hashing that manifest. The integrity guarantee comes from THIS digest: any
+# tamper (including a planted symlink, whose target content differs or whose
+# presence perturbs the file set) changes the manifest and fails the pin match,
+# so the tree is rejected before anything is linked. (`find -type f` follows
+# symlinks when classifying, so it is NOT itself the guard — the digest is; and
+# link_skills_into independently refuses symlink/out-of-tree skill entries.)
+# Echoes the hex digest, or nothing if no sha tool is available.
 content_digest() {
   _cd_dir="$1"
   { sha256_of "$_cd_dir/AGENTS.md"
@@ -125,6 +128,10 @@ if [ ! -e "$dir/AGENTS.md" ]; then
   # TLS) is surfaced on failure. This is safe: the token lives in the -K config,
   # never on the URL/argv, so curl's error text cannot contain it.
   #
+  # --connect-timeout / --max-time bound the fetch: curl has NO default overall
+  # timeout, so a black-holing network or MITM could hang startup indefinitely,
+  # violating this script's never-hang / always-exit-0 contract. Bound both.
+  #
   # -L follows the api.github.com -> codeload.github.com 302 redirect. curl
   # re-sends the Authorization header to codeload; on msb (which substitutes the
   # placeholder ONLY for api.github.com) the literal placeholder reaches codeload
@@ -134,12 +141,14 @@ if [ ! -e "$dir/AGENTS.md" ]; then
   if [ -n "$token" ]; then
     printf 'header = "Authorization: Bearer %s"\n' "$token" | \
       curl -fsSL -K - \
+        --connect-timeout 15 --max-time 120 \
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
         -o "$tgz" "$api" 2>"$cerr"
     _fetch_rc=$?
   else
     curl -fsSL \
+      --connect-timeout 15 --max-time 120 \
       -H "Accept: application/vnd.github+json" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
       -o "$tgz" "$api" 2>"$cerr"
@@ -156,42 +165,81 @@ if [ ! -e "$dir/AGENTS.md" ]; then
   fi
   rm -f "$cerr"
 
-  # Extract into a FRESH dir. The tarball's top-level is a single owner-repo-<sha>
-  # directory; --strip-components=1 drops it so files land directly under $dir.
-  # Remove any partial/stale tree first so a prior aborted run can't leave content
-  # we then extract on top of. Distinguish an unwritable target (a mis-provisioned
-  # home, e.g. /home/agent not owned by the agent user) from a corrupt archive —
-  # the messages point at very different fixes.
-  rm -rf "$dir"
-  if ! mkdir -p "$dir" 2>/dev/null; then
-    rm -f "$tgz"
-    warn "cannot create $dir (is \$HOME writable by this user?). Skipping;"
-    warn "  will retry on next start. This usually means the sandbox's agent"
-    warn "  home is not owned by the user running this kit."
-    exit 0
-  fi
-  if ! tar xzf "$tgz" -C "$dir" --strip-components=1 2>/dev/null; then
-    rm -f "$tgz"; rm -rf "$dir"
+  # Extract into a STAGING dir first, verify the content digest there, and only
+  # then move it into place. The tarball's top-level is a single owner-repo-<sha>
+  # directory; --strip-components=1 drops it. Staging (not extracting straight to
+  # $dir) means unverified content never occupies the final path, and if a
+  # traversal-crafted tarball wrote outside the staging dir despite tar's own
+  # `../` rejection, the later reject/rm affects staging only. --no-same-owner /
+  # --no-same-permissions avoid honoring owner/mode bits from the archive.
+  stage="$(mktemp -d "${TMPDIR:-/tmp}/acp-playbook-stage.XXXXXX" 2>/dev/null)" || stage="/tmp/acp-playbook-stage.$$"
+  if ! tar xzf "$tgz" -C "$stage" --strip-components=1 --no-same-owner --no-same-permissions 2>/dev/null; then
+    rm -f "$tgz"; rm -rf "$stage"
     warn "downloaded tarball but extraction failed (corrupt archive?); skipping."
     warn "  Will retry on next start."
     exit 0
   fi
   rm -f "$tgz"
+
+  # AGENTS.md must exist in the staged tree before we bother verifying/moving.
+  if [ ! -f "$stage/AGENTS.md" ]; then
+    rm -rf "$stage"
+    warn "fetched, but AGENTS.md not found in the archive; skipping linking."
+    warn "  Will retry on next start."
+    exit 0
+  fi
+
+  # INTEGRITY (pre-move): verify the CONSUMED content (AGENTS.md + all skill
+  # files) against the pinned sha256 while still in staging. The ref is a mutable
+  # tag over a possibly MITM-inspected path, so content — not just a successful
+  # download — must be checked, and skills (executable agent instructions) must
+  # be covered, not just AGENTS.md. On mismatch, drop staging and never touch the
+  # live path.
+  staged_sha="$(content_digest "$stage")"
+  if [ -z "$staged_sha" ]; then
+    rm -rf "$stage"
+    warn "no sha256 tool (sha256sum/shasum) available; cannot verify integrity."
+    warn "  Refusing to install unverified playbook content."
+    exit 0
+  fi
+  if [ "$staged_sha" != "$agents_sha" ]; then
+    rm -rf "$stage"
+    warn "SECURITY: playbook content sha256 is $staged_sha, expected $agents_sha."
+    warn "  Refusing to install untrusted playbook content."
+    warn "  If you intentionally bumped the playbook, update PLAYBOOK_AGENTS_SHA256."
+    exit 0
+  fi
+
+  # Verified. Atomically-ish replace the live dir with the staged tree. Remove any
+  # partial/stale tree first, then move staging into place. mkdir the parent so a
+  # missing/unwritable home surfaces clearly.
+  if ! mkdir -p "$(dirname "$dir")" 2>/dev/null; then
+    rm -rf "$stage"
+    warn "cannot create $(dirname "$dir") (is \$HOME writable by this user?)."
+    warn "  Skipping; will retry on next start. The sandbox's agent home may not"
+    warn "  be owned by the user running this kit."
+    exit 0
+  fi
+  rm -rf "$dir"
+  if ! mv "$stage" "$dir" 2>/dev/null; then
+    rm -rf "$stage" "$dir"
+    warn "could not install the verified playbook into $dir; skipping."
+    warn "  Will retry on next start."
+    exit 0
+  fi
 fi
 
 agents="$dir/AGENTS.md"
 skills="$dir/.agents/skills"
+
+# Re-verify integrity on EVERY start (not just the fetch-if-missing path): an
+# existing tree could have been tampered with between starts, and this is cheap.
+# On mismatch, drop the tree and skip linking rather than trust it.
 if [ ! -f "$agents" ]; then
-  warn "fetched, but AGENTS.md not found at $agents; removing and skipping linking."
+  warn "playbook present but AGENTS.md missing at $agents; removing and skipping."
   rm -rf "$dir"
   exit 0
 fi
-
-# 2) INTEGRITY: verify the CONSUMED content (AGENTS.md + all skill files) matches
-#    the pinned sha256. The ref is a mutable tag over a possibly MITM-inspected
-#    path, so content — not just a successful download — must be checked, and
-#    skills (executable agent instructions) must be covered, not just AGENTS.md.
-#    On mismatch, drop the tree and skip linking rather than trust it.
 got_sha="$(content_digest "$dir")"
 if [ -z "$got_sha" ]; then
   warn "no sha256 tool (sha256sum/shasum) available; cannot verify integrity."

--- a/integrations/isolation/acq-kits/agentic-coding-playbook/scripts/verify
+++ b/integrations/isolation/acq-kits/agentic-coding-playbook/scripts/verify
@@ -80,27 +80,37 @@ else
 fi
 sleep 2
 
-info "3. Playbook cloned and pinned to PLAYBOOK_SHA?"
+info "3. Playbook fetched and pinned to PLAYBOOK_AGENTS_SHA256?"
 # Neutral hybrid/v1 spec: the pins live in the startup command as
-# PLAYBOOK_REF="..." / PLAYBOOK_SHA="..." (and as fallback defaults in
-# files/home/playbook-clone.sh). Extract from either the spec or the script.
+# PLAYBOOK_REF="..." / PLAYBOOK_AGENTS_SHA256="..." (and as fallback defaults in
+# files/home/playbook-clone.sh). The kit fetches a REST source TARBALL (no .git)
+# and verifies a sha256 over the consumed content (AGENTS.md + all skill files).
 ref_expected="$(grep -Eho 'PLAYBOOK_REF[:=][[:space:]]*"?[^"]+' "$KIT_DIR/spec.yaml" "$KIT_DIR/files/home/playbook-clone.sh" 2>/dev/null | head -n1 | sed -E 's/.*[:=][[:space:]]*"?([^"[:space:]]+).*/\1/')"
-sha_expected="$(grep -Eho 'PLAYBOOK_SHA[:=][[:space:]]*"?[0-9a-f]+' "$KIT_DIR/spec.yaml" "$KIT_DIR/files/home/playbook-clone.sh" 2>/dev/null | head -n1 | sed -E 's/.*[:=][[:space:]]*"?([0-9a-f]+).*/\1/')"
+sha_expected="$(grep -Eho 'PLAYBOOK_AGENTS_SHA256[:=][[:space:]]*"?[0-9a-f]+' "$KIT_DIR/spec.yaml" "$KIT_DIR/files/home/playbook-clone.sh" 2>/dev/null | head -n1 | sed -E 's/.*[:=][[:space:]]*"?([0-9a-f]+).*/\1/')"
 echo "  expected PLAYBOOK_REF: ${ref_expected:-<unknown>}"
-echo "  expected PLAYBOOK_SHA: ${sha_expected:-<unknown>}"
-if [ "$(in_sbx 'test -e "$HOME/.agentic-coding-playbook/.git" && echo yes')" = "yes" ]; then
-  ok "playbook cloned to \$HOME/.agentic-coding-playbook"
-  sha_actual="$(in_sbx 'cd "$HOME/.agentic-coding-playbook" && git rev-parse HEAD 2>/dev/null')"
-  echo "  checked-out SHA: ${sha_actual:-<unknown>}"
+echo "  expected PLAYBOOK_AGENTS_SHA256: ${sha_expected:-<unknown>}"
+if [ "$(in_sbx 'test -f "$HOME/.agentic-coding-playbook/AGENTS.md" && echo yes')" = "yes" ]; then
+  ok "playbook fetched to \$HOME/.agentic-coding-playbook (AGENTS.md present)"
+  # Recompute the content digest in-guest exactly as the kit does, and confirm it
+  # matches the pin (the kit already refuses to link on mismatch, so a linked
+  # tree implies a match — but assert it explicitly here for the integrity gate).
+  sha_actual="$(in_sbx '
+    d="$HOME/.agentic-coding-playbook"
+    { sha256sum "$d/AGENTS.md" | cut -d" " -f1
+      if [ -d "$d/.agents/skills" ]; then
+        find "$d/.agents/skills" -type f | LC_ALL=C sort | while IFS= read -r f; do sha256sum "$f" | cut -d" " -f1; done
+      fi
+    } | sha256sum | cut -d" " -f1')"
+  echo "  content digest: ${sha_actual:-<unknown>}"
   if [ -n "$sha_expected" ] && [ "$sha_actual" = "$sha_expected" ]; then
-    ok "checked-out commit matches PLAYBOOK_SHA (integrity pin verified)"
+    ok "content digest matches PLAYBOOK_AGENTS_SHA256 (integrity pin verified)"
   else
-    bad "checked-out commit does not match PLAYBOOK_SHA"
+    bad "content digest does not match PLAYBOOK_AGENTS_SHA256"
   fi
 else
-  bad "playbook NOT cloned — offline, missing github secret, or SHA-mismatch rejection"
+  bad "playbook NOT fetched — offline, missing github secret, or sha-mismatch rejection"
   echo "  Inspect: sbx exec $SBX_NAME -- sh -c 'ls -la ~/.agentic-coding-playbook'" >&2
-  echo "  And:     sbx policy log $SBX_NAME   (look for blocked github.com)" >&2
+  echo "  And:     sbx policy log $SBX_NAME   (look for blocked api.github.com)" >&2
 fi
 
 info "4. AGENTS.md linked into agent rules paths?"

--- a/integrations/isolation/acq-kits/agentic-coding-playbook/spec.yaml
+++ b/integrations/isolation/acq-kits/agentic-coding-playbook/spec.yaml
@@ -1,7 +1,7 @@
 # spec.yaml — agentic-coding-playbook (a neutral acq mixin kit, hybrid/v1)
 #
 # Delivers the GSA agentic-coding-playbook (federal AGENTS.md rules + Agent
-# Skills) into a sandbox. At startup it clones the playbook at a pinned ref and
+# Skills) into a sandbox. At startup it fetches the playbook at a pinned ref and
 # symlinks its AGENTS.md and skills into every supported agent's search paths.
 #
 # NEUTRAL (backend-agnostic) form. Converted from the former sbx kit in Phase 2;
@@ -9,75 +9,95 @@
 # The inline startup shell of the old sbx kit was extracted into a tested,
 # standalone script (files/home/playbook-clone.sh) per the acq design doc §6.
 #
-# Behavior (unchanged):
-#   - caps.network: allow egress to GitHub so the clone can run.
-#   - files: drop the clone/link script into the agent home.
+# Behavior:
+#   - caps.network: allow egress to the GitHub REST API + archive CDN.
+#   - files: drop the fetch/link script into the agent home.
 #   - commands (phase startup, agent uid): run the script. It is idempotent
-#     (clone-if-missing) and NON-FATAL (warns + exits 0 on any failure, so the
+#     (fetch-if-missing) and NON-FATAL (warns + exits 0 on any failure, so the
 #     sandbox still starts and self-heals on a later start).
 #
-# Pinning: the playbook ref + integrity SHA are passed to the script via the
-# startup command's own environment (the neutral spec has no environment block;
-# the pins live in the command and as fallback defaults inside the script — keep
-# the two in sync). The tag is a MUTABLE ref over a possibly MITM-inspected path,
-# so the script verifies HEAD == PLAYBOOK_SHA and refuses to link on mismatch.
+# FETCH MECHANISM (cross-backend parity, fixes quickstart#203): the script does
+# NOT `git clone`. It fetches the repo SOURCE TARBALL from the REST API
+# (api.github.com/repos/<repo>/tarball/<ref>, 302 -> codeload.github.com) with a
+# Bearer token. git's smart-HTTP transport is NOT credential-substituted on the
+# msb backend (verified msb 0.6.7), but the api.github.com path IS — on both sbx
+# and msb. So one tarball codepath authenticates on both backends, needs no .git,
+# and needs no `gh` install.
+#
+# Pinning: the ref + integrity hash are passed via the startup command env (the
+# neutral spec has no environment block; the pins also live as fallback defaults
+# inside the script — keep the two in sync). A GitHub source tarball is NOT
+# byte-stable (server recompression), so integrity is verified on the extracted
+# AGENTS.md content hash, not the archive bytes. To bump the playbook: change
+# PLAYBOOK_REF, then regenerate PLAYBOOK_AGENTS_SHA256 with:
+#   curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" \
+#     https://api.github.com/repos/GSA-TTS/agentic-coding-playbook/tarball/<REF> \
+#     | tar xz -O --wildcards '*/AGENTS.md' | sha256sum
+# (update BOTH this command's env and the script's fallback default).
 #
 # GitHub auth (while the playbook repo is PRIVATE): this kit does NOT declare a
 # github credential. The base agent sandbox already provides one; acq's backend
-# injects it on the outbound clone. This kit only allow-lists the egress.
+# injects it to api.github.com (sbx proxy / msb --secret GITHUB_TOKEN@api.github.com).
+# This kit only allow-lists the egress and reads GITHUB_TOKEN/GH_TOKEN.
 schemaVersion: "hybrid/v1"
 kind: mixin
 name: agentic-coding-playbook
 displayName: Agentic Coding Playbook (federal rules + skills)
 description: >
-  Clones the GSA agentic-coding-playbook at a pinned ref at container startup and
-  links its AGENTS.md and Agent Skills into each supported agent's search paths
-  (OpenCode, Claude Code, Codex, Copilot, Cursor, Droid, Kiro, Docker Agent).
-  Degrades gracefully (warns and continues) when the clone is unavailable;
-  self-heals on a later start. Relies on the base sandbox's github credential for
-  cloning while the playbook repo is private.
+  Fetches the GSA agentic-coding-playbook at a pinned ref at container startup
+  (via the GitHub REST source tarball) and links its AGENTS.md and Agent Skills
+  into each supported agent's search paths (OpenCode, Claude Code, Codex, Copilot,
+  Cursor, Droid, Kiro, Docker Agent). Degrades gracefully (warns and continues)
+  when the fetch is unavailable; self-heals on a later start. Relies on the base
+  sandbox's github credential (injected to api.github.com) while the repo is private.
 
 caps:
   network:
     allow:
-      # git clone over HTTPS hits github.com; the smart-HTTP pack fetch for a
-      # shallow clone is served from codeload.github.com. Pinned to the minimal
-      # set. Network allow lists union across kits.
-      - github.com:443
+      # The playbook is fetched as a REST-API source tarball, NOT a git clone:
+      #   GET https://api.github.com/repos/<owner>/<repo>/tarball/<ref>
+      # which 302-redirects to codeload.github.com for the archive bytes. This
+      # rides the api.github.com credential path both backends substitute (the
+      # git smart-HTTP transport is NOT substituted on msb — the origin of
+      # quickstart#203). github.com is retained for the redirect hop. Pinned to
+      # the minimal set. Network allow lists union across kits.
+      - api.github.com:443
       - codeload.github.com:443
+      - github.com:443
 
 files:
   - path: /home/agent/playbook-clone.sh
     mode: "0755"
     source: files/home/playbook-clone.sh
-    description: Clone the playbook at the pinned ref and link rules + skills
+    description: Fetch the playbook at the pinned ref and link rules + skills
 
 commands:
-  # Run the extracted clone/link script as the agent user at every start. The
+  # Run the extracted fetch/link script as the agent user at every start. The
   # pins are exported here (the script also carries matching fallback defaults);
   # bump BOTH together with the script's defaults to adopt a newer playbook.
   - phase: startup
     user: "1000"
-    description: Clone the playbook at the pinned ref and link rules + skills
+    description: Fetch the playbook at the pinned ref and link rules + skills
     command:
       - sh
       - -c
       - |
         PLAYBOOK_REF="v0.14.0" \
-        PLAYBOOK_SHA="cfadbc32b079d85c6328a20d3dadc583faa8aef1" \
+        PLAYBOOK_AGENTS_SHA256="5b875f032e021e155faa2a7ee133a65f32aff3f2599b3b7b12384f1124417bba" \
           sh /home/agent/playbook-clone.sh
 
 agentContext: |
   ## Agentic Coding Playbook
 
-  The GSA agentic-coding-playbook is cloned into `~/.agentic-coding-playbook` and
+  The GSA agentic-coding-playbook is fetched into `~/.agentic-coding-playbook` and
   its `AGENTS.md` (federal behavioral rules) plus its Agent Skills are linked into
   your search paths. Follow the playbook's rules; use its skills when a task
-  matches one. If the clone was unavailable at start, the playbook may be absent —
+  matches one. If the fetch was unavailable at start, the playbook may be absent —
   it self-heals on a later start.
 
-# No backend shortcuts: every backend allow-lists github.com and runs the same
-# clone+link script at startup. GitHub token handled by the backend, not the kit.
+# No backend shortcuts: every backend allow-lists the GitHub REST/archive hosts
+# and runs the same fetch+link script at startup. The github token is injected by
+# the backend (to api.github.com), not declared by the kit.
 backend_shortcuts:
   sbx: {}
   msb: {}

--- a/integrations/isolation/acq-kits/agentic-coding-playbook/spec.yaml
+++ b/integrations/isolation/acq-kits/agentic-coding-playbook/spec.yaml
@@ -28,12 +28,20 @@
 # neutral spec has no environment block; the pins also live as fallback defaults
 # inside the script — keep the two in sync). A GitHub source tarball is NOT
 # byte-stable (server recompression), so integrity is verified on the extracted
-# AGENTS.md content hash, not the archive bytes. To bump the playbook: change
-# PLAYBOOK_REF, then regenerate PLAYBOOK_AGENTS_SHA256 with:
+# CONTENT — a sha256 over AGENTS.md plus every file under .agents/skills (a
+# sorted per-file digest manifest) — not the archive bytes. This covers skills
+# (executable agent instructions), not just AGENTS.md. To bump the playbook:
+# change PLAYBOOK_REF, then regenerate PLAYBOOK_AGENTS_SHA256 by extracting the
+# tarball and running the SAME manifest hash the script uses, e.g.:
+#   d=$(mktemp -d)
 #   curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" \
 #     https://api.github.com/repos/GSA-TTS/agentic-coding-playbook/tarball/<REF> \
-#     | tar xz -O --wildcards '*/AGENTS.md' | sha256sum
-# (update BOTH this command's env and the script's fallback default).
+#     | tar xz -C "$d" --strip-components=1
+#   { sha256sum "$d/AGENTS.md" | cut -d' ' -f1
+#     find "$d/.agents/skills" -type f | LC_ALL=C sort \
+#       | while read -r f; do sha256sum "$f" | cut -d' ' -f1; done
+#   } | sha256sum | cut -d' ' -f1
+# (update BOTH this command's env and the script's fallback default.)
 #
 # GitHub auth (while the playbook repo is PRIVATE): this kit does NOT declare a
 # github credential. The base agent sandbox already provides one; acq's backend
@@ -59,8 +67,10 @@ caps:
       # which 302-redirects to codeload.github.com for the archive bytes. This
       # rides the api.github.com credential path both backends substitute (the
       # git smart-HTTP transport is NOT substituted on msb — the origin of
-      # quickstart#203). github.com is retained for the redirect hop. Pinned to
-      # the minimal set. Network allow lists union across kits.
+      # quickstart#203). codeload.github.com serves the redirected archive bytes.
+      # github.com is retained as defense-in-depth (some GitHub archive redirects
+      # have historically traversed it). Pinned to the minimal set. Network allow
+      # lists union across kits.
       - api.github.com:443
       - codeload.github.com:443
       - github.com:443
@@ -83,7 +93,7 @@ commands:
       - -c
       - |
         PLAYBOOK_REF="v0.14.0" \
-        PLAYBOOK_AGENTS_SHA256="5b875f032e021e155faa2a7ee133a65f32aff3f2599b3b7b12384f1124417bba" \
+        PLAYBOOK_AGENTS_SHA256="a9c438acfe8082ba959fd248be9b667f26f17c10c1c763ca57fdcb2396e43759" \
           sh /home/agent/playbook-clone.sh
 
 agentContext: |


### PR DESCRIPTION
## Context

The `agentic-coding-playbook` kit cloned a **private** GitHub repo with `git clone` over HTTPS. On the **msb** backend, injected credentials are substituted on the wire only for the REST API host (`api.github.com`) — **not** for git's smart-HTTP transport (`github.com`/`codeload.github.com`), verified on msb 0.6.7. So a private clone could not authenticate there, and on a credential-less path `git` would even drop to an interactive `Username for 'https://github.com':` prompt and **hang provisioning**. This is the origin of [quickstart#203](https://github.com/GSA-TTS/agentic-coding-quickstart/issues/203).

## What changed

The kit now fetches the repo **source tarball from the GitHub REST API** instead of cloning:

`GET https://api.github.com/repos/GSA-TTS/agentic-coding-playbook/tarball/<ref>` (302 → `codeload.github.com`), with an `Authorization: Bearer` token. This rides the one channel **both** backends authenticate (the sbx proxy and msb both substitute the token for `api.github.com`), needs no `.git`, and needs no `gh` install. Result: the playbook now works on **both** sbx and msb.

Commits:
1. **Non-interactive git guards** (`GIT_TERMINAL_PROMPT=0`, `GIT_ASKPASS`/`SSH_ASKPASS=/bin/false`) so nothing can hang provisioning on a prompt.
2. **REST tarball fetch** — token read from `GITHUB_TOKEN`/`GH_TOKEN`, passed via `curl -K -` (never argv). A GitHub source tarball is not byte-stable (server recompression), so integrity is verified against the extracted `AGENTS.md` **sha256** (`PLAYBOOK_AGENTS_SHA256`) rather than the archive bytes; refuse to link on mismatch. `spec.yaml` network allow updated to `api.github.com` + `codeload.github.com` (+ `github.com` for the redirect hop). Pins are now `PLAYBOOK_REF` + `PLAYBOOK_AGENTS_SHA256` with a documented regeneration command.
3. **Clearer failure messages** — distinguish an unwritable agent home from a corrupt archive.

Degrades gracefully (warns + `exit 0`) when no token is present or offline.

## Verification

Validated live end-to-end with the quickstart `acq` wrapper (`scripts/verify-backends`) against **both** backends on msb 0.6.7 / sbx: playbook `AGENTS.md` fetched + linked, `/home/agent` agent-owned, no hangs. Kit validator (`validate-kits.py`) passes.

## Consumer

Quickstart bumps `PATTERNS_KIT_REF` to this branch's merge commit once landed.

Co-authored-by: OpenCode Agent <bret.mogilefsky@gsa.gov>
