### PR TITLE
feat(communications): design-artifact pack + workflow + multi-artifact output (#241)

### DIFF
--- a/.agents/skills/communications/artifact-brief/SKILL.md
+++ b/.agents/skills/communications/artifact-brief/SKILL.md
@@ -1,0 +1,145 @@
+---
+id: artifact-brief
+version: "1.0.0"
+title: "Artifact Brief"
+description: "Capture the audience, action, core message, evidence, and constraints for a communication artifact before any design or drafting begins, producing a small structured brief the rest of the design-artifact pipeline consumes."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Brief"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "artifact brief"
+  - "who is the audience"
+  - "what is the core message"
+tags:
+  - "communications"
+  - "planning"
+  - "briefing"
+routing:
+  task_types:
+    - plan
+  input_artifacts:
+    - documentation
+  output_artifacts:
+    - artifact-brief
+  aliases:
+    - "comms brief"
+    - "message brief"
+  prefer_when:
+    - "starting any executive/marketing/explainer artifact and the audience, action, or core message is not yet pinned down"
+  priority: 60
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Skill: Artifact Brief
+
+## Summary
+
+Before designing or drafting any communication artifact (one-pager, slide deck,
+explainer), capture the decisions that everything downstream depends on:
+**who** it's for, **what** you want them to do, the **one core message**, the
+**evidence** that supports it, and the **constraints** (length, format, brand,
+deadline). This produces a small structured brief the rest of the
+`design-artifact` pipeline reads — so narrative, visuals, and QA all serve the
+same goal instead of guessing.
+
+## When to Use
+
+- Kicking off an executive one-pager, slide deck, or explainer.
+- The audience, desired action, or core message is fuzzy or unstated.
+- Multiple people will contribute and need a shared source of truth.
+
+## When NOT to Use
+
+- The brief already exists (feed it straight to `narrative-architect`).
+- You are only reviewing an existing artifact (use `artifact-qa`).
+
+## Prerequisites
+
+- The raw material: what happened, the ask, and any supporting numbers.
+
+## Procedure
+
+1. **Audience.** Name the specific reader and their context (e.g. "an agency
+   CIO deciding whether to fund a pilot"), their prior knowledge, and what they
+   care about. One primary audience — not "everyone."
+2. **Action.** State the single decision or action you want them to take after
+   reading. If there are two, split into two artifacts.
+3. **Core message.** One sentence they should remember. Everything else supports
+   it or is cut.
+4. **Evidence.** The 3–5 strongest facts/numbers/quotes that make the core
+   message credible. Note the source of each (no fabricated figures).
+5. **Constraints.** Output profile (one-pager / slide-deck / explainer), length,
+   brand/USWDS requirements, accessibility level, deadline, and any prohibited
+   content.
+6. **Emit the brief** in the structured shape below.
+
+## Brief shape
+
+```yaml
+audience: "..."
+action: "..."
+core_message: "..."
+evidence:
+  - claim: "..."
+    source: "..."
+constraints:
+  profile: one-pager | slide-deck | technical-explainer | marketing-kit
+  length: "..."
+  accessibility: "508 / WCAG AA"
+  deadline: "..."
+```
+
+## Verification
+
+- Exactly one audience and one action.
+- Core message fits in one sentence.
+- Every evidence item names a real source (none invented).
+- Constraints name a concrete output profile.
+
+## Examples
+
+| Raw ask | Audience | Action | Core message |
+|---------|----------|--------|--------------|
+| "Tell leadership the pilot worked" | Agency CIO | Fund phase 2 | "The pilot cut review time 40% with no security regressions." |
+
+## Human Review Checklist
+
+- [ ] Audience is one specific reader, not "everyone."
+- [ ] The action is a single concrete decision.
+- [ ] Every number/quote traces to a real source.
+- [ ] No secrets, PII, CUI, or internal URLs.
+
+## Notes
+
+Feeds `narrative-architect` (structure) → `visual-direction` (look) →
+`one-pager`/`slide-deck` (render) → `artifact-qa` (validate). The
+`design-artifact` workflow orchestrates the whole chain.

--- a/.agents/skills/communications/artifact-qa/SKILL.md
+++ b/.agents/skills/communications/artifact-qa/SKILL.md
@@ -1,0 +1,134 @@
+---
+id: artifact-qa
+version: "1.0.0"
+title: "Artifact QA"
+description: "Render, inspect, and validate a produced communication artifact against its brief and visual contract — checking the actual output files (HTML/PDF/PNG), accessibility, offline-safety, and prohibited content — then report pass/fail with concrete fixes."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Findings"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "External CDN Links"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "artifact qa"
+  - "check this deck"
+  - "validate this one-pager"
+tags:
+  - "communications"
+  - "qa"
+  - "review"
+routing:
+  task_types:
+    - review
+    - test
+  input_artifacts:
+    - one-pager
+    - slide-deck
+  output_artifacts:
+    - qa-report
+  aliases:
+    - "design qa"
+    - "artifact review"
+  prefer_when:
+    - "a communication artifact (one-pager, deck, explainer) has been produced and needs validation of the actual files"
+  delegates:
+    - pattern: accessibility-review
+      when: "the artifact is a web page/prototype needing a full 508/WCAG audit"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Skill: Artifact QA
+
+## Summary
+
+Validate a **produced** communication artifact, not just a markdown answer:
+render it, inspect the **actual output files** (HTML/PDF/PNG), and check it
+against its brief and visual contract. Confirms accessibility, offline-safety
+(no external requests), and that no prohibited content leaked, then reports
+pass/fail with concrete fixes.
+
+## When to Use
+
+- A one-pager, slide deck, or explainer has been produced and needs sign-off.
+- You need to confirm the rendered files (not just the source) are correct.
+
+## When NOT to Use
+
+- Nothing has been rendered yet (produce it first).
+- A full web-app 508 audit is needed → delegate to `accessibility-review`.
+
+## Prerequisites
+
+- The artifact's output files + its brief and visual contract.
+- Offline headless renderer to re-render and inspect.
+
+## Procedure
+
+1. **Re-render** the source and confirm exports regenerate deterministically.
+2. **Inspect the actual files** — open the PDF/PNG/HTML; confirm the one-pager is
+   one page, the deck has the expected slide count, and the preview matches.
+3. **Brief conformance** — the core message leads and is dominant; the closing
+   action is present; primary beats are all there.
+4. **Accessibility** — WCAG AA contrast on every text/background pair; semantic
+   structure; alt text on images; sensible reading order.
+5. **Offline-safety** — no external network requests during render; all assets
+   vendored.
+6. **Prohibited content** — no secrets, real PII, real CUI, internal URLs.
+7. **Report** findings with concrete, actionable fixes; mark PASS/FAIL.
+
+## Findings
+
+Report as a table: check | result (pass/fail) | evidence | fix.
+
+## Verification
+
+- The check inspected the **rendered files**, not only the markdown/source.
+- Contrast ratios are stated, not assumed.
+- A FAIL names the exact file + fix.
+
+## Examples
+
+| Artifact | Typical finding |
+|----------|-----------------|
+| one-pager | "PDF spills to 2 pages — reduce proof-card padding" |
+| slide-deck | "Slide 4 body text 3.9:1 contrast (<4.5 AA) — darken text token" |
+
+## Human Review Checklist
+
+- [ ] Rendered files inspected (not just the source).
+- [ ] WCAG AA contrast verified with stated ratios.
+- [ ] No external requests; assets vendored.
+- [ ] No secrets, PII, CUI, or internal URLs in the artifact.
+
+## Notes
+
+Final stage of the `design-artifact` workflow. For web prototypes/pages, defer
+the deep conformance audit to `accessibility-review`.

--- a/.agents/skills/communications/narrative-architect/SKILL.md
+++ b/.agents/skills/communications/narrative-architect/SKILL.md
@@ -1,0 +1,136 @@
+---
+id: narrative-architect
+version: "1.0.0"
+title: "Narrative Architect"
+description: "Turn an artifact brief into an information hierarchy and argument sequence — the order in which points are made and how they build to the core message — before any visual design or rendering."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Narrative"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "narrative structure"
+  - "information hierarchy"
+  - "argument sequence"
+tags:
+  - "communications"
+  - "narrative"
+  - "structure"
+routing:
+  task_types:
+    - plan
+    - visualize
+  input_artifacts:
+    - artifact-brief
+  output_artifacts:
+    - storyboard
+  aliases:
+    - "story structure"
+    - "outline the argument"
+  prefer_when:
+    - "you have a brief and need the order + hierarchy of points before choosing visuals"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Skill: Narrative Architect
+
+## Summary
+
+Given an [`artifact-brief`](../artifact-brief/SKILL.md), decide the
+**information hierarchy** (what's primary vs supporting) and the **argument
+sequence** (the order that builds to the core message). Output a storyboard the
+visual and rendering skills follow — so the artifact leads with the point, not
+with background.
+
+## When to Use
+
+- You have a brief and need the structure before visuals or slides exist.
+- An artifact feels like a data dump with no through-line.
+
+## When NOT to Use
+
+- The brief doesn't exist yet (run `artifact-brief` first).
+- You're choosing colors/layout (that's `visual-direction`).
+
+## Prerequisites
+
+- A completed artifact brief (audience, action, core message, evidence).
+
+## Procedure
+
+1. **Lead with the core message.** The first beat states the takeaway; do not
+   bury it after setup.
+2. **Order the evidence** to build the argument — strongest support first for a
+   skeptical audience, or problem→solution→proof for a narrative one.
+3. **Assign hierarchy** — mark each beat primary (must land) or supporting
+   (cut first if space runs out).
+4. **Map beats to the output profile** — a one-pager gets ~3–5 beats; a slide
+   deck gets one beat per slide; an explainer gets a scene per beat.
+5. **End on the action** from the brief.
+6. **Emit the storyboard** below.
+
+## Narrative shape
+
+```yaml
+core_message: "..."
+beats:
+  - id: 1
+    point: "..."
+    role: primary | supporting
+    evidence_ref: "which brief evidence item"
+closing_action: "..."
+```
+
+## Verification
+
+- Beat 1 is the core message, not background.
+- Every beat maps to a brief evidence item or the action.
+- Primary beats alone still tell the whole story (supporting are droppable).
+- Beat count fits the target profile.
+
+## Examples
+
+| Profile | Beats |
+|---------|-------|
+| one-pager | message → 3 proofs → ask |
+| slide-deck | title/message → problem → approach → proof → ask |
+
+## Human Review Checklist
+
+- [ ] The core message leads.
+- [ ] Cutting supporting beats still leaves a coherent argument.
+- [ ] The closing is the brief's action.
+- [ ] No secrets, PII, CUI, or internal URLs.
+
+## Notes
+
+Consumes the brief; produces a storyboard for `visual-direction` and the
+renderers. Orchestrated by `design-artifact`.

--- a/.agents/skills/communications/one-pager/SKILL.md
+++ b/.agents/skills/communications/one-pager/SKILL.md
@@ -1,0 +1,153 @@
+---
+id: one-pager
+version: "1.0.0"
+title: "One-Pager"
+description: "Render a single-page executive artifact (HTML source plus PDF/PNG exports) from a storyboard and visual contract, following the design-artifact pipeline, with all assets locally vendored and accessibility built in."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: multi
+  artifacts:
+    - role: source
+      media_type: text/html
+      extension: html
+    - role: export
+      media_type: application/pdf
+      extension: pdf
+    - role: preview
+      media_type: image/png
+      extension: png
+  contract:
+    required_sections:
+      - "Summary"
+      - "Composition HTML"
+      - "Render Command"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "External CDN Links"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "one-pager"
+  - "one page summary"
+  - "executive summary"
+tags:
+  - "communications"
+  - "design"
+  - "one-pager"
+routing:
+  task_types:
+    - author
+    - render
+  input_artifacts:
+    - storyboard
+    - visual-contract
+    - artifact-brief
+  output_artifacts:
+    - one-pager
+  aliases:
+    - "executive one-pager"
+    - "leave-behind"
+  prefer_when:
+    - "the requested output is a single-page summary artifact"
+  avoid_when:
+    - "the request is a multi-slide deck"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Skill: One-Pager
+
+## Summary
+
+Render a **single-page** executive artifact from a storyboard +
+[`visual-direction`](../visual-direction/SKILL.md) contract. Output is
+multi-file: an **HTML source** (the editable master), a **PDF export** (the
+share/print copy), and a **PNG preview**. All assets are locally vendored (no
+external CDN), and the layout follows the visual contract so it's accessible and
+on-brand.
+
+## When to Use
+
+- The requested deliverable is a one-page summary / leave-behind.
+- You already have a storyboard and visual contract.
+
+## When NOT to Use
+
+- The ask is a multi-slide deck → `slide-deck`.
+- The ask is motion/video → `explainer-video` / `explainer-gif`.
+
+## Prerequisites
+
+- Storyboard (beats + hierarchy), visual contract, and the brief.
+- Headless Chromium + a PDF/PNG renderer available offline.
+
+## Procedure
+
+1. **Lay out the beats** on one page per the visual contract: message header,
+   supporting proof blocks, closing action.
+2. **Author the composition HTML** — self-contained, assets inlined or locally
+   vendored, semantic markup (headings, landmarks, alt text).
+3. **Verify contrast + reading order** meet WCAG AA before export.
+4. **Render exports** — HTML → PDF (print CSS, one page) and a PNG preview.
+5. **Emit** the composition HTML, the render command, and the review checklist.
+
+## Composition HTML
+
+Provide a complete, offline, single-file HTML document using the visual
+contract's tokens. Semantic structure; alt text on every image; no external
+requests.
+
+## Render Command
+
+```bash
+# Offline HTML -> PDF + PNG (headless Chromium). Adjust to your renderer.
+chromium --headless --print-to-pdf=one-pager.pdf one-pager.html
+chromium --headless --screenshot=one-pager.png --window-size=1200,1553 one-pager.html
+```
+
+## Verification
+
+- Output fits **one page** in the PDF.
+- Every text/background pair meets WCAG AA.
+- No external network requests during render (all vendored).
+- Core message is the visually dominant element.
+
+## Examples
+
+| Brief | Result |
+|-------|--------|
+| "Executive one-pager for the pilot" | message header + 3 proof cards + fund-phase-2 ask, HTML+PDF+PNG |
+
+## Human Review Checklist
+
+- [ ] Fits one page; core message dominant.
+- [ ] WCAG AA contrast; images have alt text.
+- [ ] All assets locally vendored — no CDN, no internal URLs.
+- [ ] No secrets, PII, or CUI.
+
+## Notes
+
+Usually invoked by the `design-artifact` workflow after
+`artifact-brief` → `narrative-architect` → `visual-direction`, and validated by
+`artifact-qa`.

--- a/.agents/skills/communications/slide-deck/SKILL.md
+++ b/.agents/skills/communications/slide-deck/SKILL.md
@@ -1,0 +1,154 @@
+---
+id: slide-deck
+version: "1.0.0"
+title: "Slide Deck"
+description: "Render a presentation deck (HTML source plus PDF export and a PNG preview) from a storyboard and visual contract, one beat per slide, with locally vendored assets and accessibility built in."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: multi
+  artifacts:
+    - role: source
+      media_type: text/html
+      extension: html
+    - role: export
+      media_type: application/pdf
+      extension: pdf
+    - role: preview
+      media_type: image/png
+      extension: png
+  contract:
+    required_sections:
+      - "Summary"
+      - "Composition HTML"
+      - "Render Command"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "External CDN Links"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "slide deck"
+  - "presentation"
+  - "slides"
+tags:
+  - "communications"
+  - "design"
+  - "slide-deck"
+routing:
+  task_types:
+    - author
+    - render
+  input_artifacts:
+    - storyboard
+    - visual-contract
+    - artifact-brief
+  output_artifacts:
+    - slide-deck
+  aliases:
+    - "presentation deck"
+    - "briefing slides"
+  prefer_when:
+    - "the requested output is a multi-slide presentation"
+  avoid_when:
+    - "the request is a single-page summary"
+    - "the request is motion/video"
+  delegates:
+    - pattern: one-pager
+      when: "the request is a single-page summary, not a deck"
+    - pattern: explainer-video
+      when: "the request is an animated/narrated video"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Skill: Slide Deck
+
+## Summary
+
+Render a **multi-slide** presentation from a storyboard +
+[`visual-direction`](../visual-direction/SKILL.md) contract — one beat per
+slide. Output is multi-file: an **HTML source** (editable master, e.g. a
+reveal-style deck), a **PDF export**, and a **PNG preview** of the title slide.
+All assets are locally vendored (no external CDN).
+
+## When to Use
+
+- The deliverable is a presentation / briefing deck.
+- You have a storyboard and visual contract.
+
+## When NOT to Use
+
+- Single-page summary → `one-pager`.
+- Motion/video → `explainer-video` / `explainer-gif`.
+
+## Prerequisites
+
+- Storyboard (one beat ≈ one slide), visual contract, brief.
+- Offline headless Chromium + PDF/PNG renderer.
+
+## Procedure
+
+1. **One beat per slide** — title/message slide first, then a slide per beat,
+   closing on the action.
+2. **Author the composition HTML** — self-contained deck, assets inlined/vendored,
+   semantic headings per slide, alt text, high-contrast large type.
+3. **Check contrast + reading order** meet WCAG AA.
+4. **Render exports** — HTML → PDF (one page per slide) and a PNG of slide 1.
+5. **Emit** the composition HTML, the render command, and the review checklist.
+
+## Composition HTML
+
+A complete offline deck (e.g. sections as slides) using the visual contract's
+tokens; no external requests; alt text on all images.
+
+## Render Command
+
+```bash
+# Offline deck -> PDF + title PNG (headless Chromium). Adjust to your renderer.
+chromium --headless --print-to-pdf=deck.pdf deck.html
+chromium --headless --screenshot=deck-title.png --window-size=1280,720 deck.html
+```
+
+## Verification
+
+- One beat per slide; title slide carries the core message.
+- WCAG AA contrast; large readable type.
+- No external requests during render (all vendored).
+
+## Examples
+
+| Brief | Result |
+|-------|--------|
+| "Deck for the pilot review" | title/message → problem → approach → proof → ask, HTML+PDF+PNG |
+
+## Human Review Checklist
+
+- [ ] One beat per slide; core message on the title slide.
+- [ ] WCAG AA contrast; images have alt text.
+- [ ] All assets locally vendored — no CDN, no internal URLs.
+- [ ] No secrets, PII, or CUI.
+
+## Notes
+
+Usually invoked by the `design-artifact` workflow and validated by `artifact-qa`.

--- a/.agents/skills/communications/visual-direction/SKILL.md
+++ b/.agents/skills/communications/visual-direction/SKILL.md
@@ -1,0 +1,144 @@
+---
+id: visual-direction
+version: "1.0.0"
+title: "Visual Direction"
+description: "Turn a storyboard into a concrete visual contract — layout, type scale, color, spacing, and asset rules (USWDS-aligned where federal) — that a renderer can follow to produce an accessible, on-brand artifact."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Visual Contract"
+      - "Human Review Checklist"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "External CDN Links"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "visual direction"
+  - "design direction"
+  - "layout and color"
+tags:
+  - "communications"
+  - "design"
+  - "visual"
+routing:
+  task_types:
+    - visualize
+  input_artifacts:
+    - storyboard
+  output_artifacts:
+    - visual-contract
+  aliases:
+    - "design system for this artifact"
+    - "look and feel"
+  prefer_when:
+    - "you have a storyboard and need the concrete visual rules before rendering"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Skill: Visual Direction
+
+## Summary
+
+Given a storyboard from [`narrative-architect`](../narrative-architect/SKILL.md),
+produce a **visual contract**: the concrete layout, type scale, color roles,
+spacing, and asset rules a renderer follows. For federal artifacts, align to
+USWDS tokens. The contract is deterministic enough that
+`one-pager`/`slide-deck` can render without re-deciding design.
+
+## When to Use
+
+- You have a storyboard and need the look-and-feel pinned before rendering.
+- Multiple renderers/formats must stay visually consistent.
+
+## When NOT to Use
+
+- No storyboard yet (run `narrative-architect`).
+- You're building a full interactive site (see the `uswds-*` skills).
+
+## Prerequisites
+
+- A storyboard (beats + hierarchy) and the brief's constraints (brand, a11y).
+
+## Procedure
+
+1. **Grid & layout** — pick a layout per beat that reflects its hierarchy
+   (primary beats get dominant space).
+2. **Type scale** — heading/body/caption sizes with a clear ratio; enough
+   contrast for the primary message to dominate.
+3. **Color roles** — background, text, accent, and semantic colors as named
+   roles (not one-off hex). USWDS tokens where federal. All text/background pairs
+   must meet WCAG AA contrast.
+4. **Spacing** — a consistent spacing unit; whitespace protects the primary
+   message.
+5. **Assets** — allowed asset types and the rule that all assets are **locally
+   vendored** (no external CDN links; matches explainer skills).
+6. **Emit the visual contract** below.
+
+## Visual Contract shape
+
+```yaml
+grid: "..."
+type_scale:
+  heading: "..."
+  body: "..."
+  caption: "..."
+color_roles:
+  background: "..."
+  text: "..."
+  accent: "..."
+contrast: "WCAG AA verified"
+spacing_unit: "..."
+assets: "locally vendored only; no external CDN"
+```
+
+## Verification
+
+- Every text/background pair meets WCAG AA (state the ratios).
+- Primary beats are visually dominant.
+- No external CDN/asset links — all vendored.
+- Tokens/roles named, not scattered literals.
+
+## Examples
+
+| Profile | Direction |
+|---------|-----------|
+| one-pager | single column, big message header, 3 proof cards |
+| slide-deck | 16:9, one message per slide, large type, high contrast |
+
+## Human Review Checklist
+
+- [ ] Contrast meets WCAG AA for all text.
+- [ ] Assets are locally vendored (no CDN).
+- [ ] Visual hierarchy matches the storyboard's primary/supporting split.
+- [ ] No secrets, PII, CUI, or internal URLs.
+
+## Notes
+
+Consumes the storyboard; produces the visual contract for `one-pager` /
+`slide-deck`. Accessibility is verified end-to-end by `artifact-qa` (and, for
+web artifacts, `accessibility-review`).

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -2,7 +2,7 @@
 
 > **Generated file — do not edit by hand.** Run `make generate` (regenerates INDEX.yaml + CATALOG.md). Source of truth is each pattern's `SKILL.md`/`AGENTS.md` frontmatter.
 
-31 patterns — 21 skills, 3 prompts, 3 agents, 3 workflows, 1 lessons.
+38 patterns — 27 skills, 3 prompts, 3 agents, 4 workflows, 1 lessons.
 
 For machine routing use the [`pattern-router`](.agents/skills/meta/pattern-router/SKILL.md) skill + `scripts/route_patterns.py`; this catalog is the human view.
 
@@ -64,5 +64,12 @@ For machine routing use the [`pattern-router`](.agents/skills/meta/pattern-route
 
 | Pattern | Type | Status | Tasks | Consumes | Produces |
 |---------|------|--------|-------|----------|----------|
+| [`artifact-brief`](skills/communications/artifact-brief/SKILL.md) | skill | experimental | plan | documentation | artifact-brief |
+| [`artifact-qa`](skills/communications/artifact-qa/SKILL.md) | skill | experimental | review, test | one-pager, slide-deck | qa-report |
+| [`design-artifact`](workflows/design-artifact/SKILL.md) | workflow | experimental | author, orchestrate, render, review, visualize | documentation | one-pager, slide-deck |
 | [`explainer-gif`](skills/outreach/explainer-gif/SKILL.md) | skill | experimental | author, render | artifact-brief, shell-script | explainer-gif, terminal-demo |
 | [`explainer-video`](skills/outreach/explainer-video/SKILL.md) | skill | experimental | author, render | artifact-brief, web-page | explainer-video, marketing-asset |
+| [`narrative-architect`](skills/communications/narrative-architect/SKILL.md) | skill | experimental | plan, visualize | artifact-brief | storyboard |
+| [`one-pager`](skills/communications/one-pager/SKILL.md) | skill | experimental | author, render | artifact-brief, storyboard, visual-contract | one-pager |
+| [`slide-deck`](skills/communications/slide-deck/SKILL.md) | skill | experimental | author, render | artifact-brief, storyboard, visual-contract | slide-deck |
+| [`visual-direction`](skills/communications/visual-direction/SKILL.md) | skill | experimental | visualize | storyboard | visual-contract |

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -50,6 +50,44 @@ patterns:
       - ci agent audit
       - github actions security
       - workflow audit
+  - path: skills/communications/artifact-brief/SKILL.md
+    id: artifact-brief
+    title: Artifact Brief
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - plan
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - artifact-brief
+      aliases:
+      - comms brief
+      - message brief
+      priority: 60
+  - path: skills/communications/artifact-qa/SKILL.md
+    id: artifact-qa
+    title: Artifact QA
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - review
+      - test
+      input_artifacts:
+      - one-pager
+      - slide-deck
+      output_artifacts:
+      - qa-report
+      aliases:
+      - artifact review
+      - design qa
+      priority: 55
   - path: skills/backdoor-review/SKILL.md
     id: backdoor-review
     title: Backdoor Review
@@ -258,6 +296,46 @@ patterns:
       - permission minimality
       - permissions minimal
       - token scope review
+  - path: skills/communications/narrative-architect/SKILL.md
+    id: narrative-architect
+    title: Narrative Architect
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - plan
+      - visualize
+      input_artifacts:
+      - artifact-brief
+      output_artifacts:
+      - storyboard
+      aliases:
+      - outline the argument
+      - story structure
+      priority: 55
+  - path: skills/communications/one-pager/SKILL.md
+    id: one-pager
+    title: One-Pager
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      - storyboard
+      - visual-contract
+      output_artifacts:
+      - one-pager
+      aliases:
+      - executive one-pager
+      - leave-behind
+      priority: 55
   - path: skills/over-engineering-review/SKILL.md
     id: over-engineering-review
     title: Over-Engineering Review
@@ -361,6 +439,27 @@ patterns:
       - owasp review
       - security code review
       - vulnerability review
+  - path: skills/communications/slide-deck/SKILL.md
+    id: slide-deck
+    title: Slide Deck
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - author
+      - render
+      input_artifacts:
+      - artifact-brief
+      - storyboard
+      - visual-contract
+      output_artifacts:
+      - slide-deck
+      aliases:
+      - briefing slides
+      - presentation deck
+      priority: 55
   - path: skills/test-generation/SKILL.md
     id: test-generation
     title: Test Case Generation
@@ -467,6 +566,24 @@ patterns:
       - federal page
       - html prototype
       - uswds prototype
+  - path: skills/communications/visual-direction/SKILL.md
+    id: visual-direction
+    title: Visual Direction
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - visualize
+      input_artifacts:
+      - storyboard
+      output_artifacts:
+      - visual-contract
+      aliases:
+      - design system for this artifact
+      - look and feel
+      priority: 55
   prompts:
   - path: prompts/planning/implementation-plan/SKILL.md
     id: implementation-plan
@@ -592,6 +709,30 @@ patterns:
       - security agent
       - vuln review agent
   workflows:
+  - path: workflows/design-artifact/SKILL.md
+    id: design-artifact
+    title: Design Artifact Workflow
+    type: workflow
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - author
+      - orchestrate
+      - render
+      - review
+      - visualize
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - one-pager
+      - slide-deck
+      aliases:
+      - design pipeline
+      - executive one-pager
+      - presentation deck
+      priority: 70
   - path: workflows/issue-to-merge-request/SKILL.md
     id: issue-to-merge-request
     title: Issue to Merge Request Workflow
@@ -756,8 +897,15 @@ categories:
   - uswds-prototype
 collections:
   communications:
+  - artifact-brief
+  - artifact-qa
+  - design-artifact
   - explainer-gif
   - explainer-video
+  - narrative-architect
+  - one-pager
+  - slide-deck
+  - visual-direction
   content:
   - documentation-agent
   - documentation-review
@@ -811,12 +959,15 @@ task_types:
   - security-scan-review
   - untrusted-input-boundary-review
   author:
+  - design-artifact
   - documentation-agent
   - explainer-gif
   - explainer-video
   - general-agent
   - issue-to-merge-request
+  - one-pager
   - safe-shell-script-author
+  - slide-deck
   - test-generation
   - uswds-form-flow
   - uswds-landing-page
@@ -825,26 +976,34 @@ task_types:
   - federal-service-blueprint
   - pattern-router
   orchestrate:
+  - design-artifact
   - issue-to-merge-request
   - pattern-router
   - qa-workflow
   - security-scan-review
   plan:
+  - artifact-brief
   - federal-service-blueprint
   - general-agent
   - implementation-plan
+  - narrative-architect
   render:
+  - design-artifact
   - explainer-gif
   - explainer-video
+  - one-pager
+  - slide-deck
   - uswds-form-flow
   - uswds-landing-page
   - uswds-prototype
   review:
   - accessibility-review
   - agentic-actions-auditor
+  - artifact-qa
   - backdoor-review
   - compliance-claim-checker
   - dependency-analysis
+  - design-artifact
   - documentation-agent
   - documentation-review
   - incident-evidence-review
@@ -859,11 +1018,18 @@ task_types:
   - security-scan-review
   - untrusted-input-boundary-review
   test:
+  - artifact-qa
   - issue-to-merge-request
   - qa-round
   - qa-workflow
   - test-generation
+  visualize:
+  - design-artifact
+  - narrative-architect
+  - visual-direction
 output_artifacts:
+  artifact-brief:
+  - artifact-brief
   documentation:
   - documentation-agent
   - example-agentic-session
@@ -879,10 +1045,14 @@ output_artifacts:
   - uswds-landing-page
   marketing-asset:
   - explainer-video
+  one-pager:
+  - design-artifact
+  - one-pager
   pull-request-diff:
   - issue-to-merge-request
   qa-report:
   - accessibility-review
+  - artifact-qa
   - documentation-review
   - over-engineering-review
   - plain-language-review
@@ -905,6 +1075,9 @@ output_artifacts:
   - federal-service-blueprint
   shell-script:
   - safe-shell-script-author
+  slide-deck:
+  - design-artifact
+  - slide-deck
   source-code:
   - general-agent
   - issue-to-merge-request
@@ -912,14 +1085,18 @@ output_artifacts:
   - uswds-form-flow
   - uswds-landing-page
   - uswds-prototype
+  storyboard:
+  - narrative-architect
   terminal-demo:
   - explainer-gif
+  visual-contract:
+  - visual-direction
   web-prototype:
   - uswds-prototype
 stats:
-  total_patterns: 31
-  skills: 21
+  total_patterns: 38
+  skills: 27
   prompts: 3
   agents: 3
-  workflows: 3
+  workflows: 4
   lessons: 1

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -100,8 +100,35 @@
       "properties": {
         "format": {
           "type": "string",
-          "enum": ["markdown", "json", "yaml", "text", "unknown"],
+          "description": "Primary output format. 'multi' means the pattern emits a bundle of files described by `artifacts` (#241, design/media patterns).",
+          "enum": ["markdown", "json", "yaml", "text", "html", "svg", "png", "pdf", "pptx", "gif", "mp4", "multi", "unknown"],
           "default": "markdown"
+        },
+        "artifacts": {
+          "type": "array",
+          "description": "Multi-file output description for design/media patterns; each entry names a produced file's role + IANA media type (#241). Use with format: multi.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["role", "media_type"],
+            "properties": {
+              "role": {
+                "type": "string",
+                "description": "What this file is.",
+                "enum": ["source", "export", "preview", "sidecar", "manifest"]
+              },
+              "media_type": {
+                "type": "string",
+                "description": "IANA media type, e.g. text/html, application/pdf, image/png.",
+                "pattern": "^[a-z]+/[a-zA-Z0-9.+-]+$"
+              },
+              "extension": {
+                "type": "string",
+                "description": "File extension without the dot.",
+                "pattern": "^[a-z0-9]+$"
+              }
+            }
+          }
         },
         "contract": {
           "type": "object",

--- a/schemas/taxonomy.yaml
+++ b/schemas/taxonomy.yaml
@@ -104,6 +104,9 @@ artifact_types:
   storyboard:
     description: An ordered visual/narrative plan.
     aliases: []
+  visual-contract:
+    description: The concrete visual rules (layout, type, color, spacing, asset rules) a renderer follows.
+    aliases: [design-direction]
   diagram:
     description: A technical diagram.
     aliases: [technical-diagram]

--- a/scripts/route_patterns.py
+++ b/scripts/route_patterns.py
@@ -52,9 +52,13 @@ P_DELEGATED = -100
 P_DEPRECATED = -100
 
 # A workflow that covers the requested outcome is preferred over assembling
-# skills; a prompt is only a fallback. Encoded as a small type nudge so ties
-# resolve toward the right granularity without overriding real facet matches.
-TYPE_NUDGE = {"workflow": 3, "skill": 0, "prompt": -3, "agent": -5, "lesson": -50}
+# skills; a prompt is only a fallback. The workflow nudge is sized to overcome a
+# single extra trigger/alias hit on a competing renderer skill (W_TRIGGER_MATCH),
+# so an outcome-level request ("create an executive one-pager") routes to the
+# design-artifact workflow, while a narrow skill-only request still wins on
+# stronger facet matches. Encoded as a small type nudge, applied only to
+# candidates that already have a substantive match.
+TYPE_NUDGE = {"workflow": 12, "skill": 0, "prompt": -3, "agent": -5, "lesson": -50}
 
 
 @dataclass

--- a/scripts/tests/test_route_patterns.py
+++ b/scripts/tests/test_route_patterns.py
@@ -336,3 +336,41 @@ class TestLiveIndexRouting:
         )
         selected = {route["primary"]["id"]} | {s["id"] for s in route["supporting"]}
         assert "safe-code-review" not in selected
+
+    # #241: communications pack — full artifact requests route to the workflow;
+    # narrow skill-level requests route to the renderer skill.
+    def test_executive_one_pager_routes_to_workflow(self):
+        route = self._route(
+            task_types=["author", "render"],
+            output_artifacts=["one-pager"],
+            keywords=["create an executive one-pager explaining the pilot"],
+        )
+        assert route["primary"]["id"] == "design-artifact"
+        assert route["primary"]["type"] == "workflow"
+
+    def test_slide_deck_request_routes_to_workflow(self):
+        route = self._route(
+            task_types=["author"],
+            output_artifacts=["slide-deck"],
+            keywords=["make a slide deck for the review"],
+        )
+        assert route["primary"]["id"] == "design-artifact"
+
+    def test_narrow_render_routes_to_skill_not_workflow(self):
+        # Rendering a one-pager from an existing storyboard is a skill-level op.
+        route = self._route(
+            task_types=["render"],
+            input_artifacts=["storyboard"],
+            output_artifacts=["one-pager"],
+        )
+        assert route["primary"]["id"] == "one-pager"
+        assert route["primary"]["type"] == "skill"
+
+    def test_slide_deck_request_excludes_explainer_video(self):
+        route = self._route(
+            task_types=["author"],
+            output_artifacts=["slide-deck"],
+            keywords=["make a slide deck for the review"],
+        )
+        selected = {route["primary"]["id"]} | {s["id"] for s in route["supporting"]}
+        assert "explainer-video" not in selected

--- a/scripts/tests/test_validate_frontmatter.py
+++ b/scripts/tests/test_validate_frontmatter.py
@@ -447,6 +447,81 @@ class TestRealSchemaStrictness:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=fm, schema=real_schema)
 
+    # --- #241: multi-artifact output ------------------------------------------
+
+    def test_multi_artifact_output_accepted(self, real_schema):
+        import jsonschema
+
+        fm = self._base()
+        fm["output"] = {
+            "format": "multi",
+            "artifacts": [
+                {"role": "source", "media_type": "text/html", "extension": "html"},
+                {"role": "export", "media_type": "application/pdf", "extension": "pdf"},
+            ],
+            "contract": {"required_sections": ["Summary"], "prohibited_content": ["Secrets"]},
+        }
+        jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_new_media_formats_accepted(self, real_schema):
+        import jsonschema
+
+        for fmt in ("html", "svg", "png", "pdf", "pptx", "gif", "mp4"):
+            fm = self._base()
+            fm["output"]["format"] = fmt
+            jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_artifact_unknown_role_rejected(self, real_schema):
+        import jsonschema
+
+        fm = self._base()
+        fm["output"] = {
+            "format": "multi",
+            "artifacts": [{"role": "bogus", "media_type": "text/html"}],
+            "contract": {"required_sections": ["Summary"], "prohibited_content": ["Secrets"]},
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=fm, schema=real_schema)
+
+    def test_multi_without_artifacts_rejected_by_validator(self, real_schema):
+        # Schema alone allows it, but validate_file enforces "multi ⇒ artifacts".
+        from pathlib import Path
+
+        from scripts.validate_frontmatter import load_taxonomy, validate_file
+
+        repo_root = Path(__file__).resolve().parents[2]
+        tax = load_taxonomy(repo_root / "schemas" / "taxonomy.yaml")
+        # Build a temp file with format: multi and no artifacts.
+        import tempfile
+        import textwrap
+
+        content = textwrap.dedent("""\
+            ---
+            id: multi-x
+            version: "1.0.0"
+            title: "Multi X"
+            type: skill
+            status: experimental
+            owners: ["@GSA-TTS/agentic-coding-team"]
+            primary_personas: ["developers"]
+            requires: {anchors: []}
+            output:
+              format: multi
+              contract:
+                required_sections: ["Summary"]
+                prohibited_content: ["Secrets"]
+            quality_gates: {readability_max_grade: 10, citations_required: false}
+            ---
+            # body
+            """)
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write(content)
+            path = Path(f.name)
+        ok, errors, _ = validate_file(path, real_schema, tax)
+        path.unlink()
+        assert not ok
+        assert any("multi" in e for e in errors)
+
 
 class TestRoutingTaxonomy:
     """#238: routing.* facet values are cross-checked against schemas/taxonomy.yaml."""

--- a/scripts/validate_frontmatter.py
+++ b/scripts/validate_frontmatter.py
@@ -215,6 +215,17 @@ def validate_file(
     if routing_errors:
         return False, routing_errors, gov_warnings
 
+    # Multi-artifact output check (#241): format: multi must list artifacts.
+    output = frontmatter.get("output")
+    if isinstance(output, dict) and output.get("format") == "multi":
+        artifacts = output.get("artifacts")
+        if not isinstance(artifacts, list) or not artifacts:
+            return (
+                False,
+                ["output.format is 'multi' but output.artifacts is empty (list at least one produced file)"],
+                gov_warnings,
+            )
+
     return True, [], gov_warnings
 
 

--- a/workflows/design-artifact/SKILL.md
+++ b/workflows/design-artifact/SKILL.md
@@ -1,0 +1,147 @@
+---
+id: design-artifact
+version: "1.0.0"
+title: "Design Artifact Workflow"
+description: "End-to-end workflow to produce a QA'd communication artifact — brief, narrative, visual direction, render, validate — selecting an output profile (one-pager or slide-deck) so one shared pipeline serves every format."
+type: workflow
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills:
+    - artifact-brief
+    - narrative-architect
+    - visual-direction
+    - one-pager
+    - slide-deck
+    - artifact-qa
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Outcome"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "External CDN Links"
+quality_gates:
+  readability_max_grade: 10
+  citations_required: false
+collection: communications
+triggers:
+  - "design artifact"
+  - "make an executive one-pager"
+  - "create a slide deck"
+  - "build a communication artifact"
+tags:
+  - "workflow"
+  - "communications"
+  - "design"
+routing:
+  task_types:
+    - orchestrate
+    - author
+    - visualize
+    - render
+    - review
+  input_artifacts:
+    - documentation
+  output_artifacts:
+    - one-pager
+    - slide-deck
+  aliases:
+    - "executive one-pager"
+    - "presentation deck"
+    - "design pipeline"
+  prefer_when:
+    - "the request is to create an executive/marketing/explainer artifact (one-pager, deck) end to end"
+  priority: 70
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+---
+
+# Workflow: Design Artifact
+
+## Summary
+
+Turn a request for a communication artifact into a finished, QA'd deliverable.
+The workflow runs one shared pipeline —
+[`artifact-brief`](../../skills/communications/artifact-brief/SKILL.md) →
+[`narrative-architect`](../../skills/communications/narrative-architect/SKILL.md) →
+[`visual-direction`](../../skills/communications/visual-direction/SKILL.md) →
+renderer →
+[`artifact-qa`](../../skills/communications/artifact-qa/SKILL.md) —
+and selects an **output profile** for the render step so the same briefing,
+narrative, and QA don't get duplicated across four separate workflows.
+
+## When to Use
+
+- "Create an executive one-pager / slide deck about X."
+- Any request to produce a communication artifact from raw material.
+
+## When NOT to Use
+
+- You only need to *review* an existing artifact → `artifact-qa` directly.
+- The output is a live website/prototype → the `uswds-*` skills.
+- The output is motion/video → `explainer-video` / `explainer-gif`.
+
+## Output profiles
+
+```yaml
+profiles:
+  - one-pager            # → skills/communications/one-pager
+  - slide-deck           # → skills/communications/slide-deck
+  - technical-explainer  # (future) longer explanatory doc
+  - marketing-kit        # (future) multi-asset outreach bundle
+```
+
+The profile is chosen from the brief's `constraints.profile`. `one-pager` and
+`slide-deck` are implemented today; the other two are placeholders for future
+renderers and should route to the closest implemented profile until they exist.
+
+## Procedure
+
+1. **Brief** — run `artifact-brief` to pin audience, action, core message,
+   evidence, constraints (incl. the output profile).
+2. **Narrative** — run `narrative-architect` to produce the storyboard (beats +
+   hierarchy) for that profile.
+3. **Visual direction** — run `visual-direction` to produce the visual contract
+   (layout, type, color, spacing, vendored assets).
+4. **Render** — dispatch to the profile's renderer:
+   - `one-pager` → `one-pager` skill
+   - `slide-deck` → `slide-deck` skill
+5. **QA** — run `artifact-qa` on the rendered files; if it FAILs, loop back to
+   the smallest responsible step (usually render or visual-direction) and
+   re-run.
+6. **Accessibility** — for web-delivered artifacts, additionally run
+   `accessibility-review`.
+
+## Outcome
+
+Report the profile chosen, the produced files, and the `artifact-qa` verdict
+(PASS/FAIL with fixes applied).
+
+## Verification
+
+- Exactly one output profile was selected and rendered.
+- `artifact-qa` PASSed on the actual rendered files.
+- No external requests; all assets vendored.
+
+## Notes
+
+This workflow is why the individual communications skills stay small and
+single-purpose: the workflow owns orchestration and profile selection; each
+skill owns one step. The `pattern-router` prefers this workflow over assembling
+the skills by hand for a full artifact request.


### PR DESCRIPTION
Closes #241. Part of epic #237. Final phase of the router stack — PR1 (#245), PR2 (#266), PR3 (#267) all merged; this is now rebased directly on `main`.

> Supersedes #268 (auto-closed when its stacked base branch was deleted on the #267 merge). Same content + Bret's prior approval; rebased onto main with an identical diff.

Adds a **communications pack** so a full "create an executive one-pager / slide deck" request routes to one shared, QA'd pipeline instead of the router assembling six skills by hand.

## Schema (additive)
- `output.format` gains `html/svg/png/pdf/pptx/gif/mp4/multi`; new `output.artifacts[]` (`{role, media_type, extension}`) for multi-file output.
- Validator enforces **`format: multi` ⇒ non-empty `artifacts`**.
- `taxonomy.yaml` gains the `visual-contract` artifact slug.

## New skills (`.agents/skills/communications/`)
| Skill | Consumes → Produces |
|-------|---------------------|
| `artifact-brief` | (raw) → `artifact-brief` |
| `narrative-architect` | `artifact-brief` → `storyboard` |
| `visual-direction` | `storyboard` → `visual-contract` (WCAG AA + vendored assets) |
| `one-pager` / `slide-deck` | `storyboard`+`visual-contract`+`artifact-brief` → **multi**: HTML + PDF + PNG (offline, vendored) |
| `artifact-qa` | `one-pager`/`slide-deck` → `qa-report` (validates the **actual rendered files**; delegates web 508 audits to `accessibility-review`) |

## Workflow
- `workflows/design-artifact` — orchestrates brief → narrative → visual-direction → renderer(profile) → artifact-qa, selecting a `one-pager`/`slide-deck` profile.

## Router
Raised the workflow `TYPE_NUDGE` so an **outcome-level** request routes to the design-artifact **workflow**, while a **narrow skill-level** render (`storyboard → one-pager`) still routes to the **skill**. New `TestLiveIndexRouting` cases cover both + "slide-deck excludes explainer-video".

## Verification
- `make validate` (frontmatter + refs/cycles) ✓ · `make generate-check` ✓ · markdownlint ✓ · **248 tests pass** ✓
- QA/accuracy subagent review: clean; fixed the one should-fix (visual-direction `diagram` → `visual-contract` slug + wired renderers) and the artifact-qa CDN nit.

Co-authored-by: OpenCode Agent <william.zujkowski@gsa.gov>