### PR TITLE
docs: remove internal Slack references for public readiness (#288)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Slack Channel
-    url: https://gsa.enterprise.slack.com/archives/C0B44531QLE
-    about: For quick questions and real-time discussion, ask in the agentic-coding Slack channel
   - name: Agentic Coding Quickstart
     url: https://github.com/GSA-TTS/agentic-coding-quickstart
     about: For environment setup, SBX configuration, and getting started

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ This repo is one of three in the agentic coding ecosystem:
 
 ## Getting Help
 
-- **Questions:** Ask in the agentic-coding Slack channel
+- **Questions:** Open a GitHub issue or start a discussion
 - **Bugs/improvements:** Open a GitHub issue or submit a PR
 - **Security issues:** See [SECURITY.md](SECURITY.md) — direct fixes preferred
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ This repository is released under [CC0-1.0](LICENSE) (public domain). Content is
 
 ## Getting Help
 
-- **Questions:** Ask in the agentic-coding Slack channel
+- **Questions:** Open a GitHub issue or start a discussion
 - **Browse docs:** See [docs/](docs/) for guides
 - **Improvement ideas:** Open an issue or submit a PR
 - **Relationship to other repos:** See [docs/repository-ecosystem.md](docs/repository-ecosystem.md)


### PR DESCRIPTION
## Summary

Public-readiness blocker (epic #291, closes #288). Removes the internal GSA Slack workspace URL and "agentic-coding Slack channel" pointers from public-facing files — external contributors can't access them and they leak internal org topology.

## Changes (docs-only)

- `.github/ISSUE_TEMPLATE/config.yml` — drop the Slack `contact_link` (keep sibling-repo links)
- `README.md` — "Questions" → open a GitHub issue
- `CONTRIBUTING.md` — "Questions" → open a GitHub issue

## Verification

`config.yml` YAML valid; 0 residual internal-Slack references.

Closes #288.

AI-assisted (OpenCode); requires human review.