### PR TITLE
feat(kits): add neutral publishedPorts + background to hybrid/v1 schema

### DIFF
--- a/integrations/isolation/acq-kits/validate-kits.py
+++ b/integrations/isolation/acq-kits/validate-kits.py
@@ -60,6 +60,14 @@ _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 # alphanumerics and . _ / - are permitted. Mirrors the schema's path pattern.
 _SAFE_PATH_RE = re.compile(r"^/[A-Za-z0-9._/-]+$")
 
+# Safe charset for a publishedPorts[].name label. Mirrors the schema's name
+# pattern: alphanumerics . _ - only, 1-64 chars. A name may be surfaced by a
+# backend adapter (labels, generated primitives), so keep it metacharacter-free.
+_PORT_NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
+
+# Valid transport protocols for a published port (mirrors the schema enum).
+_PORT_PROTOCOLS = {"tcp", "udp"}
+
 # Extensions that indicate a kit-provided payload/script a command expects to
 # have been dropped by files[] (as opposed to a base-image binary, a runtime-
 # generated file, or a system destination path).
@@ -83,6 +91,11 @@ def _referenced_payload_paths(commands: list) -> set[str]:
                 continue
             found.update(_PATH_RE.findall(token))
     return found
+
+
+def _is_valid_port(value: object) -> bool:
+    """A port is an integer in 1..65535. A bool is not a valid port here."""
+    return isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= 65535
 
 
 def validate_kit(kit_dir: Path, schema: dict) -> tuple[list[str], list[str]]:
@@ -152,6 +165,65 @@ def validate_kit(kit_dir: Path, schema: dict) -> tuple[list[str], list[str]]:
 
     if not (kit_dir / "README.md").exists():
         errors.append(f"{kit_dir.name}: missing README.md (parity note required)")
+
+    # publishedPorts[] field-level checks (ADR-0014, quickstart repo). The
+    # schema already constrains these, but — as with environment/path above —
+    # we ALSO check them here so a bad value is reported with a clear per-entry
+    # message at the gate (rather than only a terse jsonschema path). A port
+    # published to the host is a boundary primitive: report offenders, reject.
+    published_ports = spec.get("publishedPorts")
+    if published_ports is not None:
+        if not isinstance(published_ports, list):
+            errors.append(
+                f"{kit_dir.name}: publishedPorts must be an array of port-mapping objects "
+                f"(got {type(published_ports).__name__})"
+            )
+        else:
+            for i, entry in enumerate(published_ports):
+                if not isinstance(entry, dict):
+                    errors.append(
+                        f"{kit_dir.name}: publishedPorts[{i}] must be an object "
+                        f"(got {type(entry).__name__})"
+                    )
+                    continue
+                # guest: required int in 1..65535.
+                if "guest" not in entry:
+                    errors.append(f"{kit_dir.name}: publishedPorts[{i}]: missing required 'guest' port")
+                else:
+                    guest = entry["guest"]
+                    if not _is_valid_port(guest):
+                        errors.append(
+                            f"{kit_dir.name}: publishedPorts[{i}].guest must be an integer 1..65535 "
+                            f"(got {guest!r})"
+                        )
+                # host: optional int in 1..65535 (defaults to guest when omitted).
+                if "host" in entry and not _is_valid_port(entry["host"]):
+                    errors.append(
+                        f"{kit_dir.name}: publishedPorts[{i}].host must be an integer 1..65535 "
+                        f"(got {entry['host']!r})"
+                    )
+                # protocol: optional, tcp|udp (defaults to tcp when omitted).
+                if "protocol" in entry and entry["protocol"] not in _PORT_PROTOCOLS:
+                    errors.append(
+                        f"{kit_dir.name}: publishedPorts[{i}].protocol must be one of "
+                        f"{sorted(_PORT_PROTOCOLS)} (got {entry['protocol']!r})"
+                    )
+                # name: optional, safe charset only.
+                if "name" in entry and not _PORT_NAME_RE.match(str(entry["name"])):
+                    errors.append(
+                        f"{kit_dir.name}: publishedPorts[{i}].name has an unsafe or invalid value "
+                        f"(allowed: alphanumerics . _ -, 1-64 chars): {entry['name']!r}"
+                    )
+
+    # commands[].background field-level check (ADR-0014, quickstart repo). Marks
+    # a startup command that must be detached rather than awaited. Optional; when
+    # present it MUST be a boolean (default false when omitted).
+    for i, c in enumerate(spec.get("commands", []) or []):
+        if isinstance(c, dict) and "background" in c and not isinstance(c["background"], bool):
+            errors.append(
+                f"{kit_dir.name}: commands[{i}].background must be a boolean "
+                f"(got {type(c['background']).__name__})"
+            )
 
     # Best-effort commands[] ↔ files[] consistency: a kit-owned payload path
     # (e.g. /home/agent/foo.sh) referenced by a command but dropped by no

--- a/schemas/kit-hybrid-v1.schema.json
+++ b/schemas/kit-hybrid-v1.schema.json
@@ -129,6 +129,45 @@
               "type": "string"
             },
             "description": "argv form (list of strings). To run a shell snippet, use [\"sh\", \"-c\", \"...\"]."
+          },
+          "background": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, run this command detached rather than awaited — for a startup command whose process never exits (e.g. a supervisor loop) so it must not block sandbox start. Neutral vocabulary: each backend maps this to its native background/detached hook. Defaults to false (the command is awaited)."
+          }
+        }
+      }
+    },
+    "publishedPorts": {
+      "type": "array",
+      "description": "Guest ports to publish to the host. Each backend maps these to its native port-publish primitive (e.g. sbx port-publish). Host loopback binding and per-sandbox ephemeral host ports are a backend concern; the neutral spec only declares the guest port, optional fixed host port, protocol, and a name.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["guest"],
+        "properties": {
+          "guest": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535,
+            "description": "Guest (container) port to publish. Required, 1..65535."
+          },
+          "host": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535,
+            "description": "Fixed host port to bind. Optional; when omitted the backend defaults it to the guest value (or an ephemeral host port, backend's choice). 1..65535."
+          },
+          "protocol": {
+            "type": "string",
+            "enum": ["tcp", "udp"],
+            "default": "tcp",
+            "description": "Transport protocol. Optional; conceptually defaults to \"tcp\" when omitted."
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9._-]{1,64}$",
+            "description": "Optional human-readable label for the mapping (e.g. \"opencode-server\"). Safe charset only: alphanumerics . _ -, 1-64 chars."
           }
         }
       }

--- a/scripts/tests/test_validate_kits_ports.py
+++ b/scripts/tests/test_validate_kits_ports.py
@@ -1,0 +1,192 @@
+"""Tests for the hybrid/v1 publishedPorts + commands[].background fields.
+
+ADR-0014 (quickstart repo) promotes published-port declarations and a
+detached-startup-command flag to the NEUTRAL kit vocabulary; acq consumes both.
+This locks in the schema shape and the validator's field-level enforcement:
+
+  - publishedPorts[]: guest (required int 1..65535), host (optional int 1..65535,
+    defaults to guest when omitted), protocol (optional tcp|udp, default tcp),
+    name (optional, ^[A-Za-z0-9._-]{1,64}$), no additional properties.
+  - commands[].background: optional boolean (default false).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "schemas" / "kit-hybrid-v1.schema.json"
+VALIDATOR_PATH = ROOT / "integrations" / "isolation" / "acq-kits" / "validate-kits.py"
+
+
+def _load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def _load_validate_kit():
+    spec = importlib.util.spec_from_file_location("validate_kits", VALIDATOR_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.validate_kit
+
+
+def _base(**extra) -> dict:
+    d = {
+        "schemaVersion": "hybrid/v1",
+        "kind": "mixin",
+        "name": "t",
+        "displayName": "T",
+        "description": "d",
+    }
+    d.update(extra)
+    return d
+
+
+def _write_kit(kit_dir: Path, spec_yaml: str) -> Path:
+    kit_dir.mkdir(parents=True, exist_ok=True)
+    (kit_dir / "README.md").write_text("# t\n")
+    (kit_dir / "spec.yaml").write_text(spec_yaml)
+    return kit_dir
+
+
+# --- schema-level: publishedPorts --------------------------------------------
+
+
+class TestPublishedPortsSchema:
+    def test_absent_published_ports_still_valid(self):
+        jsonschema.validate(instance=_base(), schema=_load_schema())
+
+    def test_full_valid_entry_accepted(self):
+        inst = _base(
+            publishedPorts=[
+                {"guest": 4096, "host": 14096, "protocol": "tcp", "name": "opencode-server"},
+                {"guest": 3000},  # host/protocol/name all optional
+            ]
+        )
+        jsonschema.validate(instance=inst, schema=_load_schema())  # must not raise
+
+    def test_guest_required(self):
+        inst = _base(publishedPorts=[{"host": 8080}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=inst, schema=_load_schema())
+
+    @pytest.mark.parametrize("bad", [0, 65536, -1])
+    def test_guest_out_of_range_rejected(self, bad):
+        inst = _base(publishedPorts=[{"guest": bad}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=inst, schema=_load_schema())
+
+    def test_bad_protocol_rejected(self):
+        inst = _base(publishedPorts=[{"guest": 80, "protocol": "sctp"}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=inst, schema=_load_schema())
+
+    def test_bad_name_charset_rejected(self):
+        inst = _base(publishedPorts=[{"guest": 80, "name": "bad name!"}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=inst, schema=_load_schema())
+
+    def test_additional_property_on_entry_rejected(self):
+        inst = _base(publishedPorts=[{"guest": 80, "container": 80}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=inst, schema=_load_schema())
+
+
+# --- schema-level: commands[].background -------------------------------------
+
+
+class TestBackgroundSchema:
+    def test_background_true_accepted(self):
+        inst = _base(commands=[{"phase": "startup", "command": ["sh"], "background": True}])
+        jsonschema.validate(instance=inst, schema=_load_schema())  # must not raise
+
+    def test_background_absent_accepted(self):
+        inst = _base(commands=[{"phase": "startup", "command": ["sh"]}])
+        jsonschema.validate(instance=inst, schema=_load_schema())
+
+    def test_background_non_boolean_rejected(self):
+        inst = _base(commands=[{"phase": "startup", "command": ["sh"], "background": "yes"}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=inst, schema=_load_schema())
+
+
+# --- validate_kit field-level enforcement ------------------------------------
+
+
+class TestValidateKitPortsAndBackground:
+    def test_valid_kit_has_no_errors(self, tmp_path):
+        validate_kit = _load_validate_kit()
+        kit = _write_kit(
+            tmp_path / "portkit",
+            "schemaVersion: hybrid/v1\n"
+            "kind: mixin\n"
+            "name: portkit\n"
+            "displayName: Port\n"
+            "description: d\n"
+            "publishedPorts:\n"
+            "  - guest: 4096\n"
+            "    protocol: tcp\n"
+            "    name: opencode-server\n"
+            "  - guest: 3000\n"
+            "commands:\n"
+            "  - phase: startup\n"
+            '    command: ["sh", "-c", "loop &"]\n'
+            "    background: true\n",
+        )
+        errors, _warnings = validate_kit(kit, _load_schema())
+        assert errors == [], errors
+
+    def test_flags_out_of_range_guest(self, tmp_path):
+        validate_kit = _load_validate_kit()
+        kit = _write_kit(
+            tmp_path / "badport",
+            "schemaVersion: hybrid/v1\n"
+            "kind: mixin\n"
+            "name: badport\n"
+            "displayName: Bad\n"
+            "description: d\n"
+            "publishedPorts:\n"
+            "  - guest: 99999\n",
+        )
+        errors, _warnings = validate_kit(kit, _load_schema())
+        assert any("guest must be an integer 1..65535" in e for e in errors), errors
+
+    def test_flags_bad_protocol_and_name(self, tmp_path):
+        validate_kit = _load_validate_kit()
+        kit = _write_kit(
+            tmp_path / "badproto",
+            "schemaVersion: hybrid/v1\n"
+            "kind: mixin\n"
+            "name: badproto\n"
+            "displayName: Bad\n"
+            "description: d\n"
+            "publishedPorts:\n"
+            "  - guest: 80\n"
+            "    protocol: sctp\n"
+            '    name: "bad name!"\n',
+        )
+        errors, _warnings = validate_kit(kit, _load_schema())
+        assert any("protocol must be one of" in e for e in errors), errors
+        assert any("name has an unsafe or invalid value" in e for e in errors), errors
+
+    def test_flags_non_boolean_background(self, tmp_path):
+        validate_kit = _load_validate_kit()
+        kit = _write_kit(
+            tmp_path / "badbg",
+            "schemaVersion: hybrid/v1\n"
+            "kind: mixin\n"
+            "name: badbg\n"
+            "displayName: Bad\n"
+            "description: d\n"
+            "commands:\n"
+            "  - phase: startup\n"
+            '    command: ["sh"]\n'
+            '    background: "yes"\n',
+        )
+        errors, _warnings = validate_kit(kit, _load_schema())
+        assert any("background must be a boolean" in e for e in errors), errors


### PR DESCRIPTION
## Summary

Adds two neutral fields to the `hybrid/v1` kit vocabulary so a kit can express port publishing and a background startup command once, backend-neutrally: top-level `publishedPorts[]` and a `background` boolean on `commands[]` items. Enforced in `validate-kits.py` with field-level validation and tests. This is the schema half of the acq wrapper's ADR-0014 (the quickstart consumer reads these fields defensively and lights up once this lands + releases).

## What changed

- **`schemas/kit-hybrid-v1.schema.json`**
  - `publishedPorts[]` (optional, top-level): each entry `additionalProperties:false`, `required:[guest]`; `guest` (int 1–65535), `host` (optional int 1–65535; defaults to guest), `protocol` (enum `tcp`/`udp`, default `tcp`), `name` (`^[A-Za-z0-9._-]{1,64}$`).
  - `background` (optional boolean, default `false`) on each `commands[]` item, preserving the item's existing `additionalProperties:false`.
- **`integrations/isolation/acq-kits/validate-kits.py`** — field-level enforcement mirroring the existing defense-in-depth style: integer range (booleans rejected), protocol enum, name charset, `background` boolean; per-entry error messages.
- **`scripts/tests/test_validate_kits_ports.py`** — valid + invalid cases for each rule.

## Test plan

- Schema is well-formed JSON and meta-valid (Draft 2020-12).
- `validate-kits.py --root .` passes on all existing kits (no regression); `openchamber/spec.yaml` intentionally **not** migrated off `backend_extras.sbx` (that's the acq consumer's follow-up).
- New test module: 16 cases pass; existing injection suite: 7 pass. (Note: run under a stdlib shim locally since `pytest` wasn't installed in the dev sandbox; CI runs `pytest scripts/tests/`.)

## Related

- Consumed by quickstart ADR-0014 / quickstart#224 (neutral port-publish + background consumer)
- Dovetails with #225 here (validate-kits field validation)
- Unblocks quickstart#233-style `backends: [sbx, msb]` once released + pinned

AI-assisted (OpenCode); requires human review.
