### PR TITLE
feat(network-tiers): balanced baseline allowlist + deterministic additions guard (#301, #302)

### DIFF
--- a/integrations/isolation/network-tiers/balanced.yaml
+++ b/integrations/isolation/network-tiers/balanced.yaml
@@ -1,0 +1,261 @@
+# balanced.yaml — curated baseline egress allowlist for the `balanced` network tier
+#
+# STATUS: PROPOSED — pending CODEOWNERS + security-skill review (#301).
+# An agent may PROPOSE entries here; it MUST NOT self-approve. The contents of a
+# federally-shipped default egress allowlist are a human decision.
+#
+# WHAT THIS IS
+#   The neutral, version-controlled source of truth for what the `balanced`
+#   network tier (schemas/kit-hybrid-v1.schema.json `caps.network.tier`) allows,
+#   BEFORE any per-kit `caps.network.allow` or per-sandbox additions. All tiers
+#   are deny-by-default; `balanced` = this baseline ∪ kit allow ∪ sandbox
+#   additions. `strict` uses none of this baseline; `open` ignores it (all
+#   egress). See ADR 0002 (integrations/isolation/docs/decisions).
+#
+#   Pinned in-repo (no runtime fetch): consumers read this at a full-SHA
+#   PATTERNS_KIT_REF, same as every other kit artifact.
+#
+# CORE vs EXTENDED (the deny-by-default judgment)
+#   `core`     — the minimal, vouched-safe set SHIPPED as the `balanced`
+#                default: language/package registries, first-party AI model
+#                APIs, the source-host + container-registry family, OS package
+#                mirrors, and certificate validation (CRL/OCSP). Every entry is
+#                one we vouch a prompt-injectable agent may reach by default.
+#   `extended` — dev-convenience SaaS hosts (design tools, app-platform/BaaS,
+#                third-party AI IDEs). NOT shipped in the default `balanced`
+#                baseline — a wider exfiltration surface than a federal default
+#                should carry. Available as a documented opt-in (a deployment
+#                may include `extended` explicitly). Kept here, justified, so the
+#                decision is auditable rather than silently dropped.
+#
+# ENTRY FORMAT
+#   host[:port]  — port defaults to 443; :80 is used only for plaintext CRL/OCSP.
+#   Wildcards mirror the sbx `balanced` policy and translate per ADR-0018:
+#     `**.h` / `*.h`  -> backend domain-suffix match (apex + any depth)
+#     `crl*.digicert.com` -> intra-label glob; msb cannot express it, so the
+#        adapter BROADENS it to `*.digicert.com` and logs the widened match.
+#   Each entry carries `why` — a one-line justification for review + pruning.
+#
+# RE-SYNC / PROVENANCE
+#   Seeded from quickstart `acq.backends/msb-balanced-hosts.txt`, itself a
+#   verbatim mirror of `sbx policy inspect local-policy`. Re-verify on the
+#   quarterly cadence: diff that mirror's network-allow rows against `core` +
+#   `extended` here and reconcile (a host present in the mirror but absent here
+#   was a deliberate curation choice — keep the `why`/exclusion note).
+
+version: "1.0"
+tier: balanced
+
+core:
+  # --- Language & package registries (toolchain fetch; core to any build) ---
+  - { host: "npmjs.org", why: "npm registry (apex)" }
+  - { host: "npmjs.com", why: "npm registry (web/apex)" }
+  - { host: "registry.npmjs.org", why: "npm package registry API" }
+  - { host: "npm.duckdb.org", why: "DuckDB npm distribution" }
+  - { host: "**.yarnpkg.com", why: "Yarn registry/CDN" }
+  - { host: "yarnpkg.com", why: "Yarn (apex)" }
+  - { host: "**.bun.sh", why: "Bun runtime + registry" }
+  - { host: "bun.sh", why: "Bun (apex)" }
+  - { host: "pypi.org", why: "Python Package Index" }
+  - { host: "pypi.python.org", why: "PyPI legacy host" }
+  - { host: "files.pythonhosted.org", why: "PyPI package files CDN" }
+  - { host: "pythonhosted.org", why: "PyPI package files (apex)" }
+  - { host: "bootstrap.pypa.io", why: "pip/get-pip bootstrap" }
+  - { host: "pypa.io", why: "Python Packaging Authority (apex)" }
+  - { host: "astral.sh", why: "uv / ruff distribution (Astral)" }
+  - { host: "crates.io", why: "Rust crate registry" }
+  - { host: "index.crates.io", why: "Rust crate index" }
+  - { host: "static.crates.io", why: "Rust crate downloads" }
+  - { host: "rustup.rs", why: "Rust toolchain installer" }
+  - { host: "sh.rustup.rs", why: "rustup install script" }
+  - { host: "static.rust-lang.org", why: "Rust toolchain artifacts" }
+  - { host: "proxy.golang.org", why: "Go module proxy" }
+  - { host: "sum.golang.org", why: "Go checksum database" }
+  - { host: "goproxy.io", why: "Go module proxy (mirror)" }
+  - { host: "pkg.go.dev", why: "Go package index" }
+  - { host: "golang.org", why: "Go project + module redirects" }
+  - { host: "rubygems.org", why: "Ruby gem registry" }
+  - { host: "ruby-lang.org", why: "Ruby distribution" }
+  - { host: "rubyonrails.org", why: "Rails distribution" }
+  - { host: "rvm.io", why: "Ruby Version Manager" }
+  - { host: "hex.pm", why: "Elixir/Erlang package registry" }
+  - { host: "nuget.org", why: ".NET package registry" }
+  - { host: "dot.net", why: ".NET installer redirects" }
+  - { host: "dotnet.microsoft.com", why: ".NET SDK downloads" }
+  - { host: "maven.org", why: "Maven Central (apex)" }
+  - { host: "repo.maven.apache.org", why: "Maven Central repository" }
+  - { host: "**.gradle.org", why: "Gradle distribution/plugins" }
+  - { host: "gradle.org", why: "Gradle (apex)" }
+  - { host: "spring.io", why: "Spring dependency metadata" }
+  - { host: "**.packagist.org", why: "PHP Composer registry" }
+  - { host: "packagist.org", why: "Composer registry (apex)" }
+  - { host: "packagist.com", why: "Composer registry (com)" }
+  - { host: "cpan.org", why: "Perl CPAN" }
+  - { host: "metacpan.org", why: "Perl CPAN metadata" }
+  - { host: "pub.dev", why: "Dart/Flutter package registry" }
+  - { host: "swift.org", why: "Swift toolchain" }
+  - { host: "cocoapods.org", why: "CocoaPods (iOS) registry" }
+  - { host: "haskell.org", why: "Haskell toolchain" }
+  - { host: "ziglang.org", why: "Zig toolchain" }
+  - { host: "nodejs.org", why: "Node.js runtime downloads" }
+  - { host: "nodesource.com", why: "NodeSource Node.js distribution" }
+  - { host: "apache.org", why: "Apache project source/dependency host" }
+  - { host: "eclipse.org", why: "Eclipse/Java tooling" }
+  - { host: "java.com", why: "Java runtime downloads" }
+  - { host: "java.net", why: "Java project host" }
+  - { host: "mise.run", why: "mise (dev tool version manager) install" }
+  - { host: "mise-versions.jdx.dev", why: "mise tool version index" }
+  - { host: "tuf-repo-cdn.sigstore.dev", why: "Sigstore TUF root (supply-chain verify)" }
+
+  # --- First-party AI / model APIs (the agent's own model backends) ---
+  - { host: "api.anthropic.com", why: "Anthropic API" }
+  - { host: "claude.com", why: "Anthropic Claude" }
+  - { host: "platform.claude.com", why: "Anthropic platform" }
+  - { host: "downloads.claude.ai", why: "Claude client downloads" }
+  - { host: "mcp-proxy.anthropic.com", why: "Anthropic MCP proxy" }
+  - { host: "statsig.anthropic.com", why: "Anthropic client telemetry/config" }
+  - { host: "**.openai.com", why: "OpenAI API + subdomains" }
+  - { host: "**.oaistatic.com", why: "OpenAI static assets" }
+  - { host: "**.oaiusercontent.com", why: "OpenAI user content" }
+  - { host: "cdn.openaimerge.com", why: "OpenAI CDN" }
+  - { host: "generativelanguage.googleapis.com", why: "Google Gemini API" }
+  - { host: "gemini.google.com", why: "Google Gemini" }
+  - { host: "models.dev", why: "models.dev catalog (used by the usai-provider kit)" }
+
+  # --- Source hosts & container registries ---
+  - { host: "**.github.com", why: "GitHub + subdomains (git/API)" }
+  - { host: "github.com", why: "GitHub (apex)" }
+  - { host: "**.githubusercontent.com", why: "GitHub raw/user content + codeload" }
+  - { host: "**.githubcopilot.com", why: "GitHub Copilot API" }
+  - { host: "**.gitlab.com", why: "GitLab + subdomains" }
+  - { host: "gitlab.com", why: "GitLab (apex)" }
+  - { host: "bitbucket.org", why: "Bitbucket source host" }
+  - { host: "sourceforge.net", why: "SourceForge source/release host" }
+  - { host: "launchpad.net", why: "Launchpad source/PPA host" }
+  - { host: "**.docker.io", why: "Docker Hub registry" }
+  - { host: "docker.io", why: "Docker Hub (apex)" }
+  - { host: "**.docker.com", why: "Docker services + subdomains" }
+  - { host: "docker.com", why: "Docker (apex)" }
+  - { host: "**.production.cloudflare.docker.com", why: "Docker Hub blob CDN (Cloudflare)" }
+  - { host: "**.production.cloudfront.docker.com", why: "Docker Hub blob CDN (CloudFront)" }
+  - { host: "production.cloudflare.docker.com", why: "Docker Hub blob CDN (apex)" }
+  - { host: "production.cloudfront.docker.com", why: "Docker Hub blob CDN (apex)" }
+  - { host: "docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com", why: "Docker Hub image blobs (R2)" }
+  - { host: "**.gcr.io", why: "Google Container Registry" }
+  - { host: "gcr.io", why: "GCR (apex)" }
+  - { host: "ghcr.io", why: "GitHub Container Registry" }
+  - { host: "quay.io", why: "Quay container registry" }
+  - { host: "public.ecr.aws", why: "AWS public ECR" }
+  - { host: "mcr.microsoft.com", why: "Microsoft Container Registry" }
+  - { host: "**.data.mcr.microsoft.com", why: "MCR image data CDN" }
+  - { host: "registry.k8s.io", why: "Kubernetes image registry" }
+  - { host: "k8s.io", why: "Kubernetes project redirects" }
+  - { host: "dhi.io", why: "Docker Hardened Images registry" }
+  - { host: "dhi.io:80", why: "Docker Hardened Images (plaintext redirect)" }
+
+  # --- OS package mirrors ---
+  - { host: "**.debian.org", why: "Debian mirrors + subdomains" }
+  - { host: "debian.org", why: "Debian (apex)" }
+  - { host: "ubuntu.com", why: "Ubuntu" }
+  - { host: "archive.ubuntu.com", why: "Ubuntu package archive" }
+  - { host: "archive.ubuntu.com:80", why: "Ubuntu archive (apt plaintext)" }
+  - { host: "security.ubuntu.com", why: "Ubuntu security updates" }
+  - { host: "security.ubuntu.com:80", why: "Ubuntu security (apt plaintext)" }
+  - { host: "ports.ubuntu.com", why: "Ubuntu ports (non-amd64)" }
+  - { host: "ports.ubuntu.com:80", why: "Ubuntu ports (apt plaintext)" }
+  - { host: "alpinelinux.org", why: "Alpine Linux" }
+  - { host: "dl-cdn.alpinelinux.org", why: "Alpine package CDN" }
+  - { host: "archlinux.org", why: "Arch Linux" }
+  - { host: "centos.org", why: "CentOS" }
+  - { host: "fedoraproject.org", why: "Fedora" }
+  - { host: "apt.llvm.org", why: "LLVM apt repository" }
+  - { host: "ppa.launchpad.net", why: "Ubuntu PPA package host" }
+  - { host: "packagecloud.io", why: "packagecloud OS package hosting" }
+  - { host: "packages.microsoft.com", why: "Microsoft apt/yum repositories" }
+
+  # --- Certificate validation (CRL / OCSP; :80 is required, plaintext by spec) ---
+  - { host: "**.amazontrust.com", why: "Amazon Trust CA chain" }
+  - { host: "**.amazontrust.com:80", why: "Amazon Trust CRL/OCSP (plaintext)" }
+  - { host: "**.lencr.org", why: "Let's Encrypt CA" }
+  - { host: "**.lencr.org:80", why: "Let's Encrypt CRL/OCSP (plaintext)" }
+  - { host: "**.pki.goog", why: "Google Trust Services CA" }
+  - { host: "**.pki.goog:80", why: "Google PKI CRL/OCSP (plaintext)" }
+  - { host: "**.pki.microsoft.com", why: "Microsoft PKI CA" }
+  - { host: "**.pki.microsoft.com:80", why: "Microsoft PKI CRL/OCSP (plaintext)" }
+  - { host: "*.one.digicert.com:80", why: "DigiCert OCSP (plaintext)" }
+  - { host: "*.one.au.digicert.com:80", why: "DigiCert OCSP AU (plaintext)" }
+  - { host: "*.one.ch.digicert.com:80", why: "DigiCert OCSP CH (plaintext)" }
+  - { host: "*.one.digicert.co.jp:80", why: "DigiCert OCSP JP (plaintext)" }
+  - { host: "*.one.nl.digicert.com:80", why: "DigiCert OCSP NL (plaintext)" }
+  - { host: "cacerts.digicert.com:80", why: "DigiCert intermediate certs (plaintext)" }
+  - { host: "crl*.digicert.com:80", why: "DigiCert CRL (plaintext; msb broadens to *.digicert.com — logged)" }
+  - { host: "ocsp.digicert.com:80", why: "DigiCert OCSP (plaintext)" }
+  - { host: "crl.comodoca.com:80", why: "Comodo/Sectigo CRL (plaintext)" }
+  - { host: "ocsp.comodoca.com:80", why: "Comodo/Sectigo OCSP (plaintext)" }
+  - { host: "crl.sectigo.com:80", why: "Sectigo CRL (plaintext)" }
+  - { host: "crt.sectigo.com:80", why: "Sectigo intermediate certs (plaintext)" }
+  - { host: "ocsp.sectigo.com:80", why: "Sectigo OCSP (plaintext)" }
+  - { host: "crl.usertrust.com:80", why: "USERTrust CRL (plaintext)" }
+  - { host: "ocsp.usertrust.com:80", why: "USERTrust OCSP (plaintext)" }
+  - { host: "crl.globalsign.com:80", why: "GlobalSign CRL (plaintext)" }
+  - { host: "crl.globalsign.net:80", why: "GlobalSign CRL (plaintext)" }
+  - { host: "ocsp.globalsign.com:80", why: "GlobalSign OCSP (plaintext)" }
+  - { host: "ocsp.globalsign.com", why: "GlobalSign OCSP (TLS)" }
+  - { host: "ocsp2.globalsign.com:80", why: "GlobalSign OCSP secondary (plaintext)" }
+  - { host: "ocsp2.globalsign.com", why: "GlobalSign OCSP secondary (TLS)" }
+  - { host: "isrg.trustid.ocsp.identrust.com:80", why: "IdenTrust OCSP for ISRG root (plaintext)" }
+
+# EXTENDED — opt-in only; NOT part of the shipped `balanced` default (#301).
+# These are dev-convenience SaaS hosts a prompt-injectable agent does not need by
+# default and that widen the exfiltration surface. A deployment may opt in
+# explicitly. Kept here, justified, so the exclusion is auditable — not silently
+# dropped from the sbx-balanced mirror.
+extended:
+  # Design / collaboration SaaS
+  - { host: "figma.com", why: "Figma design assets (opt-in: not core toolchain)" }
+  # App platform / backend-as-a-service (broad egress; opt-in)
+  - { host: "supabase.com", why: "Supabase BaaS (opt-in)" }
+  - { host: "vercel.com", why: "Vercel deploy platform (opt-in)" }
+  - { host: "**.public.blob.vercel-storage.com", why: "Vercel blob storage (opt-in)" }
+  - { host: "clerk.com", why: "Clerk auth SaaS (opt-in)" }
+  - { host: "app.daytona.io", why: "Daytona dev-environment SaaS (opt-in)" }
+  - { host: "binaries.prisma.sh", why: "Prisma engine binaries (opt-in; ORM-specific)" }
+  # Third-party AI IDEs / assistants (not USAi/first-party; opt-in)
+  - { host: "**.cursor.sh", why: "Cursor IDE (third-party AI IDE; opt-in)" }
+  - { host: "cursor.com", why: "Cursor IDE (opt-in)" }
+  - { host: "**.factory.ai", why: "Factory AI IDE (opt-in)" }
+  - { host: "factory.ai", why: "Factory AI (opt-in)" }
+  - { host: "**.chatgpt.com", why: "ChatGPT web app (opt-in; not the API)" }
+  - { host: "chatgpt.com", why: "ChatGPT web (opt-in)" }
+  - { host: "api.perplexity.ai", why: "Perplexity API (opt-in)" }
+  - { host: "api.workos.com", why: "WorkOS auth (opt-in)" }
+  # General cloud/CDN convenience (broad; opt-in). These wildcard cloud
+  # providers are an especially wide surface for a default agent egress.
+  - { host: "**.amazonaws.com", why: "AWS services (very broad; opt-in)" }
+  - { host: "**.blob.core.windows.net", why: "Azure blob storage (broad; opt-in)" }
+  - { host: "**.googleapis.com", why: "Google APIs (very broad; opt-in — first-party model API is in core)" }
+  - { host: "**.googleusercontent.com", why: "Google user content (broad; opt-in)" }
+  - { host: "**.gstatic.com", why: "Google static assets (opt-in)" }
+  - { host: "**.gvt1.com", why: "Google downloads (opt-in)" }
+  - { host: "**.visualstudio.com", why: "Azure DevOps / VS services (opt-in)" }
+  - { host: "**.hashicorp.com", why: "HashiCorp releases (opt-in)" }
+  - { host: "hashicorp.com", why: "HashiCorp (apex; opt-in)" }
+  - { host: "apis.google.com", why: "Google APIs frontend (opt-in)" }
+  - { host: "play.google.com", why: "Google Play (opt-in)" }
+  - { host: "play.googleapis.com", why: "Google Play services (opt-in)" }
+  - { host: "dl.google.com", why: "Google downloads (opt-in)" }
+  - { host: "www.google.com", why: "Google (opt-in)" }
+  - { host: "csp.withgoogle.com", why: "Google CSP reporting (opt-in)" }
+  - { host: "challenges.cloudflare.com", why: "Cloudflare Turnstile (opt-in)" }
+  - { host: "fastly.com", why: "Fastly CDN (opt-in)" }
+  - { host: "jsdelivr.net", why: "jsDelivr CDN (opt-in)" }
+  - { host: "unpkg.com", why: "unpkg CDN (opt-in)" }
+  - { host: "json-schema.org", why: "JSON Schema meta-schemas (opt-in)" }
+  - { host: "json.schemastore.org", why: "SchemaStore (opt-in)" }
+  - { host: "azure.com", why: "Azure (apex; opt-in)" }
+  - { host: "dev.azure.com", why: "Azure DevOps (opt-in)" }
+  - { host: "login.microsoftonline.com", why: "Microsoft Entra login (opt-in)" }
+  - { host: "code.visualstudio.com", why: "VS Code updates/extensions (opt-in)" }
+  - { host: "vscode.dev", why: "VS Code web (opt-in)" }
+  - { host: "vscode.download.prss.microsoft.com", why: "VS Code download CDN (opt-in)" }
+  - { host: "playwright.azureedge.net", why: "Playwright browser downloads (opt-in)" }

--- a/integrations/isolation/network-tiers/balanced.yaml
+++ b/integrations/isolation/network-tiers/balanced.yaml
@@ -4,6 +4,15 @@
 # An agent may PROPOSE entries here; it MUST NOT self-approve. The contents of a
 # federally-shipped default egress allowlist are a human decision.
 #
+# ADDING A HOST: `scripts/check_balanced_allowlist_additions.py` (run by
+# `make validate` / CI, #302) is a deterministic, offline risk lint over these
+# hosts — it ERRORS on a raw-IP or public-suffix wildcard and WARNS on punycode,
+# risky TLDs, deep nesting, or unexpected plaintext :80, so a reviewer sees the
+# signal on the PR. It is NOT a runtime blocklist and makes NO network call
+# (a live reputation feed was consensus-rejected as over-engineering + a federal
+# data-sharing concern for a hand-curated list). The lint is an aid; the actual
+# authority for an addition is the per-host `why` + CODEOWNERS/security review.
+#
 # WHAT THIS IS
 #   The neutral, version-controlled source of truth for what the `balanced`
 #   network tier (schemas/kit-hybrid-v1.schema.json `caps.network.tier`) allows,

--- a/schemas/network-tier-baseline-v1.schema.json
+++ b/schemas/network-tier-baseline-v1.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GSA-TTS/agentic-coding-patterns/schemas/network-tier-baseline-v1.schema.json",
+  "title": "Network-tier baseline egress allowlist (balanced)",
+  "description": "Curated, version-controlled baseline egress allowlist for the `balanced` network tier (#301, ADR 0002). `core` ships as the balanced default; `extended` is opt-in. Every entry carries a `why` justification. No runtime fetch — pinned in-repo.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "tier", "core"],
+  "properties": {
+    "version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$" },
+    "tier": { "type": "string", "const": "balanced" },
+    "core": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/entry" },
+      "description": "The minimal, vouched-safe set SHIPPED as the balanced default."
+    },
+    "extended": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/entry" },
+      "description": "Opt-in dev-convenience hosts; NOT shipped in the default balanced baseline."
+    }
+  },
+  "$defs": {
+    "entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["host", "why"],
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Hostname, optionally with :port (default 443). Charset is DNS labels plus a leading `**.`/`*.` wildcard and an intra-label `*` (e.g. crl*.digicert.com); optional :NNNNN port.",
+          "pattern": "^(\\*\\*\\.|\\*\\.)?([A-Za-z0-9_*-]+\\.)*[A-Za-z0-9_*-]+(:[0-9]{1,5})?$",
+          "minLength": 1
+        },
+        "why": {
+          "type": "string",
+          "minLength": 3,
+          "description": "One-line justification for review and future pruning."
+        }
+      }
+    }
+  }
+}

--- a/scripts/check_balanced_allowlist_additions.py
+++ b/scripts/check_balanced_allowlist_additions.py
@@ -50,15 +50,11 @@ DATA = ROOT / "integrations" / "isolation" / "network-tiers" / "balanced.yaml"
 
 # TLDs disproportionately associated with abuse / not expected in a federal
 # toolchain allowlist. Not exhaustive — a signal for the reviewer, not a verdict.
-_RISKY_TLDS = frozenset(
-    {"zip", "mov", "xyz", "top", "click", "link", "gq", "tk", "ml", "cf", "ga", "cn", "ru", "su"}
-)
+_RISKY_TLDS = frozenset({"zip", "mov", "xyz", "top", "click", "link", "gq", "tk", "ml", "cf", "ga", "cn", "ru", "su"})
 # Public-suffix-ish single labels: a wildcard directly on one of these opens a
 # whole TLD/registry. (A wildcard on a normal registrable domain like
 # `**.github.com` is fine — that's the intended use.)
-_PUBLIC_SUFFIXES = frozenset(
-    {"com", "org", "net", "io", "dev", "gov", "edu", "co", "us", "app", "sh", "ai", "cloud"}
-)
+_PUBLIC_SUFFIXES = frozenset({"com", "org", "net", "io", "dev", "gov", "edu", "co", "us", "app", "sh", "ai", "cloud"})
 # Hosts legitimately reached over plaintext :80 (CRL/OCSP/cert distribution must
 # be HTTP per the CA/Browser Forum — TLS on a revocation endpoint is circular),
 # plus OS package mirrors that serve apt/dnf metadata over :80 by design (the

--- a/scripts/check_balanced_allowlist_additions.py
+++ b/scripts/check_balanced_allowlist_additions.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Additions guard for the network-tier `balanced` baseline allowlist (#302).
+
+A DETERMINISTIC, offline, in-repo lint that surfaces review-worthy signals about
+the hosts in `integrations/isolation/network-tiers/balanced.yaml`. It runs the
+same whether in CI or locally — no network call, no reputation API, no secret,
+no flakiness (a multi-model consensus rejected a live reputation feed as
+over-engineering + a federal data-sharing concern for a hand-curated ~150-entry
+list that already requires a `why` justification + CODEOWNERS review; see the
+issue thread and ADR 0002).
+
+It emits WARNINGS (advisory, for the human/CODEOWNERS reviewer) for hosts that
+match risk heuristics, and ERRORS only for a genuinely unsafe shape that should
+never ship. Because it audits the whole file each run, a NEWLY ADDED risky host
+is exactly what a PR surfaces — while the existing curated entries stay quiet.
+
+Heuristics (pure functions of the host string):
+  WARN  - IDN / punycode `xn--` label (homograph risk) — decode + note.
+  WARN  - uncommon / risk-associated TLD (see _RISKY_TLDS).
+  WARN  - deep subdomain nesting (> 4 labels) — unusually specific.
+  WARN  - plaintext :80 on a host that is NOT a known CRL/OCSP/cert or OS-mirror
+          endpoint.
+  ERROR - wildcard breadth: a public-suffix-level wildcard (`*.com`, `**.io`)
+          — one entry that opens an entire TLD is never acceptable.
+  ERROR - raw IPv4/IPv6 literal (allowlist is by hostname; an IP bypasses
+          name-based egress intent and is unauditable).
+
+A typosquat/edit-distance heuristic was deliberately NOT included: on a
+co-curated allowlist, legitimate sibling brands (github.com/gitlab.com,
+docker.io/docker.com) sit within a small edit distance and would fire every run,
+training reviewers to ignore the guard. "Is this host what it claims to be" is
+the job of the per-host `why` + CODEOWNERS review, not a distance metric against
+the list itself (see the #302 consensus thread).
+
+Exit 0 when there are no ERRORS (warnings alone do not fail — they defer to
+review). Exit 1 on any ERROR. Dependency-free (stdlib + PyYAML).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "integrations" / "isolation" / "network-tiers" / "balanced.yaml"
+
+# TLDs disproportionately associated with abuse / not expected in a federal
+# toolchain allowlist. Not exhaustive — a signal for the reviewer, not a verdict.
+_RISKY_TLDS = frozenset(
+    {"zip", "mov", "xyz", "top", "click", "link", "gq", "tk", "ml", "cf", "ga", "cn", "ru", "su"}
+)
+# Public-suffix-ish single labels: a wildcard directly on one of these opens a
+# whole TLD/registry. (A wildcard on a normal registrable domain like
+# `**.github.com` is fine — that's the intended use.)
+_PUBLIC_SUFFIXES = frozenset(
+    {"com", "org", "net", "io", "dev", "gov", "edu", "co", "us", "app", "sh", "ai", "cloud"}
+)
+# Hosts legitimately reached over plaintext :80 (CRL/OCSP/cert distribution must
+# be HTTP per the CA/Browser Forum — TLS on a revocation endpoint is circular),
+# plus OS package mirrors that serve apt/dnf metadata over :80 by design (the
+# packages are signed; the transport need not be TLS).
+_CERT_HINT = re.compile(
+    r"(?:^|\.)(crl\d*|ocsp\d*|cacerts?|crt|pki|digicert|sectigo|comodoca|globalsign|"
+    r"usertrust|identrust|amazontrust|lencr|isrg)\b",
+    re.IGNORECASE,
+)
+_OS_MIRROR_HINT = re.compile(r"(?:^|\.)(ubuntu|debian|alpinelinux|archlinux|fedora|centos|dhi)\b", re.IGNORECASE)
+
+
+def _strip(host: str) -> tuple[str, int | None]:
+    """Split `host[:port]` and strip a leading `**.`/`*.` wildcard."""
+    port: int | None = None
+    if ":" in host and not host.count(":") > 1:  # host:port (not an IPv6 literal)
+        h, _, p = host.rpartition(":")
+        if p.isdigit():
+            host, port = h, int(p)
+    bare = host
+    for pre in ("**.", "*."):
+        if bare.startswith(pre):
+            bare = bare[len(pre) :]
+            break
+    return bare, port
+
+
+def _labels(bare: str) -> list[str]:
+    return [x for x in bare.split(".") if x]
+
+
+def _is_raw_ip(bare: str) -> bool:
+    try:
+        ipaddress.ip_address(bare)
+        return True
+    except ValueError:
+        return False
+
+
+def audit(data: dict) -> tuple[list[str], list[str]]:
+    """Return (errors, warnings) for every host in core + extended."""
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    hosts: list[tuple[str, str]] = []  # (group, raw host)
+    for grp in ("core", "extended"):
+        for e in data.get(grp, []) or []:
+            if isinstance(e, dict) and e.get("host"):
+                hosts.append((grp, str(e["host"])))
+
+    for grp, raw in hosts:
+        bare, port = _strip(raw)
+        labels = _labels(bare)
+
+        # ERROR: raw IP literal.
+        if _is_raw_ip(bare):
+            errors.append(f"{grp}: {raw!r} is a raw IP literal — allowlist by hostname, not IP.")
+            continue
+
+        # ERROR: wildcard directly on a public suffix (opens a whole TLD).
+        if raw.startswith(("*.", "**.")) and len(labels) == 1 and labels[0] in _PUBLIC_SUFFIXES:
+            errors.append(f"{grp}: {raw!r} is a wildcard over a public suffix — far too broad.")
+
+        # WARN: IDN / punycode homograph.
+        if "xn--" in bare:
+            try:
+                decoded = bare.encode("ascii").decode("idna")
+            except (UnicodeError, ValueError):
+                decoded = "(undecodable)"
+            warnings.append(f"{grp}: {raw!r} is an IDN/punycode host (decodes to {decoded!r}) — homograph risk.")
+
+        # WARN: uncommon/risk TLD.
+        if labels and labels[-1].lower() in _RISKY_TLDS:
+            warnings.append(f"{grp}: {raw!r} uses an uncommon/risk-associated TLD (.{labels[-1]}).")
+
+        # WARN: deep nesting.
+        if len(labels) > 4:
+            warnings.append(f"{grp}: {raw!r} has deep subdomain nesting ({len(labels)} labels).")
+
+        # WARN: plaintext :80 that isn't a cert/CRL/OCSP endpoint or an OS mirror
+        # (both legitimately serve over :80 — signed content, not TLS-dependent).
+        if port == 80 and not _CERT_HINT.search(bare) and not _OS_MIRROR_HINT.search(bare):
+            warnings.append(f"{grp}: {raw!r} is plaintext :80 but not a known CRL/OCSP/cert/OS-mirror host.")
+
+        # NOTE: a typosquat heuristic that compares each host to OTHER hosts
+        # already on the list is intentionally NOT run here. On a co-curated
+        # allowlist, legitimate sibling brands (github.com/gitlab.com,
+        # docker.io/docker.com, gcr.io/ghcr.io, rust-lang.org/ruby-lang.org) sit
+        # within a small edit distance of each other and would fire on every
+        # pass — training reviewers to ignore the guard. Typosquat detection is
+        # only meaningful against a TRUSTED reference set the added host should
+        # NOT resemble, which this list is not. The `why` justification + a
+        # CODEOWNERS review are the correct control for "is this host what it
+        # claims to be"; see the #302 consensus thread.
+
+    return errors, warnings
+
+
+def main() -> int:
+    if not DATA.is_file():
+        print(f"✗ missing {DATA.relative_to(ROOT)}")
+        return 1
+    data = yaml.safe_load(DATA.read_text()) or {}
+    errors, warnings = audit(data)
+
+    for w in warnings:
+        print(f"WARNING: {w}")
+    for e in errors:
+        print(f"ERROR: {e}")
+
+    if errors:
+        print(f"\n✗ balanced-allowlist additions guard: {len(errors)} error(s), {len(warnings)} warning(s)")
+        return 1
+    if warnings:
+        print(
+            f"\n⚠ balanced-allowlist additions guard: {len(warnings)} warning(s) for reviewer "
+            "attention (advisory — defer to CODEOWNERS + the per-host `why`)."
+        )
+    else:
+        print("✓ balanced-allowlist additions guard: no risk signals")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_balanced_allowlist_additions.py
+++ b/scripts/tests/test_check_balanced_allowlist_additions.py
@@ -1,0 +1,117 @@
+"""Tests for the balanced-allowlist additions guard (#302).
+
+Deterministic, offline heuristic lint: warnings are advisory (exit 0), errors
+fail (exit 1). Covers each heuristic + the live-file invariant (no ERRORS).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECK = ROOT / "scripts" / "check_balanced_allowlist_additions.py"
+
+
+def _mod():
+    spec = importlib.util.spec_from_file_location("cbaa", CHECK)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _audit(core=None, extended=None):
+    data = {"version": "1.0", "tier": "balanced", "core": core or [], "extended": extended or []}
+    return _mod().audit(data)
+
+
+# --- ERROR cases (fail closed) -----------------------------------------------
+
+
+def test_raw_ipv4_is_error():
+    e, _ = _audit(core=[{"host": "10.0.0.5", "why": "x"}])
+    assert any("raw IP" in x for x in e)
+
+
+def test_raw_ipv6_is_error():
+    e, _ = _audit(core=[{"host": "2606:4700:4700::1111", "why": "x"}])
+    assert any("raw IP" in x for x in e)
+
+
+def test_wildcard_over_public_suffix_is_error():
+    e, _ = _audit(core=[{"host": "**.com", "why": "x"}])
+    assert any("public suffix" in x for x in e)
+    e2, _ = _audit(core=[{"host": "*.io", "why": "x"}])
+    assert any("public suffix" in x for x in e2)
+
+
+def test_wildcard_over_real_domain_is_ok():
+    # `**.github.com` is the intended use — not an error.
+    e, _ = _audit(core=[{"host": "**.github.com", "why": "x"}])
+    assert e == []
+
+
+# --- WARN cases (advisory) ---------------------------------------------------
+
+
+def test_punycode_warns():
+    _, w = _audit(core=[{"host": "xn--80ak6aa92e.com", "why": "x"}])
+    assert any("IDN/punycode" in x for x in w)
+
+
+def test_risky_tld_warns():
+    _, w = _audit(core=[{"host": "evil.zip", "why": "x"}])
+    assert any("risk-associated TLD" in x for x in w)
+
+
+def test_deep_nesting_warns():
+    _, w = _audit(core=[{"host": "a.b.c.d.e.example.com", "why": "x"}])
+    assert any("deep subdomain nesting" in x for x in w)
+
+
+def test_plaintext_80_non_cert_warns():
+    _, w = _audit(core=[{"host": "api.example.com:80", "why": "x"}])
+    assert any("plaintext :80" in x for x in w)
+
+
+def test_plaintext_80_cert_host_is_quiet():
+    _, w = _audit(core=[{"host": "ocsp.digicert.com:80", "why": "x"}])
+    assert not any("plaintext :80" in x for x in w)
+
+
+def test_plaintext_80_os_mirror_is_quiet():
+    _, w = _audit(core=[{"host": "archive.ubuntu.com:80", "why": "x"}])
+    assert not any("plaintext :80" in x for x in w)
+
+
+def test_clean_host_no_signal():
+    e, w = _audit(core=[{"host": "registry.npmjs.org", "why": "x"}])
+    assert e == [] and w == []
+
+
+def test_sibling_brands_do_not_warn():
+    # The deliberately-omitted typosquat heuristic: sibling brands must be quiet.
+    e, w = _audit(
+        core=[
+            {"host": "github.com", "why": "x"},
+            {"host": "gitlab.com", "why": "x"},
+            {"host": "docker.io", "why": "x"},
+            {"host": "docker.com", "why": "x"},
+        ]
+    )
+    assert e == [] and w == []
+
+
+# --- live file ---------------------------------------------------------------
+
+
+def test_live_balanced_has_no_errors():
+    import yaml
+
+    data = yaml.safe_load((ROOT / "integrations" / "isolation" / "network-tiers" / "balanced.yaml").read_text())
+    errors, _ = _mod().audit(data)
+    assert errors == [], f"live balanced.yaml has hard errors: {errors}"
+
+
+def test_main_exit_zero_on_live_file():
+    assert _mod().main() == 0

--- a/scripts/tests/test_validate_network_tiers.py
+++ b/scripts/tests/test_validate_network_tiers.py
@@ -1,0 +1,120 @@
+"""Tests for the network-tier `balanced` baseline allowlist (#301, ADR 0002).
+
+Covers the schema (host pattern, core required, tier const) and the curation
+rules the standalone validator adds (every entry justified, no cross-tier
+duplicate host), plus a consistency check on the live data file.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "schemas" / "network-tier-baseline-v1.schema.json"
+DATA_PATH = ROOT / "integrations" / "isolation" / "network-tiers" / "balanced.yaml"
+VALIDATOR_PATH = ROOT / "scripts" / "validate_network_tiers.py"
+
+
+def _schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def _data() -> dict:
+    return yaml.safe_load(DATA_PATH.read_text())
+
+
+def _base(**extra) -> dict:
+    d = {"version": "1.0", "tier": "balanced", "core": [{"host": "npmjs.org", "why": "npm"}]}
+    d.update(extra)
+    return d
+
+
+# --- schema ------------------------------------------------------------------
+
+
+class TestBaselineSchema:
+    def test_minimal_valid(self):
+        jsonschema.validate(_base(), _schema())
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "npmjs.org",
+            "registry.npmjs.org",
+            "**.github.com",
+            "*.one.digicert.com:80",
+            "crl*.digicert.com:80",
+            "archive.ubuntu.com:80",
+        ],
+    )
+    def test_valid_host_forms(self, host):
+        jsonschema.validate(_base(core=[{"host": host, "why": "test"}]), _schema())
+
+    def test_tier_must_be_balanced(self):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(_base(tier="strict"), _schema())
+
+    def test_entry_requires_why(self):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(_base(core=[{"host": "npmjs.org"}]), _schema())
+
+    def test_core_required_nonempty(self):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(_base(core=[]), _schema())
+
+    def test_typo_key_rejected(self):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(_base(core=[{"host": "npmjs.org", "reason": "x"}]), _schema())
+
+    def test_bad_host_rejected(self):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(_base(core=[{"host": "has space.com", "why": "test"}]), _schema())
+
+
+# --- validator curation rules ------------------------------------------------
+
+
+def _load_validator():
+    spec = importlib.util.spec_from_file_location("vnt", VALIDATOR_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestBaselineDataFile:
+    def test_live_file_is_schema_valid(self):
+        jsonschema.validate(_data(), _schema())
+
+    def test_every_entry_has_why(self):
+        data = _data()
+        for grp in ("core", "extended"):
+            for e in data.get(grp, []):
+                assert e.get("why", "").strip(), f"{grp}: {e.get('host')} missing why"
+
+    def test_no_cross_tier_duplicate_host(self):
+        data = _data()
+        core = {e["host"] for e in data.get("core", [])}
+        ext = {e["host"] for e in data.get("extended", [])}
+        assert not (core & ext), f"host in both core and extended: {core & ext}"
+
+    def test_core_has_essential_toolchain(self):
+        # Sanity: the shipped default must include the core registries + AI API.
+        core = {e["host"] for e in _data().get("core", [])}
+        for essential in ("registry.npmjs.org", "pypi.org", "api.anthropic.com", "github.com"):
+            assert essential in core, f"core baseline missing essential host {essential}"
+
+    def test_saas_convenience_not_in_core(self):
+        # The curation decision: dev-convenience SaaS is opt-in (extended), not
+        # shipped in the default balanced egress for a prompt-injectable agent.
+        core = {e["host"] for e in _data().get("core", [])}
+        for opt_in in ("figma.com", "supabase.com", "vercel.com", "**.amazonaws.com"):
+            assert opt_in not in core, f"{opt_in} should be extended (opt-in), not core"
+
+    def test_validator_passes_on_live_file(self):
+        assert _load_validator().main() == 0

--- a/scripts/validate_network_tiers.py
+++ b/scripts/validate_network_tiers.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Validate the network-tier baseline egress allowlist (#301, ADR 0002).
+
+Checks integrations/isolation/network-tiers/balanced.yaml against
+schemas/network-tier-baseline-v1.schema.json and enforces the curation rules
+that JSON Schema alone cannot express:
+
+  - every entry has a non-empty `why` justification (auditable pruning);
+  - no duplicate host within core, within extended, or across the two
+    (a host must live in exactly one tier so its posture is unambiguous);
+  - host syntax matches the schema pattern (wildcards, optional :port).
+
+Governance (documented, not machine-enforceable here): the CONTENTS of the
+shipped `balanced` default are a human/CODEOWNERS + security-skill decision. An
+agent may PROPOSE entries; it must not self-approve. This validator only keeps
+the file well-formed and internally consistent.
+
+Exit 0 on success, 1 on any error. Dependency-free beyond PyYAML + (optional)
+jsonschema; falls back to a regex host check when jsonschema is absent.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "integrations" / "isolation" / "network-tiers" / "balanced.yaml"
+SCHEMA = ROOT / "schemas" / "network-tier-baseline-v1.schema.json"
+
+
+def main() -> int:
+    if not DATA.is_file():
+        print(f"✗ missing {DATA.relative_to(ROOT)}")
+        return 1
+    if not SCHEMA.is_file():
+        print(f"✗ missing {SCHEMA.relative_to(ROOT)}")
+        return 1
+
+    schema = json.loads(SCHEMA.read_text())
+    data = yaml.safe_load(DATA.read_text()) or {}
+    errors: list[str] = []
+
+    # Structural validation (jsonschema if available; else the host pattern).
+    try:
+        import jsonschema
+
+        try:
+            jsonschema.validate(data, schema)
+        except jsonschema.ValidationError as e:
+            errors.append(f"schema: {e.message} (at {'/'.join(str(p) for p in e.absolute_path)})")
+    except ImportError:
+        pat = re.compile(schema["$defs"]["entry"]["properties"]["host"]["pattern"])
+        for grp in ("core", "extended"):
+            for e in data.get(grp, []) or []:
+                host = (e or {}).get("host", "")
+                if not pat.match(host):
+                    errors.append(f"{grp}: host {host!r} fails the schema pattern")
+
+    # Curation rules beyond the schema.
+    seen: dict[str, str] = {}
+    for grp in ("core", "extended"):
+        for e in data.get(grp, []) or []:
+            host = (e or {}).get("host", "")
+            why = (e or {}).get("why", "")
+            if not why or len(why.strip()) < 3:
+                errors.append(f"{grp}: entry {host!r} is missing a `why` justification")
+            if host in seen:
+                errors.append(
+                    f"duplicate host {host!r} in {grp} (already in {seen[host]}); "
+                    "a host must live in exactly one tier"
+                )
+            else:
+                seen[host] = grp
+
+    if errors:
+        print(f"✗ network-tier baseline: {len(errors)} error(s)")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+
+    core = len(data.get("core", []) or [])
+    ext = len(data.get("extended", []) or [])
+    print(f"✓ network-tier baseline valid: {core} core + {ext} extended host(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_network_tiers.py
+++ b/scripts/validate_network_tiers.py
@@ -71,8 +71,7 @@ def main() -> int:
                 errors.append(f"{grp}: entry {host!r} is missing a `why` justification")
             if host in seen:
                 errors.append(
-                    f"duplicate host {host!r} in {grp} (already in {seen[host]}); "
-                    "a host must live in exactly one tier"
+                    f"duplicate host {host!r} in {grp} (already in {seen[host]}); a host must live in exactly one tier"
                 )
             else:
                 seen[host] = grp

--- a/scripts/validate_repo.py
+++ b/scripts/validate_repo.py
@@ -35,6 +35,10 @@ def main() -> int:
         ("scripts/validate_sensitive_terms.py", "Sensitive terms scan"),
         ("scripts/validate_references.py", "Cross-reference & delegation-cycle validation"),
         ("scripts/validate_network_tiers.py", "Network-tier baseline allowlist validation"),
+        (
+            "scripts/check_balanced_allowlist_additions.py",
+            "Balanced-allowlist additions guard (deterministic risk lint)",
+        ),
     ]
 
     failed = []

--- a/scripts/validate_repo.py
+++ b/scripts/validate_repo.py
@@ -34,6 +34,7 @@ def main() -> int:
         ("scripts/validate_frontmatter.py", "Frontmatter schema validation"),
         ("scripts/validate_sensitive_terms.py", "Sensitive terms scan"),
         ("scripts/validate_references.py", "Cross-reference & delegation-cycle validation"),
+        ("scripts/validate_network_tiers.py", "Network-tier baseline allowlist validation"),
     ]
 
     failed = []


### PR DESCRIPTION
## Summary
Two pieces of the neutral-network-tiers epic (#303; design ADR 0002, schema vocab #300 in PR #313), folded together because the baseline data and its additions-guard are one reviewable unit.

### #301 — curated `balanced` baseline
`integrations/isolation/network-tiers/balanced.yaml` — the version-controlled source of truth for what the `balanced` tier allows, seeded from the merged quickstart msb-balanced mirror. Every host carries a one-line `why`.
- **core (148)** = the minimal, vouched-safe set SHIPPED as the balanced default (language/package registries, first-party AI model APIs, source-host + container-registry family, OS mirrors, cert CRL/OCSP).
- **extended (43)** = dev-convenience SaaS (Figma/Supabase/Vercel, third-party AI IDEs, broad `**.amazonaws`/`**.googleapis` wildcards) — deliberately NOT in the default egress for a prompt-injectable agent; documented, justified, opt-in.
- `schemas/network-tier-baseline-v1.schema.json` (draft-2020-12) + `scripts/validate_network_tiers.py` (per-entry `why` required, no cross-tier dup, host/wildcard/port pattern).

### #302 — deterministic additions guard
`scripts/check_balanced_allowlist_additions.py` — an **offline, no-network** risk lint over the hosts (wired into `make validate`/CI). A **3/3 nexus-agents consensus rejected a live reputation feed** (over-engineering + a federal data-sharing concern for a hand-curated, human+CODEOWNERS-reviewed list); Option A (no network) satisfies the fail-safe/offline/deterministic constraints and cannot flake.
- **ERROR:** raw IP literal; wildcard over a public suffix (opens a whole TLD).
- **WARN (advisory, exit 0):** punycode/IDN homograph, risky TLD, deep nesting, unexpected plaintext :80 (cert/CRL/OCSP + OS mirrors excused).
- Typosquat/edit-distance heuristic **deliberately omitted** — sibling brands (github/gitlab, docker.io/docker.com) would fire every run and train reviewers to ignore it.

## Governance
Ships as a **PROPOSED** list — an agent proposes, never self-approves; the contents of a federally-shipped default egress allowlist are a CODEOWNERS + security decision. The per-host `why` makes that review fast; the guard is an aid, not the authority.

## Verification
342 tests pass (30 for the tier work); `make validate` green; ruff clean.

## Dependencies
Consumes the `network.tier` vocab from #313 (#300). Unblocks quickstart #294 (adapter maps tier → sbx/msb and consumes this baseline). Closes #301 and #302.

AI-assisted (OpenCode); consensus-reviewed (3/3). Requires human review — especially the core/extended split.