### PR TITLE
chore(deps): bump js-yaml to 4.3.1 in .github/linters (CVE-2026-59870)

### DIFF
--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/.github/linters/package.json
+++ b/.github/linters/package.json
@@ -10,7 +10,7 @@
     "markdownlint-cli2": "0.22.1"
   },
   "overrides": {
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "markdown-it": "14.2.0",
     "linkify-it": "5.0.2"
   }


### PR DESCRIPTION
## Summary

The Markdown Lint CI job (`npm ci && npm audit --audit-level=moderate` in `.github/linters`) fails on **GHSA-5p4m-2wfm-xmqj / CVE-2026-59870** — js-yaml quadratic CPU consumption in `!!omap` resolution, not backported to 4.x below 4.3.1. This currently **blocks Markdown Lint on every PR** in this now-public repo (e.g. #297).

## Change

- `.github/linters/package.json` — `js-yaml` override `4.3.0` → `4.3.1`.
- `.github/linters/package-lock.json` — regenerated via `npm install --package-lock-only` (integrity + license metadata correct, not hand-edited).

## Verification

- `npm audit --audit-level=moderate` → **found 0 vulnerabilities** (was failing).
- `markdownlint-cli2` still clean.
- Same fix mogul applied on the quickstart side in GSA-TTS/agentic-coding-quickstart#286.

Unblocks Markdown Lint CI (incl. #297).

AI-assisted (OpenCode); requires human review.