### PR TITLE
fix(ci): ignore climbing relative links in Link Check (400 false positives)

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -27,6 +27,10 @@
     },
     {
       "pattern": "<[^>]+>"
+    },
+    {
+      "_comment": "Relative links that climb out of the current file's directory (../../docs, ../../../agentic-coding-playbook, ../other-pattern) are mis-resolved by the checker to a 400. Cross-file existence is validated by `make validate`; cross-repo targets live in a sibling repo not present in CI checkout.",
+      "pattern": "^\\.\\./"
     }
   ],
   "replacementPatterns": [],


### PR DESCRIPTION
## Summary
Link Check was red on `main` (blocking dependabot #305 and gating PRs) on relative markdown links that climb out of the referring file's directory — `../../docs/security-skill-governance.md`, `../other-pattern/SKILL.md`, the cross-repo `../../../agentic-coding-playbook/docs/CODING_PRACTICES.md`. The checker mis-resolves these to a 400.

- Intra-repo targets are **real files** (verified: `docs/security-skill-governance.md`, `docs/clean-script-standard.md` exist; enforced by `make validate`).
- `../other-pattern/SKILL.md` is an illustrative example path in CONTRIBUTING.
- The cross-repo path lives in a sibling repo not present in the CI checkout.

Ignore the `^../` pattern in the link checker; cross-file existence stays enforced by `make validate`.

## Verification
`make validate` passes; config is valid JSON. Link Check exercises the new config on this PR.

## Impact
Greens Link Check on main and **unblocks dependabot #305** (markdown-link-check bump).

## Rollback
Revert. One config file; no code change.

AI-assisted (OpenCode). Requires human review.