### PR TITLE
feat(skills): executive technical explainer capability (3 skills + technical-explainer profile)

### DIFF
--- a/.agents/skills/communications/agentic-value-analyst/SKILL.md
+++ b/.agents/skills/communications/agentic-value-analyst/SKILL.md
@@ -1,0 +1,195 @@
+---
+id: agentic-value-analyst
+name: agentic-value-analyst
+version: "0.1.0"
+title: "Agentic Value Analyst"
+description: "Translate agentic-coding capabilities into organizational value without hype — labeling every claim by evidence class, preferring defensible delivery metrics over vanity metrics, and handling conflicting research honestly."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "Value Dimensions"
+      - "Evidence Basis"
+      - "Metrics"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+      - "Unsupported productivity multipliers"
+quality_gates:
+  readability_max_grade: 12
+  citations_required: false
+collection: communications
+triggers:
+  - "what is the value of agentic coding"
+  - "why should leadership fund this"
+  - "how do we measure AI coding value without hype"
+tags:
+  - "communications"
+  - "explainer"
+  - "executive"
+  - "measurement"
+routing:
+  task_types:
+    - analyze
+    - author
+  input_artifacts:
+    - documentation
+  output_artifacts:
+    - documentation
+  aliases:
+    - "value framing"
+    - "ROI framing without hype"
+  prefer_when:
+    - "the request is to argue or measure organizational value of agentic coding"
+  avoid_when:
+    - "the request is a single concept — use technical-concept-translator"
+    - "the request is to explain the process — use software-delivery-explainer"
+    - "the request is to render a finished artifact — use the design-artifact workflow"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+scope:
+  intended_use:
+    - "Framing organizational value of agentic coding for leadership"
+    - "Choosing and defending delivery metrics; rejecting vanity metrics"
+  exclusions:
+    - "Explaining a single concept (use technical-concept-translator)"
+    - "Producing audited savings figures (this skill produces estimates, clearly labeled)"
+    - "Any fixed productivity multiplier presented as fact"
+---
+
+# Skill: Agentic Value Analyst
+
+## Summary
+
+Translate what agentic coding can do into organizational value **without hype**.
+Every claim is labeled by how strong its evidence is; metrics are defensible
+delivery metrics, not vanity counts; conflicting external research is presented
+honestly rather than cherry-picked.
+
+## When to Use
+
+- "Why should leadership fund this work?"
+- "What is the value of agentic coding, and how would we measure it?"
+- "Does AI coding make developers 50% faster?" (answer honestly — see below).
+
+## When NOT to Use
+
+- One concept only → `technical-concept-translator`.
+- Explaining the process → `software-delivery-explainer`.
+- A finished artifact → the `design-artifact` workflow.
+
+## Prerequisites
+
+- The [measurement guidance](reference/measurement-guidance.md) (evidence classes,
+  good vs. vanity metrics, cost/value framing).
+- The audience (see the [audience profiles](../technical-concept-translator/reference/audience-profiles.md)).
+
+## Value dimensions to consider
+
+Engineering capacity; cycle time; repetitive-work reduction;
+investigation/research acceleration; documentation; testing; code-review
+assistance; security analysis; operations/troubleshooting; knowledge reuse;
+onboarding; consistency; organizational learning; reduced duplicated effort; and
+the ability to encode good practices as reusable skills. Select the dimensions
+that fit the actual capability — do not claim all of them by default.
+
+## The evidence discipline (the core of this skill)
+
+Label **every** value claim with one of five classes (see the measurement
+guidance): **published research / measured local / anecdotal / hypothesis /
+expected future**. A claim with no class is not ready to ship.
+
+Handle conflicting evidence honestly:
+
+- External research is mixed and time-sensitive — some controlled studies show AI
+  *slowing* experienced developers on familiar tasks; later self-reports show
+  gains. Effect depends on task type, tool, and experience.
+- Autocomplete assistants and agentic workflows are different interventions;
+  evidence about one is not evidence about the other.
+- **"Does AI make developers 50% faster?"** has no honest single-number answer.
+  Explain what it depends on and cite the range; refuse the bare multiplier.
+
+## Metrics
+
+Prefer defensible delivery metrics (issue→first-working-implementation, PR cycle
+time, change lead time, review time, change-failure rate, rework, defects and
+security findings caught before merge, docs-updated-with-change, onboarding time,
+reusable-pattern adoption, teams using shared capabilities; developer
+satisfaction with the self-reported caveat).
+
+Explicitly reject vanity metrics and say why when asked: **lines of AI-generated
+code** (more code is a cost), **prompt/token count** (usage, not value), **agents
+spawned** (activity, not outcome), **raw PR count without quality/context**
+(effort, not value). Pair any effort metric with a quality/outcome metric.
+
+## Cost / value framing
+
+Distinguish cost-avoidance **estimate** from **audited savings**; note the
+absence of a without-AI control group; show the method and the single biggest
+assumption; lead with the conservative figure; separate countable inputs from
+modeled levers. (See the measurement guidance §5.)
+
+## Procedure
+
+1. Pick the value dimensions that match the real capability.
+2. For each claim, attach an evidence class; drop any claim you cannot classify.
+3. Choose delivery metrics; if the audience offers a vanity metric, replace it and
+   explain why.
+4. If a dollar figure is requested, state the method, the assumption, and whether
+   it is an estimate or audited; lead conservative.
+5. Present conflicting external evidence as a range, not a single number.
+6. Adapt emphasis to the audience (acquisition/finance wants the method; a CAIO
+   wants the evidence discipline; an SES wants the plain "why it matters").
+
+## Verification
+
+- Every value claim carries an evidence class.
+- No fixed productivity multiplier is presented as fact.
+- At least one vanity metric is identified and replaced if the input used one.
+- Any cost figure is labeled estimate vs. audited, with its basis.
+- The "50% faster" style question is answered with a qualified, ranged answer.
+
+## Examples
+
+**"Does AI coding make developers 50% faster?"**
+> There is no honest single number. External research is mixed and moves fast:
+> some controlled studies found AI *slowing* experienced developers on familiar
+> tasks, while later self-reports show gains. The effect depends on the task
+> (boilerplate and investigation benefit most), the tool (agentic workflows differ
+> from autocomplete), and the developer's experience. A defensible framing is to
+> measure our own delivery metrics — cycle time, rework, defects caught before
+> merge — rather than adopt a fixed multiplier. *(Evidence class: published
+> research, conflicting.)*
+
+## Related Patterns
+
+- [`technical-concept-translator`](../technical-concept-translator/SKILL.md)
+- [`software-delivery-explainer`](../software-delivery-explainer/SKILL.md)
+- [`design-artifact`](../../../workflows/design-artifact/SKILL.md)
+
+## Human Review Checklist
+
+- [ ] Every claim has an evidence class.
+- [ ] No unsupported productivity multiplier.
+- [ ] Vanity metrics rejected/replaced; effort paired with quality.
+- [ ] Cost figures labeled estimate vs. audited, with method.
+- [ ] Conflicting research shown as a range, not cherry-picked.

--- a/.agents/skills/communications/agentic-value-analyst/reference/measurement-guidance.md
+++ b/.agents/skills/communications/agentic-value-analyst/reference/measurement-guidance.md
@@ -1,0 +1,89 @@
+# Evidence & Measurement Guidance
+
+Reference for talking about the value of agentic coding **honestly** — how to
+label evidence, how to handle conflicting research, and which metrics to use vs.
+avoid. Consumed mainly by `agentic-value-analyst`, but usable by any explainer.
+
+## 1. Label every claim by evidence class
+
+Never state a value claim without making its basis clear. Use these five classes:
+
+| Class | Meaning | How to phrase |
+|-------|---------|---------------|
+| **Published research** | An external, methodologically transparent study | "External research (DORA 2024 / METR 2026) reports…" |
+| **Measured local** | A first-party, countable figure from our own systems | "Measured in our repos (GitHub, pulled <date>): …" |
+| **Anecdotal** | An individual observation, not systematically measured | "Anecdotally, engineers report…" |
+| **Hypothesis** | A reasoned expectation we have not tested | "We expect, but have not measured, …" |
+| **Expected future** | A benefit contingent on work not yet done | "As X matures, we anticipate…" |
+
+A claim with no class is not ready to ship. If you cannot classify it, cut it.
+
+## 2. Handle conflicting and time-sensitive evidence
+
+The evidence on AI-assisted development is genuinely mixed and moves fast.
+
+- Early controlled studies have shown AI **slowing** experienced developers on
+  familiar tasks; later self-reported data shows gains. Both can be true for
+  different tasks, tools, and skill levels.
+- Autocomplete-style assistants and agentic workflows are **different
+  interventions** — do not treat evidence about one as evidence about the other.
+- Effect depends on task suitability (boilerplate and investigation benefit more
+  than novel, deeply-contextual design work) and on developer experience.
+
+**How to present it:** show the range, name the disagreement, and do not anchor
+on a single multiplier. "Does AI make developers 50% faster?" has no honest
+single-number answer — explain *what it depends on* instead.
+
+## 3. Prefer defensible delivery metrics
+
+Good metrics measure delivery and quality outcomes, are countable, and are hard
+to game without also improving the work:
+
+- issue → first-working-implementation time
+- pull-request cycle time; change lead time; review time
+- change failure rate; rework rate
+- defects caught before merge; security findings caught before merge
+- documentation updated alongside the change
+- repetitive-investigation time saved
+- onboarding time for new team members
+- reusable skill/pattern adoption; number of teams/projects using shared capabilities
+- developer satisfaction — with the caveat that it is self-reported
+
+Pair any effort metric with a quality/outcome metric so throughput is never read
+as value on its own.
+
+## 4. Avoid vanity and misleading metrics
+
+These look like productivity but are not; do not present them as value:
+
+- **Lines of AI-generated code** — more code is a cost, not an outcome.
+- **Prompt count / token count** — usage, not value; higher can mean less
+  efficient.
+- **Number of agents spawned** — activity, not outcome.
+- **Raw pull-request count without quality/context** — effort, not value; easy to
+  inflate.
+
+If asked about one of these, name why it misleads and offer the defensible
+metric that answers the real question.
+
+## 5. Cost / value framing
+
+- Distinguish **cost-avoidance estimate** from **audited savings** — say which.
+- If there is no without-AI control group, say so; it makes any figure an
+  estimate, not a measurement.
+- Show the method and the single largest assumption; lead with the conservative
+  figure.
+- Separate **countable** inputs (e.g., merged-PR counts) from **modeled** levers
+  (e.g., hours-saved-per-change).
+
+## 6. The honesty test
+
+Before a value statement ships, it should pass all of:
+
+1. Is it labeled with an evidence class?
+2. Would an engineer who knows the system agree it is accurate?
+3. Does it avoid implying the agent acted without human review?
+4. If it is a number, is its basis (and its limits) stated?
+5. Is it a defensible metric, not a vanity one?
+
+If any answer is "no," revise or cut the claim.

--- a/.agents/skills/communications/agentic-value-analyst/tests/test-cases.yml
+++ b/.agents/skills/communications/agentic-value-analyst/tests/test-cases.yml
@@ -1,0 +1,81 @@
+suite:
+  pattern_id: agentic-value-analyst
+  pattern_version: "0.1.0"
+  description: "Tests for agentic-value-analyst — evidence-labeled claims, vanity-metric rejection, honest handling of the '50% faster' question."
+
+test_cases:
+  - id: fifty-percent-faster-qualified
+    name: "Answers 'does AI make devs 50% faster' with a qualified, ranged answer"
+    description: "Must refuse the bare multiplier and explain what it depends on."
+    input:
+      type: literal
+      content: |
+        There is no honest single number. External research is mixed and time-sensitive:
+        some controlled studies found AI slowing experienced developers on familiar tasks,
+        while later self-reports show gains. The effect depends on the task, the tool, and
+        the developer's experience. Measure our own delivery metrics rather than adopt a
+        fixed multiplier. (Evidence class: published research, conflicting.)
+    assertions:
+      - type: contains
+        pattern: "no honest single number"
+        case_sensitive: false
+      - type: contains
+        pattern: "depends on"
+        case_sensitive: false
+      - type: contains
+        pattern: "Evidence class"
+        case_sensitive: false
+
+  - id: vanity-metric-rejected
+    name: "Rejects lines-of-code as a value metric"
+    description: "Lines of AI-generated code must be flagged as misleading and replaced."
+    input:
+      type: literal
+      content: |
+        ## Metrics
+        Lines of AI-generated code is a misleading metric — more code is a cost, not an outcome.
+        Prefer defensible delivery metrics: pull-request cycle time, change-failure rate, and
+        defects caught before merge.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Metrics"
+      - type: contains
+        pattern: "misleading metric"
+        case_sensitive: false
+      - type: contains
+        pattern: "cycle time"
+        case_sensitive: false
+
+  - id: claims-carry-evidence-class
+    name: "Value claims are labeled by evidence class"
+    input:
+      type: literal
+      content: |
+        ## Evidence Basis
+        Measured local: our repositories show 446 merged pull requests as of a dated GitHub pull.
+        Hypothesis: we expect onboarding time to fall, but have not measured it.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Evidence Basis"
+      - type: contains
+        pattern: "Measured local"
+        case_sensitive: false
+      - type: contains
+        pattern: "Hypothesis"
+        case_sensitive: false
+
+  - id: no-unsupported-multiplier
+    name: "Does not present a fixed productivity multiplier as fact"
+    input:
+      type: literal
+      content: |
+        We avoid claiming a fixed multiplier such as a guaranteed productivity gain; the evidence does not support one.
+    assertions:
+      - type: not_contains
+        pattern: "guarantees a 50% productivity"
+        case_sensitive: false
+      - type: not_contains
+        pattern: "makes developers twice as productive"
+        case_sensitive: false

--- a/.agents/skills/communications/software-delivery-explainer/SKILL.md
+++ b/.agents/skills/communications/software-delivery-explainer/SKILL.md
@@ -1,0 +1,201 @@
+---
+id: software-delivery-explainer
+name: software-delivery-explainer
+version: "0.1.0"
+title: "Software Delivery Explainer"
+description: "Explain how software moves from a need to production, and exactly where AI agents participate and where the human control points are — so leadership sees that agents do more work between the controls, not that the controls go away."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Summary"
+      - "The Delivery Process"
+      - "Where Agents Participate"
+      - "Human Control Points"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+quality_gates:
+  readability_max_grade: 12
+  citations_required: false
+collection: communications
+triggers:
+  - "explain how agents fit the software process"
+  - "where do humans stay in control of agentic coding"
+  - "explain the software delivery pipeline to leadership"
+tags:
+  - "communications"
+  - "explainer"
+  - "executive"
+  - "workflow"
+routing:
+  task_types:
+    - transform
+    - author
+  input_artifacts:
+    - documentation
+  output_artifacts:
+    - documentation
+  aliases:
+    - "delivery pipeline explainer"
+    - "agentic workflow explainer"
+  prefer_when:
+    - "the request is to explain the end-to-end delivery process and where agents/humans act"
+  avoid_when:
+    - "the request is a single concept — use technical-concept-translator"
+    - "the request is a value/ROI argument — use agentic-value-analyst"
+    - "the request is to render a finished artifact — use the design-artifact workflow"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+scope:
+  intended_use:
+    - "Explaining the software delivery process to non-engineering leadership"
+    - "Showing where agents participate and where human control points remain"
+  exclusions:
+    - "Explaining a single isolated concept (use technical-concept-translator)"
+    - "Making organizational value claims (use agentic-value-analyst)"
+    - "Implying one universal workflow all organizations use"
+---
+
+# Skill: Software Delivery Explainer
+
+## Summary
+
+Explain how software moves from a need to production, and make **explicit** where
+AI agents do work and where humans keep control. The central, honest thesis:
+
+> The agent accelerates work **inside** the engineering process. It does not
+> replace the process or its controls — it does more of the work **between** the
+> control points, which remain human.
+
+## When to Use
+
+- "Explain how agentic coding actually works, end to end, to leadership."
+- "Show where humans remain accountable in an agentic workflow."
+- "Where does the agent fit in our delivery pipeline?"
+
+## When NOT to Use
+
+- One concept only → `technical-concept-translator`.
+- A value/ROI argument → `agentic-value-analyst`.
+- A finished one-pager/deck → the `design-artifact` workflow.
+
+## Prerequisites
+
+- The audience (see the [audience profiles](../technical-concept-translator/reference/audience-profiles.md)).
+- Ground truth for control points:
+  [concept library](../technical-concept-translator/reference/concept-library.md)
+  and the playbook `AGENTS.md` / `SECURITY-CONTROLS.md`.
+
+## The baseline delivery model
+
+Present this as *a common shape, not the one true workflow* — organizations
+differ. Each arrow is a step; the **bold** steps are human/automated control
+points that do not go away when an agent is involved.
+
+```
+need / problem
+  → issue (define the work)
+  → branch / isolated workspace
+  → implementation
+  → automated tests
+  → pull request
+  → **CI / security checks**        (automated control)
+  → **human review**                (human control — author ≠ approver)
+  → **merge**                       (human-gated)
+  → **deployment**                  (human-gated; separate release controls)
+```
+
+## Where agents participate
+
+Agents can do more of the work between the controls. Typically:
+
+- investigate the repository and gather context
+- research relevant implementation details and dependencies
+- propose a plan
+- make changes in the isolated sandbox
+- generate and run tests, static analysis, and security checks
+- iterate on failures
+- update documentation
+- prepare the pull request and summarize the evidence
+
+## Human control points (these do not move)
+
+Cite these to the ground truth — do not soften them:
+
+- **Approval gates** — the agent must get explicit human approval before
+  destructive operations, external network requests, dependency installs,
+  license acceptance, CI/CD changes, and committing/pushing (playbook AGENTS.md §3.2).
+- **No self-approval** — the agent may not approve its own code for production
+  (AGENTS.md §8.2).
+- **No self-merge** — the agent may not merge its own pull requests or commit to
+  protected branches (AGENTS.md §14.2).
+- **Separation of duties** — author ≠ approver; the agent may assist review but is
+  not the sole reviewer for production-bound code (SECURITY-CONTROLS.md AC-5).
+- **Human author of record** — a human is accountable for every AI-assisted change
+  and must be able to explain it; "the AI wrote it" is never a sufficient account
+  (AI-CONTRIBUTION-POLICY.md).
+- **Fail closed** — on ambiguity the agent halts and escalates rather than guessing
+  (AGENTS.md §14.5).
+
+## Procedure
+
+1. **Anchor the model.** Lay out the pipeline above; state up front that workflows
+   vary by organization.
+2. **Split the work.** For each stage, say plainly whether an agent can do it,
+   assist with it, or whether it is a human decision.
+3. **Make the control points loud.** Name each human/automated gate and cite it.
+   Do not imply any gate is removed or that the agent can pass its own gate.
+4. **State the thesis.** Close on "more work between the controls, not fewer
+   controls."
+5. **Adapt to audience.** A CISO wants the control detail; an SES wants the plain
+   shape and the reassurance that humans stay accountable.
+6. **Optionally ground in a real change.** If given a real issue/PR, walk it
+   through the stages — but only assert what the evidence shows (this is the
+   future `repo-evidence-extractor` capability; until it exists, do not fabricate
+   the walkthrough).
+
+## Verification
+
+- All four required sections present.
+- Every human control point is named and none is described as something the agent
+  can perform for its own change.
+- The output does **not** state the agent merges, approves, or deploys on its own.
+- The pipeline is presented as common, not universal.
+
+## Examples
+
+**"Show where humans remain accountable."** → produce the pipeline, then the
+Human Control Points list, then the thesis. The reader should be able to point to
+review, merge, and deploy as human-held gates.
+
+## Related Patterns
+
+- [`technical-concept-translator`](../technical-concept-translator/SKILL.md)
+- [`agentic-value-analyst`](../agentic-value-analyst/SKILL.md)
+- [`design-artifact`](../../../workflows/design-artifact/SKILL.md)
+
+## Human Review Checklist
+
+- [ ] Control points named and cited; none attributed to the agent for its own work.
+- [ ] Output does not imply autonomous merge/approve/deploy.
+- [ ] Pipeline framed as common, not universal.
+- [ ] "More work between the controls" thesis is present and accurate.

--- a/.agents/skills/communications/software-delivery-explainer/tests/test-cases.yml
+++ b/.agents/skills/communications/software-delivery-explainer/tests/test-cases.yml
@@ -1,0 +1,62 @@
+suite:
+  pattern_id: software-delivery-explainer
+  pattern_version: "0.1.0"
+  description: "Tests for software-delivery-explainer — control points named, no implied agent autonomy, pipeline framed as common not universal."
+
+test_cases:
+  - id: control-points-named
+    name: "Names the human control points"
+    description: "Review, merge, and deployment must appear as human-held control points."
+    input:
+      type: literal
+      content: |
+        ## Summary
+        Software moves from a need to production through a common (not universal) set of steps.
+        ## The Delivery Process
+        need -> issue -> branch -> implementation -> automated tests -> pull request -> CI/security checks -> human review -> merge -> deployment
+        ## Where Agents Participate
+        The agent investigates the repository, drafts changes in the sandbox, runs tests, and prepares the pull request.
+        ## Human Control Points
+        Human review approves the change (author is not the approver); merge is human-gated; deployment applies separate human-approved release controls.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Summary"
+          - "The Delivery Process"
+          - "Where Agents Participate"
+          - "Human Control Points"
+      - type: contains
+        pattern: "human review"
+        case_sensitive: false
+      - type: contains
+        pattern: "author is not the approver"
+        case_sensitive: false
+
+  - id: no-autonomous-merge
+    name: "Does not imply the agent approves or merges its own work"
+    description: "Honesty guard against overclaiming autonomy."
+    input:
+      type: literal
+      content: |
+        The agent does more of the work between the control points. It cannot approve its own code or merge its own pull request; a human does that.
+    assertions:
+      - type: not_contains
+        pattern: "the agent merges its own"
+        case_sensitive: false
+      - type: not_contains
+        pattern: "the agent approves its own"
+        case_sensitive: false
+      - type: contains
+        pattern: "between the control points"
+        case_sensitive: false
+
+  - id: pipeline-not-universal
+    name: "Frames the pipeline as common, not the one true workflow"
+    input:
+      type: literal
+      content: |
+        This is a common shape, not the one workflow every organization uses; teams differ.
+    assertions:
+      - type: contains
+        pattern: "not the one workflow"
+        case_sensitive: false

--- a/.agents/skills/communications/technical-concept-translator/SKILL.md
+++ b/.agents/skills/communications/technical-concept-translator/SKILL.md
@@ -1,0 +1,187 @@
+---
+id: technical-concept-translator
+name: technical-concept-translator
+version: "0.1.0"
+title: "Technical Concept Translator"
+description: "Translate one software-engineering, security, or agentic-system concept into an accurate executive mental model — what it is, why it matters, what it is NOT, where it fits, and its control implications — without dumbing it down into something technically wrong."
+type: skill
+status: experimental
+owners:
+  - "@GSA-TTS/agentic-coding-team"
+primary_personas:
+  - developers
+  - developer-advocates
+  - technical-writers
+requires:
+  anchors: []
+  skills: []
+output:
+  format: markdown
+  contract:
+    required_sections:
+      - "Concept"
+      - "Plain-Language Explanation"
+      - "Why It Matters"
+      - "What It Is Not"
+      - "Where It Fits"
+    prohibited_content:
+      - "Secrets"
+      - "Real PII"
+      - "Real CUI"
+      - "Internal URLs"
+quality_gates:
+  readability_max_grade: 12
+  citations_required: false
+collection: communications
+triggers:
+  - "explain this concept to an executive"
+  - "what is a pull request in plain language"
+  - "translate this technical term for leadership"
+tags:
+  - "communications"
+  - "explainer"
+  - "executive"
+routing:
+  task_types:
+    - transform
+    - author
+  input_artifacts:
+    - documentation
+  output_artifacts:
+    - documentation
+  aliases:
+    - "concept explainer"
+    - "executive glossary"
+  prefer_when:
+    - "a single technical/security/agentic concept must be explained accurately to a non-engineering audience"
+  avoid_when:
+    - "the request is to build a full artifact (one-pager/deck) — use the design-artifact workflow"
+    - "the request is to explain the whole delivery process — use software-delivery-explainer"
+    - "the request is to argue organizational value — use agentic-value-analyst"
+  priority: 55
+portability:
+  opencode: true
+  cursor: true
+  claude_projects: true
+  chatgpt: true
+  generic_llm: true
+scope:
+  intended_use:
+    - "Explaining one concept (repository, PR, sandbox, agent vs model vs harness, AGENTS.md, secret, etc.) to executives"
+    - "Building or extending the executive concept library"
+  exclusions:
+    - "Producing rendered artifacts (use the design-artifact workflow)"
+    - "Making organizational value or ROI claims (use agentic-value-analyst)"
+    - "Any explanation that must sacrifice technical accuracy for simplicity"
+---
+
+# Skill: Technical Concept Translator
+
+## Summary
+
+Take **one** engineering, security, or agentic-system concept and produce an
+accurate executive mental model. The goal is an explanation an executive
+understands **without making an engineer wince at the inaccuracy**. Simplify the
+language, never the truth.
+
+## When to Use
+
+- "Explain a pull request to a senior executive who has never written software."
+- "What is a sandbox, and why does it matter to a CISO?"
+- "What is the difference between a model, an agent, a harness, AGENTS.md, and a skill?"
+- Building or extending the [executive concept library](reference/concept-library.md).
+
+## When NOT to Use
+
+- You need a finished one-pager or deck → use the `design-artifact` workflow.
+- You need to explain the whole delivery pipeline → `software-delivery-explainer`.
+- You need to argue value/ROI → `agentic-value-analyst`.
+
+## Prerequisites
+
+- The concept to explain.
+- The audience (optional but recommended — see
+  [audience profiles](reference/audience-profiles.md)).
+- The [concept library](reference/concept-library.md) as ground truth.
+
+## Procedure
+
+1. **Look it up first.** Check the [concept library](reference/concept-library.md).
+   If the concept is there, use that entry as the factual base. If it is not,
+   derive the explanation from a cited source (playbook/quickstart docs) — do
+   **not** invent facts. If you cannot ground a claim, say so.
+2. **Fill the structured model** for the concept:
+   - **Concept** — the term.
+   - **Plain-Language Explanation** — one accurate sentence a non-engineer gets.
+   - **Why It Matters** — the leadership-relevant "so what".
+   - **What It Is Not** — bound it; stop a false mental model forming. This
+     section is required because the most common failure is a tidy-but-wrong analogy.
+   - **Where It Fits** — its place in the process or architecture.
+   - **Controls** (when relevant) — the security/governance implication, honestly
+     bounded (e.g., the sandbox is isolation, *not* a perfect guarantee).
+   - **Analogy** (optional) — include **only** if it improves understanding
+     without creating a false model. If the closest analogy would mislead, omit it
+     and say why in one line.
+3. **Adapt depth to the audience** using the
+   [audience profiles](reference/audience-profiles.md). Offer 30-second /
+   3-minute / deeper variants when the request implies more than one setting.
+4. **No jargon substitution.** Replacing one technical word with five vague
+   business words is not a translation. Keep a precise technical term when it is
+   the honest word; define it in one clause.
+5. **Preserve the honesty caveats.** For the sandbox, secrets, and agent-autonomy
+   concepts, carry the "what it is not" limits from the concept library verbatim
+   in spirit — especially: secrets handling differs by backend (the msb vs.
+   sbx/USAi caveat), the sandbox does not verify image integrity, and the agent
+   cannot approve or merge its own work.
+
+## Verification
+
+- Every required section is present, including **What It Is Not**.
+- No claim is stronger than its source; security claims trace to a cited doc.
+- The explanation would not make a knowledgeable engineer wince.
+- No jargon is introduced without a plain definition.
+- Any analogy improves rather than distorts; if none does, none is used.
+
+## Examples
+
+**"Explain a pull request to an SES."**
+> **Concept:** Pull request (PR).
+> **Plain-language:** A proposal to add a set of changes to the official code,
+> opened so people can review it before anything is accepted.
+> **Why it matters:** It is the checkpoint where a person inspects and approves a
+> change before it becomes part of the system — the accountability gate.
+> **What it is not:** It is not an automatic change and not a release; opening one
+> changes nothing live by itself.
+> **Where it fits:** After the work is done on a separate branch and automated
+> checks have run; before the change is merged.
+> **Controls:** A reviewer who is not the author approves it; the person or agent
+> that wrote the change cannot approve their own.
+
+**"Model vs. agent vs. harness vs. AGENTS.md vs. skill."** — Pull the five concept-library
+entries and present them as a short contrast set: the **model** is the raw
+intelligence (takes no action); the **agent** uses the model plus tools to do
+work in a loop; the **harness** is the program that runs the agent and enforces
+its limits; **AGENTS.md** is the rules file the harness reads (a guide, not
+enforcement); a **skill** is a reusable instruction set the agent loads for a
+specific task.
+
+## Related Patterns
+
+- [`software-delivery-explainer`](../software-delivery-explainer/SKILL.md) — the whole process.
+- [`agentic-value-analyst`](../agentic-value-analyst/SKILL.md) — value framing.
+- [`design-artifact`](../../../workflows/design-artifact/SKILL.md) — render an artifact (`technical-explainer` profile).
+- [`plain-language-review`](../../frontend/plain-language-review/SKILL.md) — readability check.
+
+**How this differs (not a duplicate):** `plain-language-review` *reviews existing
+content* for readability; this skill *generates a new, accurate mental model* of a
+concept. `narrative-architect` structures a story for an artifact; this produces a
+factual concept explanation, not a narrative. `one-pager`/`slide-deck` *render*
+finished files; this is a content source, not a renderer.
+
+## Human Review Checklist
+
+- [ ] Facts trace to the concept library or a cited source; nothing invented.
+- [ ] "What It Is Not" is present and correct.
+- [ ] Sandbox / secrets / autonomy caveats are intact and accurate.
+- [ ] No misleading analogy; no undefined jargon.
+- [ ] Depth matches the stated audience.

--- a/.agents/skills/communications/technical-concept-translator/SKILL.md
+++ b/.agents/skills/communications/technical-concept-translator/SKILL.md
@@ -130,9 +130,10 @@ language, never the truth.
    the honest word; define it in one clause.
 5. **Preserve the honesty caveats.** For the sandbox, secrets, and agent-autonomy
    concepts, carry the "what it is not" limits from the concept library verbatim
-   in spirit — especially: secrets handling differs by backend (the msb vs.
-   sbx/USAi caveat), the sandbox does not verify image integrity, and the agent
-   cannot approve or merge its own work.
+   in spirit — especially: secrets are proxied into the sandbox on both backends
+   in the default setup (the agent does not hold raw key material), the sandbox
+   does not verify image integrity, and the agent cannot approve or merge its own
+   work.
 
 ## Verification
 

--- a/.agents/skills/communications/technical-concept-translator/SKILL.md
+++ b/.agents/skills/communications/technical-concept-translator/SKILL.md
@@ -130,10 +130,9 @@ language, never the truth.
    the honest word; define it in one clause.
 5. **Preserve the honesty caveats.** For the sandbox, secrets, and agent-autonomy
    concepts, carry the "what it is not" limits from the concept library verbatim
-   in spirit — especially: secrets are proxied into the sandbox on both backends
-   in the default setup (the agent does not hold raw key material), the sandbox
-   does not verify image integrity, and the agent cannot approve or merge its own
-   work.
+   in spirit — especially: secrets are proxied into the sandbox in the default
+   setup (the agent does not hold raw key material), the sandbox does not verify
+   image integrity, and the agent cannot approve or merge its own work.
 
 ## Verification
 

--- a/.agents/skills/communications/technical-concept-translator/reference/audience-profiles.md
+++ b/.agents/skills/communications/technical-concept-translator/reference/audience-profiles.md
@@ -31,13 +31,14 @@ skills read these profiles to choose emphasis, not to change the facts.
   separation of duties, what happens when something is compromised.
 - **Needs to understand:** the sandbox isolates work and bounds blast radius but
   is not a perfect guarantee (image-provenance/SI-7 caveat); deny-by-default
-  egress; that secrets handling differs by backend (the msb vs. sbx/USAi caveat)
-  — state it precisely; the agent cannot self-approve or self-merge; audit trail.
+  egress; that secrets are proxied into the sandbox on both backends in the
+  default setup (msb swap-on-wire; sbx proxy / `set-custom`), so the agent does
+  not hold raw key material; the agent cannot self-approve or self-merge; audit trail.
 - **Needs the detail:** the specific controls (AC-5, AC-6, SC-7, AU-2/3/12) and
   their honest limits.
 - **Does not need:** narrative/business-value framing up front.
-- **Watch for:** overclaiming isolation or "secrets never enter the sandbox" —
-  a CISO will (correctly) probe it; get it right or lose credibility.
+- **Watch for:** overclaiming isolation as a perfect guarantee — a CISO will
+  (correctly) probe the limits; state them accurately or lose credibility.
 
 ## CAIO — AI governance & responsible use
 

--- a/.agents/skills/communications/technical-concept-translator/reference/audience-profiles.md
+++ b/.agents/skills/communications/technical-concept-translator/reference/audience-profiles.md
@@ -31,9 +31,9 @@ skills read these profiles to choose emphasis, not to change the facts.
   separation of duties, what happens when something is compromised.
 - **Needs to understand:** the sandbox isolates work and bounds blast radius but
   is not a perfect guarantee (image-provenance/SI-7 caveat); deny-by-default
-  egress; that secrets are proxied into the sandbox on both backends in the
-  default setup (msb swap-on-wire; sbx proxy / `set-custom`), so the agent does
-  not hold raw key material; the agent cannot self-approve or self-merge; audit trail.
+  egress; that secrets are proxied into the sandbox in the default setup, so the
+  agent does not hold raw key material; the agent cannot self-approve or
+  self-merge; audit trail.
 - **Needs the detail:** the specific controls (AC-5, AC-6, SC-7, AU-2/3/12) and
   their honest limits.
 - **Does not need:** narrative/business-value framing up front.

--- a/.agents/skills/communications/technical-concept-translator/reference/audience-profiles.md
+++ b/.agents/skills/communications/technical-concept-translator/reference/audience-profiles.md
@@ -1,0 +1,93 @@
+# Executive Audience Profiles
+
+Reusable reference for adapting a technical explanation to a specific executive
+audience. **This is reference material, not a set of skills** — the explainer
+skills read these profiles to choose emphasis, not to change the facts.
+
+## How to use
+
+1. Identify the audience (or audiences).
+2. Lead with what they care about; include the technical detail they actually
+   need; omit detail they do not.
+3. Never change a fact to suit an audience. Adapt framing and depth, not truth.
+
+---
+
+## CIO / CTO — technology strategy & delivery
+
+- **Cares about:** delivery speed and predictability, engineering capacity,
+  maintainability, total cost, avoiding lock-in, how this fits existing systems.
+- **Needs to understand:** where agents accelerate delivery vs. where humans
+  still decide; that controls (review, CI, deploy gates) are unchanged; the
+  three-repo split (practices / local-dev tooling / shared knowledge).
+- **Does not need:** sandbox implementation internals, individual NIST control IDs.
+- **Lead with:** capacity and cycle-time framing, honestly labeled.
+- **Watch for:** treating throughput (PR counts) as value; be explicit that
+  throughput is effort, not outcome.
+
+## CISO — security & risk
+
+- **Cares about:** attack surface, blast radius, credential handling, auditability,
+  separation of duties, what happens when something is compromised.
+- **Needs to understand:** the sandbox isolates work and bounds blast radius but
+  is not a perfect guarantee (image-provenance/SI-7 caveat); deny-by-default
+  egress; that secrets handling differs by backend (the msb vs. sbx/USAi caveat)
+  — state it precisely; the agent cannot self-approve or self-merge; audit trail.
+- **Needs the detail:** the specific controls (AC-5, AC-6, SC-7, AU-2/3/12) and
+  their honest limits.
+- **Does not need:** narrative/business-value framing up front.
+- **Watch for:** overclaiming isolation or "secrets never enter the sandbox" —
+  a CISO will (correctly) probe it; get it right or lose credibility.
+
+## CAIO — AI governance & responsible use
+
+- **Cares about:** human accountability, model governance, evidence quality,
+  avoiding hype, alignment with federal AI guidance (NIST AI RMF, OMB memos).
+- **Needs to understand:** the human is author of record and fully accountable;
+  the agent is a tool operating under a behavioral contract; evidence is labeled
+  (published / measured / anecdotal / hypothesis / future), not asserted.
+- **Does not need:** low-level sandbox mechanics.
+- **Watch for:** unsupported productivity multipliers; conflating a model with an
+  agent; implying autonomy.
+
+## Agency / program executive (SES) — mission outcomes
+
+- **Cares about:** does this help the mission, is it safe, is it defensible, what
+  does it cost, why should we continue/fund it.
+- **Needs to understand:** the plain-language "what it is" and "why it matters";
+  that humans stay accountable; that value is real but honestly bounded.
+- **Does not need:** engineering vocabulary — define every term used, or avoid it.
+- **Lead with:** the mission framing and the one-sentence value, then the honest caveats.
+- **Watch for:** jargon; assume no software background but do not condescend.
+
+## COO / operations leadership — throughput & reliability
+
+- **Cares about:** consistency, reduced repetitive/manual work, onboarding time,
+  reliability, whether this creates operational risk.
+- **Needs to understand:** which repetitive engineering/ops work agents can
+  absorb (investigation, docs, tests, triage) and which decisions stay human;
+  that the process and its controls are unchanged.
+- **Does not need:** model/harness distinctions in depth.
+- **Watch for:** implying head-count replacement; frame as capacity and
+  consistency, not staff reduction.
+
+## Acquisition / financial leadership — cost & value
+
+- **Cares about:** cost, cost-avoidance, defensibility of any dollar figure,
+  contract/vendor implications, sustainability.
+- **Needs to understand:** how any value figure was derived and its limits
+  (estimate vs. audited); that metrics are countable where claimed; no lock-in.
+- **Needs the detail:** the measurement basis (see the measurement guidance).
+- **Does not need:** technical architecture.
+- **Watch for:** point-estimate ROI with no method; always show the basis and lead
+  with the conservative figure.
+
+---
+
+## Shared rules across all audiences
+
+- Humans remain accountable in every framing. Never imply the agent decides,
+  approves, or ships on its own.
+- Security claims are only as strong as the cited ground truth; do not inflate.
+- Prefer one accurate sentence over five vague ones.
+- If a fact is unknown, say so — do not fill the gap with a plausible guess.

--- a/.agents/skills/communications/technical-concept-translator/reference/concept-library.md
+++ b/.agents/skills/communications/technical-concept-translator/reference/concept-library.md
@@ -211,12 +211,12 @@ source: Playbook SECURITY-CONTROLS.md IA-5; CODING_PRACTICES.md §4; Quickstart 
 ```yaml
 concept: Secrets proxy / injection
 plain_language: A mechanism that lets the sandbox use a credential without the raw secret value ever being placed inside it.
-why_it_matters: The agent can call an authenticated service, but a compromised or curious agent has no raw key to read or leak — for the paths where proxying applies.
-what_it_is_not: NOT a blanket "secrets never enter the sandbox" guarantee. It is true on the default (msb) backend and for sbx's proxied built-in services, but on the sbx backend the USAi key is a custom (unproxied) secret that IS present in the sandbox and readable by the agent — there it is protected by isolation and policy, not by proxying.
+why_it_matters: The agent can call an authenticated service, but a compromised or curious agent has no raw key to read or leak.
+what_it_is_not: Not the same as putting the key in an environment variable for the agent to read. In the sanctioned setup the agent works with a placeholder or a proxied binding, not the real value.
 where_it_fits: Between the host secret store and the service the agent calls.
-controls: Real values live in a host store, never in argv or logs; msb swaps a placeholder for the real value on the wire; GitHub tokens are additionally downscoped per sandbox to only the mounted repositories (least privilege, AC-6).
-example: On msb, the guest holds a placeholder like $MSB_GITHUB_TOKEN; msb substitutes the real token on the wire to github.com, so the token never enters the guest.
-source: Quickstart acq.backends/secret-store.sh; BACKEND_GUIDE.md (swap-on-wire); KNOWN_FAILURE_MODES.md §14 (USAi-on-sbx exception); docs/adr/0013 (downscoping).
+controls: Real values live in a host store, never in argv or logs. Both backends proxy secrets in the default setup — msb swaps a placeholder for the real value on the wire (ENV@HOST), and sbx injects credentials via its proxy for built-in services and via `secret set-custom` for custom endpoints like USAi — so the agent does not hold the raw key material. GitHub tokens are additionally downscoped per sandbox to only the mounted repositories (least privilege, AC-6). Maps to IA-5, SC-28.
+example: On msb, the guest holds a placeholder like $MSB_GITHUB_TOKEN and msb substitutes the real token on the wire; on sbx, USAi is configured with `sbx secret set-custom --host api.gsa.usai.gov --env USAI_API_KEY` so the credential is injected without the agent holding the raw value.
+source: Quickstart acq.backends/secret-store.sh + acq.backends/sbx.sh (set-custom); AGENTS.md Network Access / "No Secrets Exposure" note; BACKEND_GUIDE.md (swap-on-wire); docs/adr/0013 (downscoping).
 ```
 
 ```yaml
@@ -273,7 +273,7 @@ plain_language: The underlying trained system that generates text or code from a
 why_it_matters: It is the raw capability — but on its own it only produces output; it takes no actions.
 what_it_is_not: Not an agent. A model does not read your repository, run commands, or open pull requests by itself.
 where_it_fits: The engine an agent calls; reached here through the USAi endpoint.
-controls: Model access is authenticated and, in the sandbox, mediated so the raw key is protected (see secrets proxy, with the sbx/USAi caveat).
+controls: Model access is authenticated and, in the sandbox, mediated so the raw key is protected (see secrets proxy — proxied on both backends in the default setup).
 example: A large language model accessed via the USAi API answers a coding question.
 source: Quickstart docs/adr/0001 (USAi endpoint).
 ```
@@ -302,12 +302,12 @@ source: Quickstart AGENTS.md (authorized agents: OpenCode, Claude Code, GitHub C
 
 ```yaml
 concept: AGENTS.md
-plain_language: A file in the repository that tells AI coding agents the rules to follow for that project.
+plain_language: A file in the repository that tells AI coding agents the rules and practices to follow for that project.
 why_it_matters: It is how an organization's practices and guardrails travel with the code and are applied consistently by any compatible agent.
-what_it_is_not: NOT a technical enforcement mechanism. It is a behavioral guide that relies on the agent honoring it; real enforcement comes from branch protection, CI checks, sandbox limits, and human review.
+what_it_is_not: NOT a technical enforcement mechanism. It is a behavioral guide that relies on the agent honoring it; the actual enforcement comes from branch protection, CI checks, sandbox limits, and human review — AGENTS.md sets expectations, those controls hold the line.
 where_it_fits: Read automatically by the harness at the start of work; a tool-agnostic convention supported by many agents.
-controls: Encodes the priority order (safety > correctness > compliance > simplicity > performance), the approval gates, and the prohibited actions — but must be backed by the technical controls to be effective.
-example: The playbook's universal AGENTS.md defines what an agent must never do; the quickstart applies a project-specific one in the sandbox.
+controls: Encodes the priority order (safety > correctness > compliance > simplicity > performance), the approval expectations, and the discouraged actions — but because it is guidance rather than a hard boundary, it must be backed by the technical controls to be effective.
+example: The playbook's universal AGENTS.md sets the behavioral expectations an agent should follow; the technical controls (branch protection, CI, the sandbox) are what actually enforce them.
 source: Playbook docs/GETTING-STARTED.md ("AGENTS.md is a behavioral guide, not enforcement").
 ```
 
@@ -339,7 +339,7 @@ plain_language: The authenticated gateway through which the agent reaches an app
 why_it_matters: It is the approved, governed path to model capability — not an arbitrary third-party call.
 what_it_is_not: Not a separate "broker" component with policy of its own in this setup; it is an authenticated endpoint the agent's harness is configured to use.
 where_it_fits: The model endpoint the harness calls from inside the sandbox.
-controls: Authenticated with a key that is protected via the secrets mechanism (with the documented sbx/USAi caveat); egress to the endpoint is on the allowlist.
+controls: Authenticated with a key that is protected via the secrets mechanism (proxied into the sandbox on both backends in the default setup); egress to the endpoint is on the allowlist.
 example: The agent reaches models through the USAi OpenAI-compatible endpoint configured by the usai-provider kit.
 source: Quickstart docs/adr/0001; README (usai-provider kit).
 ```

--- a/.agents/skills/communications/technical-concept-translator/reference/concept-library.md
+++ b/.agents/skills/communications/technical-concept-translator/reference/concept-library.md
@@ -212,11 +212,11 @@ source: Playbook SECURITY-CONTROLS.md IA-5; CODING_PRACTICES.md §4; Quickstart 
 concept: Secrets proxy / injection
 plain_language: A mechanism that lets the sandbox use a credential without the raw secret value ever being placed inside it.
 why_it_matters: The agent can call an authenticated service, but a compromised or curious agent has no raw key to read or leak.
-what_it_is_not: Not the same as putting the key in an environment variable for the agent to read. In the sanctioned setup the agent works with a placeholder or a proxied binding, not the real value.
+what_it_is_not: Not the same as putting the key in an environment variable for the agent to read. The agent works with a placeholder or a proxied binding, not the real value.
 where_it_fits: Between the host secret store and the service the agent calls.
-controls: Real values live in a host store, never in argv or logs. Both backends proxy secrets in the default setup — msb swaps a placeholder for the real value on the wire (ENV@HOST), and sbx injects credentials via its proxy for built-in services and via `secret set-custom` for custom endpoints like USAi — so the agent does not hold the raw key material. GitHub tokens are additionally downscoped per sandbox to only the mounted repositories (least privilege, AC-6). Maps to IA-5, SC-28.
-example: On msb, the guest holds a placeholder like $MSB_GITHUB_TOKEN and msb substitutes the real token on the wire; on sbx, USAi is configured with `sbx secret set-custom --host api.gsa.usai.gov --env USAI_API_KEY` so the credential is injected without the agent holding the raw value.
-source: Quickstart acq.backends/secret-store.sh + acq.backends/sbx.sh (set-custom); AGENTS.md Network Access / "No Secrets Exposure" note; BACKEND_GUIDE.md (swap-on-wire); docs/adr/0013 (downscoping).
+controls: Real values live in a host secret store, never in the sandbox's command line or logs. The sandbox tooling proxies secrets into the sandbox in the default setup, so the agent does not hold the raw key material. Access tokens are additionally scoped to only what a sandbox needs (least privilege, AC-6). Maps to IA-5, SC-28.
+example: The agent's environment holds a placeholder; the sandbox tooling substitutes the real credential when the request reaches the allowed service, so the raw value never enters the sandbox.
+source: Quickstart secret-handling docs (AGENTS.md "No Secrets Exposure"; BACKEND_GUIDE; per-sandbox token downscoping, docs/adr/0013).
 ```
 
 ```yaml
@@ -273,7 +273,7 @@ plain_language: The underlying trained system that generates text or code from a
 why_it_matters: It is the raw capability — but on its own it only produces output; it takes no actions.
 what_it_is_not: Not an agent. A model does not read your repository, run commands, or open pull requests by itself.
 where_it_fits: The engine an agent calls; reached here through the USAi endpoint.
-controls: Model access is authenticated and, in the sandbox, mediated so the raw key is protected (see secrets proxy — proxied on both backends in the default setup).
+controls: Model access is authenticated and, in the sandbox, mediated so the raw key is protected (see secrets proxy — the credential is proxied into the sandbox in the default setup).
 example: A large language model accessed via the USAi API answers a coding question.
 source: Quickstart docs/adr/0001 (USAi endpoint).
 ```

--- a/.agents/skills/communications/technical-concept-translator/reference/concept-library.md
+++ b/.agents/skills/communications/technical-concept-translator/reference/concept-library.md
@@ -1,0 +1,345 @@
+# Executive Concept Library
+
+Reusable, technically-correct executive explanations for the concepts that come
+up when explaining agentic coding to non-engineering leadership. Consumed by
+`technical-concept-translator`, `software-delivery-explainer`,
+`agentic-value-analyst`, and the `design-artifact` `technical-explainer` profile.
+
+## How to use this file
+
+Each entry uses a fixed schema. Take the entry, adapt the depth to the audience
+(see `../../software-delivery-explainer` and the audience profiles), and keep the
+technical facts intact. **Do not** invent detail that is not here; if a fact is
+not in this library or a cited source, say so rather than guess.
+
+```yaml
+concept:            # the term
+plain_language:     # one accurate sentence a non-engineer understands
+why_it_matters:     # why leadership should care
+what_it_is_not:     # bound the concept — stop a false mental model forming
+where_it_fits:      # where it sits in the process/architecture
+controls:           # security/governance implication, if any
+example:            # a short concrete instance
+source:             # citation to ground truth (repo/doc), if the claim needs one
+```
+
+## Ground-truth sources (cite these, do not restate as policy)
+
+The security and process claims below trace to these repositories. This library
+is **reference material, not authoritative policy** — the same rule the source
+repos state about themselves.
+
+- **Playbook** (`GSA-TTS/agentic-coding-playbook`): `AGENTS.md` (agent behavioral
+  contract), `docs/SECURITY-CONTROLS.md` (NIST 800-53 overlay), `docs/AI-CONTRIBUTION-POLICY.md`
+  (human author-of-record), `docs/AGENT-IDENTITY.md` (chain of accountability),
+  `docs/GETTING-STARTED.md` (glossary, CI/CD, "AGENTS.md is a guide not enforcement").
+- **Quickstart** (`GSA-TTS/agentic-coding-quickstart`): `docs/adr/0001` (sandbox
+  isolation), `docs/adr/0013` (token downscoping), `docs/adr/0018`/`0019` (network
+  egress), `BACKEND_GUIDE.md`, `KNOWN_FAILURE_MODES.md` §14 (the secrets caveat),
+  `acq.backends/secret-store.sh`.
+
+---
+
+## Source control & change concepts
+
+```yaml
+concept: Repository
+plain_language: A tracked folder that holds a project's files and the full history of every change to them.
+why_it_matters: It is the system of record for the software — who changed what, when, and why is all auditable.
+what_it_is_not: Not just a backup or a shared drive; it keeps ordered, attributable history, not just the latest copy.
+where_it_fits: The container everything else (issues, branches, pull requests, CI) operates on.
+controls: History is attributable and hard to rewrite silently — supports audit and accountability.
+example: The three GSA-TTS repositories (playbook, quickstart, patterns) are each a repository on GitHub.
+source: —
+```
+
+```yaml
+concept: Commit
+plain_language: A saved, labeled snapshot of a set of changes, attributed to a specific author.
+why_it_matters: It is the atomic unit of "who changed what"; every change is signed to a responsible human.
+what_it_is_not: Not a deployment and not automatically live anywhere — a commit is a recorded change, not a release.
+where_it_fits: Changes are made as commits on a branch, then bundled into a pull request.
+controls: Each commit carries author identity; AI-assisted commits also record the tool as a co-author, with the human as author of record.
+example: "feat(msb): add network tier selector" recorded against a GSA engineer's account.
+source: Playbook docs/AI-CONTRIBUTION-POLICY.md (human author-of-record).
+```
+
+```yaml
+concept: Branch
+plain_language: A separate line of work where changes can be made without affecting the main, shared version.
+why_it_matters: Work-in-progress stays isolated, so unfinished or unreviewed changes never touch the live/main code.
+what_it_is_not: Not a copy of the whole repository for one person to keep; it is a shared, mergeable line of change.
+where_it_fits: A change starts on its own branch; it only reaches the main branch after review and approval.
+controls: The main branch can be protected so nothing merges into it without review and passing checks.
+example: A fix is developed on a branch named "fix/secret-store", reviewed, then merged to main.
+source: Playbook AGENTS.md (agent must not commit directly to protected branches).
+```
+
+```yaml
+concept: Pull request (PR)
+plain_language: A proposal to merge a branch's changes into the main code, opened for review before anything is accepted.
+why_it_matters: It is the control point where humans inspect, discuss, and approve or reject a change before it lands.
+what_it_is_not: Not an automatic merge and not a deployment; opening a PR changes nothing in the live code by itself.
+where_it_fits: Sits between "changes made on a branch" and "changes merged" — the gate where review and automated checks run.
+controls: A human reviewer (not the change's author) approves; automated checks must pass first. Separation of duties (author ≠ approver).
+example: PR #295 in quickstart proposed the network-egress default and was reviewed before merge.
+source: Playbook SECURITY-CONTROLS.md AC-5; AGENTS.md §3.2/§8.2/§14.2.
+```
+
+```yaml
+concept: Review
+plain_language: A person other than the author examines a proposed change and its evidence, then approves it or asks for fixes.
+why_it_matters: Human judgment on correctness, security, and fit — the accountability step that "the AI wrote it" can never replace.
+what_it_is_not: Not a rubber stamp and not something the change's author (human or agent) can do for their own change.
+where_it_fits: On the pull request, after automated checks, before merge.
+controls: Separation of duties — the agent may assist review (flag issues, run scanners) but MUST NOT be the sole reviewer for production-bound code.
+example: A reviewer requests changes on a PR because a test is missing; the author adds it before approval.
+source: Playbook SECURITY-CONTROLS.md AC-5; AI-CONTRIBUTION-POLICY.md.
+```
+
+```yaml
+concept: Merge
+plain_language: Combining an approved branch's changes into the main version of the code.
+why_it_matters: The moment a proposed change becomes part of the shared, official codebase.
+what_it_is_not: Not a deployment to users — merging updates the main code; a separate step releases it.
+where_it_fits: After review approval and passing checks; before (or triggering) deployment.
+controls: Gated by branch protection — requires approval + green checks; the agent may not merge its own pull requests.
+example: After approval, PR #295 was merged into main.
+source: Playbook AGENTS.md §14.2 (agent must not merge its own PRs).
+```
+
+---
+
+## Delivery-pipeline concepts
+
+```yaml
+concept: Issue
+plain_language: A tracked description of a problem to solve or a piece of work to do.
+why_it_matters: It is where work is defined and prioritized before anyone writes code — the "what and why".
+what_it_is_not: Not a task assigned only to an AI, and not a change itself; an issue describes work, it does not perform it.
+where_it_fits: The start of the delivery process; a branch and pull request later reference the issue they resolve.
+controls: Creates a traceable link from a stated need to the change that addressed it.
+example: "acq secret rm cannot remove an orphaned entry" filed as an issue, later closed by a fix PR.
+source: —
+```
+
+```yaml
+concept: Automated test
+plain_language: Code that checks other code behaves as intended, run automatically and repeatably.
+why_it_matters: Catches regressions and mistakes before humans review — cheap, consistent verification at scale.
+what_it_is_not: Not a guarantee the software is correct or secure; tests check what they were written to check, nothing more.
+where_it_fits: Run on the branch and again in CI on every pull request.
+controls: A failing test blocks merge when CI is required; part of the run-and-verify loop.
+example: quickstart's test-acq suite runs on every change to the wrapper.
+source: Playbook docs/GETTING-STARTED.md (CI/CD baseline).
+```
+
+```yaml
+concept: CI (continuous integration)
+plain_language: An automated system that runs checks — tests, security scans, linters — on every proposed change.
+why_it_matters: Consistent, unbiased gate that runs the same checks every time, before a human spends review time.
+what_it_is_not: Not a human review and not a deployment; CI reports pass/fail, it does not judge fitness or ship code.
+where_it_fits: Triggered by a pull request; its results are one input to the human reviewer.
+controls: SAST, SCA, secrets scanning, and the test suite; a required check must pass before merge (SA-11, CM-5).
+example: A PR that introduces a hardcoded secret is blocked by the secrets-scan check.
+source: Playbook docs/GETTING-STARTED.md §7 (CI/CD Security Baseline).
+```
+
+```yaml
+concept: CD / deployment
+plain_language: The controlled process of releasing merged code so it actually runs for users.
+why_it_matters: Merging changes the codebase; deployment is what puts a change in front of real users, under its own controls.
+what_it_is_not: Not automatic on merge in this context, and not something the agent performs; normal deployment controls still apply.
+where_it_fits: After merge; governed by the organization's release and authorization process.
+controls: Human approval gates and (for federal production) an Authorization to Operate remain required; the sandbox environment described here is local-dev only and does not touch production.
+example: A merged change is later released through the team's normal, human-approved deploy process.
+source: Quickstart AGENTS.md (local-dev only, no production access).
+```
+
+---
+
+## Isolation & environment concepts
+
+```yaml
+concept: Sandbox
+plain_language: An isolated environment where an agent can do messy development work with limited, controlled capabilities, separated from the employee's computer.
+why_it_matters: It contains the blast radius — mistakes or misbehavior stay inside a disposable box, not on the workstation or the network at large.
+what_it_is_not: NOT a perfect security guarantee. It does not verify the integrity of the base image it runs (SI-7 is only partially addressed), and it does not stop an authenticated agent from acting broadly with a credential it legitimately holds.
+where_it_fits: Where the agent actually runs and edits code, between the developer's machine and any external service.
+controls: Isolation from the host (treated as untrusted), filesystem limited to mounted project paths, deny-by-default network egress, disposable/ephemeral. Maps to AC-6, SC-7, SC-39.
+example: The quickstart `acq` tool starts a per-project sandbox (microVM via msb, the default, or a container via sbx) for the agent to work in.
+source: Quickstart docs/adr/0001 (isolation; SI-7 partial — integrity depends on image provenance); docs/adr/0013 (egress ≠ repo authority).
+```
+
+```yaml
+concept: VM / microVM
+plain_language: A lightweight, self-contained virtual computer that boots fast and throws away cleanly.
+why_it_matters: Gives strong isolation (its own kernel boundary) without the weight of a full virtual machine — practical for per-task sandboxes.
+what_it_is_not: Not the same as a plain container sharing the host kernel; the microVM boundary is stronger, but still depends on the image it runs.
+where_it_fits: One of the sandbox backends the agent runs inside.
+controls: Process/kernel isolation (SC-39); the default quickstart backend (msb) uses a libkrun microVM.
+example: msb runs the agent in a libkrun microVM with a per-sandbox network policy.
+source: Quickstart BACKEND_GUIDE.md; docs/adr/0001.
+```
+
+```yaml
+concept: Network egress restriction
+plain_language: A rule that blocks the sandbox from reaching the internet except for an explicit list of allowed destinations.
+why_it_matters: Limits where an agent (or a compromised dependency) can send data or reach out to — deny-by-default, not open-by-default.
+what_it_is_not: It controls WHERE traffic can go, not WHAT authority a credential carries — it cannot stop an authenticated request from touching a repo the credential can already reach.
+where_it_fits: Applied to the sandbox at creation; sized by a tier (strict / balanced / open).
+controls: Deny-by-default egress for strict and balanced tiers; "open" is refused unless explicitly confirmed. Maps to SC-7 / AC-4.
+example: The balanced tier allows a curated set of developer hosts (AI services, package registries) and blocks everything else.
+source: Quickstart BACKEND_GUIDE.md (ACQ_NETWORK_TIER); docs/adr/0018, 0019.
+```
+
+---
+
+## Secrets & access concepts
+
+```yaml
+concept: Secret
+plain_language: A sensitive credential — an API key, token, or password — that grants access to a system.
+why_it_matters: A leaked secret is a direct path to whatever it unlocks; handling it correctly is a core security control.
+what_it_is_not: Not something that should ever appear in source code, logs, or a command line.
+where_it_fits: Needed by the agent to reach services (e.g., the model endpoint, source control) — but ideally without the agent ever seeing the raw value.
+controls: Stored in a host-side keychain, never committed, rotated on a schedule; maps to IA-5, SC-28.
+example: The USAi API key and a GitHub token are the secrets an agent sandbox typically needs.
+source: Playbook SECURITY-CONTROLS.md IA-5; CODING_PRACTICES.md §4; Quickstart acq.backends/secret-store.sh.
+```
+
+```yaml
+concept: Secrets proxy / injection
+plain_language: A mechanism that lets the sandbox use a credential without the raw secret value ever being placed inside it.
+why_it_matters: The agent can call an authenticated service, but a compromised or curious agent has no raw key to read or leak — for the paths where proxying applies.
+what_it_is_not: NOT a blanket "secrets never enter the sandbox" guarantee. It is true on the default (msb) backend and for sbx's proxied built-in services, but on the sbx backend the USAi key is a custom (unproxied) secret that IS present in the sandbox and readable by the agent — there it is protected by isolation and policy, not by proxying.
+where_it_fits: Between the host secret store and the service the agent calls.
+controls: Real values live in a host store, never in argv or logs; msb swaps a placeholder for the real value on the wire; GitHub tokens are additionally downscoped per sandbox to only the mounted repositories (least privilege, AC-6).
+example: On msb, the guest holds a placeholder like $MSB_GITHUB_TOKEN; msb substitutes the real token on the wire to github.com, so the token never enters the guest.
+source: Quickstart acq.backends/secret-store.sh; BACKEND_GUIDE.md (swap-on-wire); KNOWN_FAILURE_MODES.md §14 (USAi-on-sbx exception); docs/adr/0013 (downscoping).
+```
+
+```yaml
+concept: Least privilege
+plain_language: Give each actor only the access it needs for the task at hand, and no more.
+why_it_matters: If something is compromised, the damage is bounded to the narrow access it had.
+what_it_is_not: Not a one-time setup — it means actively scoping each credential and capability, not granting broad standing access.
+where_it_fits: Applied to the agent's tokens, filesystem, and network access.
+controls: Per-sandbox fine-grained tokens scoped to mounted repos; filesystem limited to the project directory; explicit capability allowlist. Maps to AC-6, CM-7.
+example: A per-sandbox GitHub token can reach only the repositories that sandbox mounts, so a prompt-injected agent in one sandbox cannot touch others.
+source: Quickstart docs/adr/0013; Playbook SECURITY-CONTROLS.md AC-6, CM-7.
+```
+
+```yaml
+concept: Audit trail
+plain_language: A tamper-resistant log of who (or what) did what, and when.
+why_it_matters: Makes agent actions traceable back to the accountable human — essential for oversight and incident response.
+what_it_is_not: Not something the agent can turn off or edit; an agent that could suppress its own logs would defeat the control.
+where_it_fits: Records every consequential agent action across the process.
+controls: Logs capture agent id, invoking user, timestamp, and correlation id; the agent MUST NOT be able to disable or modify its own audit logs. Maps to AU-2, AU-3, AU-12.
+example: An agent action is logged with both the agent identity and the human who delegated it.
+source: Playbook SECURITY-CONTROLS.md AU-2/3/12; AGENT-IDENTITY.md (chain of accountability).
+```
+
+```yaml
+concept: Human approval gate
+plain_language: A required checkpoint where a person must approve before a consequential action proceeds.
+why_it_matters: Keeps a human in control of the decisions that carry real risk, regardless of how much work the agent did.
+what_it_is_not: Not optional for the actions it covers, and not something the agent can approve for itself or escalate past.
+where_it_fits: Before destructive operations, external network requests, dependency installs, license acceptance, CI/CD changes, commits/pushes, and production deployment.
+controls: The agent MUST obtain explicit approval for the listed actions, MUST NOT self-approve, and MUST fail closed (halt and escalate) on ambiguity.
+example: The agent proposes an execution plan and waits for the human to approve before running it.
+source: Playbook AGENTS.md §3.2 (approval gates), §8.2 (no self-approve), §14.5 (fail closed).
+```
+
+```yaml
+concept: Production access
+plain_language: The ability to change or reach the live systems real users depend on.
+why_it_matters: The highest-consequence access; mistakes here affect users and data directly.
+what_it_is_not: Not something the development sandbox has — the sandbox described here is local-dev only, with no production access and no real sensitive data.
+where_it_fits: Outside the sandbox, behind the organization's deployment and authorization controls.
+controls: Sandbox is FIPS-Low, local-dev, no PII/CUI; the agent MUST NEVER access or modify production systems or data.
+example: A merged change reaches production only through the team's separate, human-approved deployment process.
+source: Quickstart AGENTS.md (prohibited actions; data classification).
+```
+
+---
+
+## Agent-system concepts
+
+```yaml
+concept: AI model
+plain_language: The underlying trained system that generates text or code from a prompt.
+why_it_matters: It is the raw capability — but on its own it only produces output; it takes no actions.
+what_it_is_not: Not an agent. A model does not read your repository, run commands, or open pull requests by itself.
+where_it_fits: The engine an agent calls; reached here through the USAi endpoint.
+controls: Model access is authenticated and, in the sandbox, mediated so the raw key is protected (see secrets proxy, with the sbx/USAi caveat).
+example: A large language model accessed via the USAi API answers a coding question.
+source: Quickstart docs/adr/0001 (USAi endpoint).
+```
+
+```yaml
+concept: Agent
+plain_language: A program that uses a model plus tools to actually do tasks — read files, run commands, edit code — in a loop toward a goal.
+why_it_matters: This is what "does the work"; understanding it as a tool operating under controls (not an autonomous worker) is the key executive point.
+what_it_is_not: Not autonomous and not a replacement for the engineer. It works inside the sandbox and stops at every human approval gate; it cannot approve or merge its own work.
+where_it_fits: Runs inside the sandbox, calls the model, uses tools, and proposes changes for human review.
+controls: Operates under the AGENTS.md behavioral contract; bounded by sandbox isolation, least-privilege credentials, approval gates, and audit logging.
+example: OpenCode running in a quickstart sandbox investigates a repo, drafts a fix, runs tests, and prepares a pull request for review.
+source: Playbook AGENTS.md (behavioral contract); Quickstart AGENTS.md (authorized agents).
+```
+
+```yaml
+concept: Agent harness
+plain_language: The tool that runs an agent — managing its loop, tool access, and configuration.
+why_it_matters: The harness is where the controls are wired in (which tools, which files, which approvals) — it is the enforcement surface around the model.
+what_it_is_not: Not the model (the intelligence) and not the AGENTS.md file (the rules); the harness is the runtime that connects them and enforces tool limits.
+where_it_fits: Between the model and the environment; it is the program a developer launches.
+controls: Enforces tool allowlists and approval prompts; different harnesses (OpenCode, Claude Code, Copilot) read the same AGENTS.md convention.
+example: OpenCode is an agent harness; it reads AGENTS.md and runs the model against the repository with tool gating.
+source: Quickstart AGENTS.md (authorized agents: OpenCode, Claude Code, GitHub Copilot).
+```
+
+```yaml
+concept: AGENTS.md
+plain_language: A file in the repository that tells AI coding agents the rules to follow for that project.
+why_it_matters: It is how an organization's practices and guardrails travel with the code and are applied consistently by any compatible agent.
+what_it_is_not: NOT a technical enforcement mechanism. It is a behavioral guide that relies on the agent honoring it; real enforcement comes from branch protection, CI checks, sandbox limits, and human review.
+where_it_fits: Read automatically by the harness at the start of work; a tool-agnostic convention supported by many agents.
+controls: Encodes the priority order (safety > correctness > compliance > simplicity > performance), the approval gates, and the prohibited actions — but must be backed by the technical controls to be effective.
+example: The playbook's universal AGENTS.md defines what an agent must never do; the quickstart applies a project-specific one in the sandbox.
+source: Playbook docs/GETTING-STARTED.md ("AGENTS.md is a behavioral guide, not enforcement").
+```
+
+```yaml
+concept: Agent Skill
+plain_language: A reusable, packaged instruction set that teaches an agent how to perform a specific procedure well.
+why_it_matters: It lets an organization encode a good practice once and have any compatible agent apply it consistently — reusable organizational knowledge.
+what_it_is_not: Not a policy and not code that runs on its own; a skill is guidance an agent loads when the task matches, still under human review.
+where_it_fits: Loaded by the harness when a task matches the skill's triggers; composed by workflows.
+controls: Skills in this repository are CC0 reference material; security-relevant skills carry governance fields and require human review of their output.
+example: This "technical-concept-translator" skill is an Agent Skill.
+source: Playbook README ("skills convert best practices into workflows any agent can follow"); patterns repo AGENTS.md.
+```
+
+```yaml
+concept: MCP / tool integration
+plain_language: A standard way to give an agent access to an external tool or data source.
+why_it_matters: It is how an agent's reach is extended — and therefore a place where access must be scoped deliberately.
+what_it_is_not: Not unrestricted access; each tool connection should be governed by the same least-privilege and approval rules as any other capability.
+where_it_fits: Configured in the harness; each integration is a capability the agent can use.
+controls: Subject to the capability allowlist and approval gates; new external integrations require explicit approval.
+example: A tool integration that lets the agent query an issue tracker.
+source: Playbook AGENTS.md (approval required for new integrations/capabilities).
+```
+
+```yaml
+concept: Model / API access (USAi)
+plain_language: The authenticated gateway through which the agent reaches an approved AI model.
+why_it_matters: It is the approved, governed path to model capability — not an arbitrary third-party call.
+what_it_is_not: Not a separate "broker" component with policy of its own in this setup; it is an authenticated endpoint the agent's harness is configured to use.
+where_it_fits: The model endpoint the harness calls from inside the sandbox.
+controls: Authenticated with a key that is protected via the secrets mechanism (with the documented sbx/USAi caveat); egress to the endpoint is on the allowlist.
+example: The agent reaches models through the USAi OpenAI-compatible endpoint configured by the usai-provider kit.
+source: Quickstart docs/adr/0001; README (usai-provider kit).
+```

--- a/.agents/skills/communications/technical-concept-translator/tests/test-cases.yml
+++ b/.agents/skills/communications/technical-concept-translator/tests/test-cases.yml
@@ -79,20 +79,27 @@ test_cases:
         case_sensitive: false
 
   - id: secrets-caveat-precise
-    name: "Secrets explanation does not overclaim 'never enter the sandbox'"
-    description: "The secrets concept must reflect the msb vs sbx/USAi caveat, not a blanket guarantee."
+    name: "Secrets explanation reflects proxying on both backends, no raw key in the sandbox"
+    description: "The secrets concept must state secrets are proxied into both backends in the default setup, and must NOT claim the agent holds the raw key or that secrets are unproxied on sbx."
     input:
       type: literal
       content: |
         Real secret values live in a host-side store and never appear in the sandbox's command line or logs.
-        On the default (msb) backend, the guest holds only a placeholder and the real value is swapped in on the wire, so it never enters the guest.
-        On the sbx backend the USAi key is a custom, unproxied secret that IS present in the sandbox and readable by the agent; there it is protected by isolation and policy, not by proxying.
+        Both backends proxy secrets in the default setup: on msb the guest holds a placeholder and the real
+        value is swapped in on the wire; on sbx credentials are injected via the proxy for built-in services
+        and via `secret set-custom` for custom endpoints like USAi. The agent does not hold the raw key material.
     assertions:
       - type: contains
-        pattern: "custom, unproxied secret"
+        pattern: "does not hold the raw key"
+        case_sensitive: false
+      - type: contains
+        pattern: "set-custom"
         case_sensitive: false
       - type: not_contains
-        pattern: "secrets never enter the sandbox"
+        pattern: "unproxied secret"
+        case_sensitive: false
+      - type: not_contains
+        pattern: "readable by the agent"
         case_sensitive: false
 
   - id: unknown-concept-says-not-in-source

--- a/.agents/skills/communications/technical-concept-translator/tests/test-cases.yml
+++ b/.agents/skills/communications/technical-concept-translator/tests/test-cases.yml
@@ -1,0 +1,113 @@
+suite:
+  pattern_id: technical-concept-translator
+  pattern_version: "0.1.0"
+  description: "Tests for the technical-concept-translator skill (accuracy + audience-appropriateness). Inputs are literal exemplar outputs; assertions pin the honesty-critical properties."
+
+test_cases:
+  - id: pull-request-for-ses
+    name: "Explains a pull request accurately with a 'what it is not'"
+    description: "A PR explanation for a non-technical SES must include the bounding 'what it is not' and not imply auto-merge."
+    input:
+      type: literal
+      content: |
+        ## Concept
+        Pull request (PR)
+        ## Plain-Language Explanation
+        A proposal to add a set of changes to the official code, opened so people can review it before anything is accepted.
+        ## Why It Matters
+        It is the checkpoint where a person inspects and approves a change before it becomes part of the system.
+        ## What It Is Not
+        It is not an automatic change and not a release; opening one changes nothing live by itself.
+        ## Where It Fits
+        After work on a separate branch and after automated checks; before the change is merged.
+    assertions:
+      - type: has_sections
+        sections:
+          - "Concept"
+          - "Plain-Language Explanation"
+          - "Why It Matters"
+          - "What It Is Not"
+          - "Where It Fits"
+      - type: not_contains
+        pattern: "merges automatically"
+        case_sensitive: false
+
+  - id: model-vs-agent-vs-harness
+    name: "Distinguishes model, agent, harness, AGENTS.md, and skill"
+    description: "The five-way contrast must keep the model as non-acting and AGENTS.md as a guide not enforcement."
+    input:
+      type: literal
+      content: |
+        The model is the raw intelligence and takes no action on its own.
+        The agent uses the model plus tools to do work in a loop.
+        The harness is the program that runs the agent and enforces its tool limits.
+        AGENTS.md is the rules file the harness reads; it is a behavioral guide, not a technical enforcement mechanism.
+        A skill is a reusable instruction set the agent loads for a specific task.
+    assertions:
+      - type: contains
+        pattern: "takes no action"
+        case_sensitive: false
+      - type: contains
+        pattern: "guide, not a technical enforcement"
+        case_sensitive: false
+
+  - id: sandbox-honest-limits
+    name: "Sandbox explanation states its limits, not a perfect guarantee"
+    description: "Sandbox must be bounded — image-provenance/authority caveat present; no absolute-guarantee language."
+    input:
+      type: literal
+      content: |
+        ## Concept
+        Sandbox
+        ## Plain-Language Explanation
+        An isolated environment where an agent does development work with limited, controlled capabilities, separated from the employee's computer.
+        ## Why It Matters
+        It contains the blast radius — mistakes stay inside a disposable box.
+        ## What It Is Not
+        Not a perfect security guarantee: it does not verify the integrity of the base image it runs, and it does not stop an authenticated agent from acting with a credential it legitimately holds.
+        ## Where It Fits
+        Where the agent runs and edits code, between the developer's machine and any external service.
+    assertions:
+      - type: has_sections
+        sections:
+          - "What It Is Not"
+      - type: contains
+        pattern: "not a perfect security guarantee"
+        case_sensitive: false
+      - type: not_contains
+        pattern: "completely secure"
+        case_sensitive: false
+
+  - id: secrets-caveat-precise
+    name: "Secrets explanation does not overclaim 'never enter the sandbox'"
+    description: "The secrets concept must reflect the msb vs sbx/USAi caveat, not a blanket guarantee."
+    input:
+      type: literal
+      content: |
+        Real secret values live in a host-side store and never appear in the sandbox's command line or logs.
+        On the default (msb) backend, the guest holds only a placeholder and the real value is swapped in on the wire, so it never enters the guest.
+        On the sbx backend the USAi key is a custom, unproxied secret that IS present in the sandbox and readable by the agent; there it is protected by isolation and policy, not by proxying.
+    assertions:
+      - type: contains
+        pattern: "custom, unproxied secret"
+        case_sensitive: false
+      - type: not_contains
+        pattern: "secrets never enter the sandbox"
+        case_sensitive: false
+
+  - id: unknown-concept-says-not-in-source
+    name: "An ungrounded concept is flagged, not fabricated"
+    description: "Anti-fabrication: when a concept is not in the library or a cited source, the skill says so instead of inventing facts."
+    input:
+      type: literal
+      content: |
+        The requested concept is not in the executive concept library and I could not
+        find it in a cited playbook or quickstart source, so I will not invent a
+        definition. Please point me at a source or confirm the concept name.
+    assertions:
+      - type: contains
+        pattern: "not in the executive concept library"
+        case_sensitive: false
+      - type: contains
+        pattern: "will not invent"
+        case_sensitive: false

--- a/.agents/skills/communications/technical-concept-translator/tests/test-cases.yml
+++ b/.agents/skills/communications/technical-concept-translator/tests/test-cases.yml
@@ -79,21 +79,21 @@ test_cases:
         case_sensitive: false
 
   - id: secrets-caveat-precise
-    name: "Secrets explanation reflects proxying on both backends, no raw key in the sandbox"
-    description: "The secrets concept must state secrets are proxied into both backends in the default setup, and must NOT claim the agent holds the raw key or that secrets are unproxied on sbx."
+    name: "Secrets explanation is accurate and backend-neutral: proxied, no raw key in the sandbox"
+    description: "The secrets concept must state secrets are proxied into the sandbox in the default setup (agent holds no raw key), stay at the acq-abstraction level (no backend internals), and must NOT claim the agent holds the raw key."
     input:
       type: literal
       content: |
         Real secret values live in a host-side store and never appear in the sandbox's command line or logs.
-        Both backends proxy secrets in the default setup: on msb the guest holds a placeholder and the real
-        value is swapped in on the wire; on sbx credentials are injected via the proxy for built-in services
-        and via `secret set-custom` for custom endpoints like USAi. The agent does not hold the raw key material.
+        The sandbox tooling proxies secrets into the sandbox in the default setup: the agent works with a
+        placeholder, and the real credential is substituted when the request reaches the allowed service.
+        The agent does not hold the raw key material.
     assertions:
       - type: contains
         pattern: "does not hold the raw key"
         case_sensitive: false
       - type: contains
-        pattern: "set-custom"
+        pattern: "proxies secrets into the sandbox"
         case_sensitive: false
       - type: not_contains
         pattern: "unproxied secret"

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -2,7 +2,7 @@
 
 > **Generated file — do not edit by hand.** Run `make generate` (regenerates INDEX.yaml + CATALOG.md). Source of truth is each pattern's `SKILL.md`/`AGENTS.md` frontmatter.
 
-38 patterns — 27 skills, 3 prompts, 3 agents, 4 workflows, 1 lessons.
+41 patterns — 30 skills, 3 prompts, 3 agents, 4 workflows, 1 lessons.
 
 For machine routing use the [`pattern-router`](.agents/skills/meta/pattern-router/SKILL.md) skill + `scripts/route_patterns.py`; this catalog is the human view.
 
@@ -64,12 +64,15 @@ For machine routing use the [`pattern-router`](.agents/skills/meta/pattern-route
 
 | Pattern | Type | Status | Tasks | Consumes | Produces |
 |---------|------|--------|-------|----------|----------|
+| [`agentic-value-analyst`](skills/communications/agentic-value-analyst/SKILL.md) | skill | experimental | analyze, author | documentation | documentation |
 | [`artifact-brief`](skills/communications/artifact-brief/SKILL.md) | skill | experimental | plan | documentation | artifact-brief |
 | [`artifact-qa`](skills/communications/artifact-qa/SKILL.md) | skill | experimental | review, test | one-pager, slide-deck | qa-report |
-| [`design-artifact`](workflows/design-artifact/SKILL.md) | workflow | experimental | author, orchestrate, render, review, visualize | documentation | one-pager, slide-deck |
+| [`design-artifact`](workflows/design-artifact/SKILL.md) | workflow | experimental | author, orchestrate, render, review, visualize | documentation | one-pager, slide-deck, technical-explainer |
 | [`explainer-gif`](skills/outreach/explainer-gif/SKILL.md) | skill | experimental | author, render | artifact-brief, shell-script | explainer-gif, terminal-demo |
 | [`explainer-video`](skills/outreach/explainer-video/SKILL.md) | skill | experimental | author, render | artifact-brief, web-page | explainer-video, marketing-asset |
 | [`narrative-architect`](skills/communications/narrative-architect/SKILL.md) | skill | experimental | plan, visualize | artifact-brief | storyboard |
 | [`one-pager`](skills/communications/one-pager/SKILL.md) | skill | experimental | author, render | artifact-brief, storyboard, visual-contract | one-pager |
 | [`slide-deck`](skills/communications/slide-deck/SKILL.md) | skill | experimental | author, render | artifact-brief, storyboard, visual-contract | slide-deck |
+| [`software-delivery-explainer`](skills/communications/software-delivery-explainer/SKILL.md) | skill | experimental | author, transform | documentation | documentation |
+| [`technical-concept-translator`](skills/communications/technical-concept-translator/SKILL.md) | skill | experimental | author, transform | documentation | documentation |
 | [`visual-direction`](skills/communications/visual-direction/SKILL.md) | skill | experimental | visualize | storyboard | visual-contract |

--- a/INDEX.yaml
+++ b/INDEX.yaml
@@ -50,6 +50,25 @@ patterns:
       - ci agent audit
       - github actions security
       - workflow audit
+  - path: skills/communications/agentic-value-analyst/SKILL.md
+    id: agentic-value-analyst
+    title: Agentic Value Analyst
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - analyze
+      - author
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - documentation
+      aliases:
+      - ROI framing without hype
+      - value framing
+      priority: 55
   - path: skills/communications/artifact-brief/SKILL.md
     id: artifact-brief
     title: Artifact Brief
@@ -461,6 +480,44 @@ patterns:
       - briefing slides
       - presentation deck
       priority: 55
+  - path: skills/communications/software-delivery-explainer/SKILL.md
+    id: software-delivery-explainer
+    title: Software Delivery Explainer
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - author
+      - transform
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - documentation
+      aliases:
+      - agentic workflow explainer
+      - delivery pipeline explainer
+      priority: 55
+  - path: skills/communications/technical-concept-translator/SKILL.md
+    id: technical-concept-translator
+    title: Technical Concept Translator
+    type: skill
+    status: experimental
+    categories: []
+    collection: communications
+    routing:
+      task_types:
+      - author
+      - transform
+      input_artifacts:
+      - documentation
+      output_artifacts:
+      - documentation
+      aliases:
+      - concept explainer
+      - executive glossary
+      priority: 55
   - path: skills/test-generation/SKILL.md
     id: test-generation
     title: Test Case Generation
@@ -729,6 +786,7 @@ patterns:
       output_artifacts:
       - one-pager
       - slide-deck
+      - technical-explainer
       aliases:
       - design pipeline
       - executive one-pager
@@ -898,6 +956,7 @@ categories:
   - uswds-prototype
 collections:
   communications:
+  - agentic-value-analyst
   - artifact-brief
   - artifact-qa
   - design-artifact
@@ -906,6 +965,8 @@ collections:
   - narrative-architect
   - one-pager
   - slide-deck
+  - software-delivery-explainer
+  - technical-concept-translator
   - visual-direction
   content:
   - documentation-agent
@@ -945,6 +1006,7 @@ task_types:
   analyze:
   - accessibility-review
   - agentic-actions-auditor
+  - agentic-value-analyst
   - backdoor-review
   - compliance-claim-checker
   - dependency-analysis
@@ -960,6 +1022,7 @@ task_types:
   - security-scan-review
   - untrusted-input-boundary-review
   author:
+  - agentic-value-analyst
   - design-artifact
   - documentation-agent
   - explainer-gif
@@ -969,6 +1032,8 @@ task_types:
   - one-pager
   - safe-shell-script-author
   - slide-deck
+  - software-delivery-explainer
+  - technical-concept-translator
   - test-generation
   - uswds-form-flow
   - uswds-landing-page
@@ -1024,6 +1089,9 @@ task_types:
   - qa-round
   - qa-workflow
   - test-generation
+  transform:
+  - software-delivery-explainer
+  - technical-concept-translator
   visualize:
   - design-artifact
   - narrative-architect
@@ -1032,10 +1100,13 @@ output_artifacts:
   artifact-brief:
   - artifact-brief
   documentation:
+  - agentic-value-analyst
   - documentation-agent
   - example-agentic-session
   - federal-service-blueprint
   - implementation-plan
+  - software-delivery-explainer
+  - technical-concept-translator
   explainer-gif:
   - explainer-gif
   explainer-video:
@@ -1088,6 +1159,8 @@ output_artifacts:
   - uswds-prototype
   storyboard:
   - narrative-architect
+  technical-explainer:
+  - design-artifact
   terminal-demo:
   - explainer-gif
   visual-contract:
@@ -1095,8 +1168,8 @@ output_artifacts:
   web-prototype:
   - uswds-prototype
 stats:
-  total_patterns: 38
-  skills: 27
+  total_patterns: 41
+  skills: 30
   prompts: 3
   agents: 3
   workflows: 4

--- a/README.md
+++ b/README.md
@@ -182,6 +182,30 @@ references it rather than restating it.
 > change to a security skill require human sign-off — see the
 > [human-review gates](docs/security-skill-governance.md#human-review-gates).
 
+## Executive Technical Explainer Skills
+
+A set of `communications` skills for explaining software development, agentic
+coding, and security controls to **executive / non-engineering audiences** —
+accurately, without hype, and without making an engineer wince at the
+inaccuracies. They are evidence-grounded: security and process claims cite the
+[playbook](https://github.com/GSA-TTS/agentic-coding-playbook) and
+[quickstart](https://github.com/GSA-TTS/agentic-coding-quickstart) as ground
+truth, and they preserve the honest limits (the sandbox is isolation, not a
+perfect guarantee; the precise secrets caveat; the agent cannot approve or merge
+its own work).
+
+| Skill | Use it for |
+|-------|------------|
+| [`technical-concept-translator`](skills/communications/technical-concept-translator/) | Explaining one concept (PR, sandbox, agent vs. model vs. harness, AGENTS.md, secret) to an executive |
+| [`software-delivery-explainer`](skills/communications/software-delivery-explainer/) | Showing where agents act and where the human control points are in the delivery process |
+| [`agentic-value-analyst`](skills/communications/agentic-value-analyst/) | Framing organizational value without hype; evidence-labeled claims, defensible metrics |
+
+These compose into the `design-artifact` workflow's **`technical-explainer`**
+profile. Any team can use them independently of a leadership-briefing use case —
+they are a reusable capability for turning technical material into accurate
+executive explanations. Reference material (an executive concept library, six
+audience profiles, and evidence/measurement guidance) ships alongside the skills.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines.

--- a/schemas/taxonomy.yaml
+++ b/schemas/taxonomy.yaml
@@ -116,6 +116,9 @@ artifact_types:
   slide-deck:
     description: A presentation deck.
     aliases: [deck, slides]
+  technical-explainer:
+    description: A longer explanatory document that translates technical/agentic/security concepts for a non-engineering executive audience.
+    aliases: [executive-explainer, concept-explainer]
   marketing-asset:
     description: A marketing/outreach asset.
     aliases: [marketing-kit]

--- a/workflows/design-artifact/SKILL.md
+++ b/workflows/design-artifact/SKILL.md
@@ -2,7 +2,7 @@
 id: design-artifact
 version: "1.0.0"
 title: "Design Artifact Workflow"
-description: "End-to-end workflow to produce a QA'd communication artifact — brief, narrative, visual direction, render, validate — selecting an output profile (one-pager or slide-deck) so one shared pipeline serves every format."
+description: "End-to-end workflow to produce a QA'd communication artifact — brief, narrative, visual direction, render, validate — selecting an output profile (one-pager, slide-deck, or technical-explainer) so one shared pipeline serves every format."
 type: workflow
 status: experimental
 owners:
@@ -20,6 +20,9 @@ requires:
     - one-pager
     - slide-deck
     - artifact-qa
+    - technical-concept-translator
+    - software-delivery-explainer
+    - agentic-value-analyst
 output:
   format: markdown
   contract:
@@ -57,6 +60,7 @@ routing:
   output_artifacts:
     - one-pager
     - slide-deck
+    - technical-explainer
   aliases:
     - "executive one-pager"
     - "presentation deck"
@@ -103,13 +107,27 @@ narrative, and QA don't get duplicated across four separate workflows.
 profiles:
   - one-pager            # → skills/communications/one-pager
   - slide-deck           # → skills/communications/slide-deck
-  - technical-explainer  # (future) longer explanatory doc
+  - technical-explainer  # → longer explanatory doc for executives (implemented)
   - marketing-kit        # (future) multi-asset outreach bundle
 ```
 
-The profile is chosen from the brief's `constraints.profile`. `one-pager` and
-`slide-deck` are implemented today; the other two are placeholders for future
-renderers and should route to the closest implemented profile until they exist.
+The profile is chosen from the brief's `constraints.profile`. `one-pager`,
+`slide-deck`, and `technical-explainer` are implemented today; `marketing-kit` is
+a placeholder for a future renderer and should route to the closest implemented
+profile until it exists.
+
+The **`technical-explainer`** profile produces an accurate, executive-facing
+explanatory document (not a one-pager or a deck). Its content is sourced from the
+three explainer skills rather than a new renderer skill:
+[`technical-concept-translator`](../../skills/communications/technical-concept-translator/SKILL.md)
+(concept mental models),
+[`software-delivery-explainer`](../../skills/communications/software-delivery-explainer/SKILL.md)
+(process + control points), and
+[`agentic-value-analyst`](../../skills/communications/agentic-value-analyst/SKILL.md)
+(evidence-labeled value). It carries a hard accuracy bar: no overclaimed agent
+autonomy, no overclaimed sandbox guarantees, and the precise secrets caveat (msb
+vs. sbx/USAi). Run `plain-language-review` for readability and `artifact-qa` for
+the output contract.
 
 ## Procedure
 
@@ -122,6 +140,10 @@ renderers and should route to the closest implemented profile until they exist.
 4. **Render** — dispatch to the profile's renderer:
    - `one-pager` → `one-pager` skill
    - `slide-deck` → `slide-deck` skill
+   - `technical-explainer` → compose `technical-concept-translator` +
+     `software-delivery-explainer` + `agentic-value-analyst` into an explanatory
+     document; run `plain-language-review` for readability. (Reuses these skills
+     rather than adding a new renderer.)
 5. **QA** — run `artifact-qa` on the rendered files; if it FAILs, loop back to
    the smallest responsible step (usually render or visual-direction) and
    re-run.


### PR DESCRIPTION
Implements the core of epic #319 — an evidence-grounded capability for explaining software development, agentic coding, and security controls to executive / non-engineering audiences.

Quality bar: hand an agent a concept, process, or value question and it produces an explanation an executive understands **without making an engineer wince at the inaccuracies.**

## What's in this PR

**Skills (`communications` collection)**
- **`technical-concept-translator`** (#320) — one concept → accurate executive mental model (what it is / plain language / why it matters / **what it is NOT** / where it fits / controls). Backed by the concept library.
- **`software-delivery-explainer`** (#321) — the delivery pipeline + where agents act and where the **human control points** are; thesis *"more work between the controls, not fewer controls."*
- **`agentic-value-analyst`** (#322) — value without hype; five evidence classes; defensible metrics over vanity metrics; honest handling of conflicting research.

**Reference material (not skills)** (#324, #325)
- `concept-library.md` — 24 concepts, each with a "what it is not" and **ground-truth `source:` citations** to the playbook/quickstart.
- `audience-profiles.md` — CIO/CTO, CISO, CAIO, program exec, COO, acquisition.
- `measurement-guidance.md` — evidence classes, good vs. misleading metrics, cost/value framing.

**Workflow / profile** (#323)
- Implemented the previously-**reserved** `technical-explainer` profile in `design-artifact` by **composing the three skills** (no new renderer). Added `technical-explainer` to `schemas/taxonomy.yaml`.

## Honesty properties (pinned by deterministic test-cases)

- **Sandbox** = isolation, *not* a perfect guarantee (image-provenance/SI-7 caveat; egress ≠ repo authority). Test asserts "not a perfect security guarantee" present, "completely secure" absent.
- **Secrets** — precise caveat: host store; msb swap-on-wire (never enters guest); on **sbx the USAi key is a custom *unproxied* secret visible to the agent**, protected by isolation not proxying. Test asserts "custom, unproxied secret" present and **"secrets never enter the sandbox" absent**.
- **Agent autonomy** — cannot self-approve/self-merge; humans review/approve. Test asserts those overclaims are absent and "author is not the approver" present.
- **Value** — "does AI make devs 50% faster?" answered qualified/ranged with an evidence class; lines-of-code flagged misleading.
- **Anti-fabrication** — an ungrounded concept is flagged ("will not invent"), not fabricated.

## Process

- Architecture (extend `design-artifact`, don't build parallel) chosen via **nexus 7/7 higher-order consensus**.
- Adversarial accuracy/security/over-triggering review: **7/7 approve**; the two hardening suggestions (anti-fabrication test + explicit differentiation from `plain-language-review`/`narrative-architect`/renderers) applied.

## Validation

- `make validate` ✓ · `make generate-check` ✓ (INDEX/CATALOG regenerated) · `run_test_cases.py` **73/73** ✓ · markdownlint ✓

## Follow-on
- `repo-evidence-extractor` (the "executive demo" input that reads a real repo/issue/PR) is tracked as a separate epic **#328** so it gets its own threat model.

Refs #319 #320 #321 #322 #323 #324 #325

AI-assisted (OpenCode).