### PR TITLE
docs(git-ssh-sign): keep backend-parity prose backend-neutral

### DIFF
--- a/integrations/isolation/acq-kits/git-ssh-sign/README.md
+++ b/integrations/isolation/acq-kits/git-ssh-sign/README.md
@@ -22,18 +22,14 @@ and signing resolves the public key from that agent at signing time.
 ## Backend parity
 
 The config half (system gitconfig) and the key-resolution script are identical
-across backends. The only per-backend difference is **how the host SSH agent is
-forwarded into the guest** — SSH-agent forwarding is the shared mechanism, with
-no spec shortcut:
-
-| Backend | SSH-agent forwarding |
-|---------|----------------------|
-| **sbx** | The SSH agent socket is forwarded into the sandbox. |
-| **msb** | `msb ssh authorize` registers the key with the sandbox's host-controlled sshd; attach forwards the agent. |
-| **ppp** (later) | `podman machine ssh -A` propagates `SSH_AUTH_SOCK`. |
+across backends — this kit carries no per-backend logic and no spec shortcut.
+Forwarding the host SSH agent into the sandbox is handled by `acq`, which does
+it on every supported backend whenever the host `SSH_AUTH_SOCK` is set; the
+per-backend plumbing is `acq`'s concern, not the kit's.
 
 **Behavioral parity:** git signs commits/tags with the forwarded host key on
-every backend; the private key never enters the guest.
+every backend; the signing key is resolved from the agent at signing time and
+the private key never enters the guest.
 
 ## Prerequisites
 

--- a/integrations/isolation/acq-kits/git-ssh-sign/spec.yaml
+++ b/integrations/isolation/acq-kits/git-ssh-sign/spec.yaml
@@ -19,10 +19,10 @@
 #     when the forwarded agent may not be connected yet.
 #
 # If no SSH agent / key is available, git signing fails with a clear error
-# (fail-closed). No backend shortcut: SSH-agent forwarding is the common
-# mechanism, and each backend enables it its own way (sbx forwards the agent
-# socket; msb uses `msb ssh authorize` + agent forwarding; ppp uses
-# `podman machine ssh -A`) — documented, not a spec shortcut.
+# (fail-closed). No backend shortcut: SSH-agent forwarding is the shared
+# mechanism. `acq` forwards the host SSH agent into the sandbox (whenever the
+# host SSH_AUTH_SOCK is set); how it does so per backend is acq's concern, not
+# this kit's — documented in the acq wrapper, not a spec shortcut.
 schemaVersion: "hybrid/v1"
 kind: mixin
 name: git-ssh-sign
@@ -65,8 +65,9 @@ agentContext: |
   Commits and tags are signed automatically. Use `git log --show-signature`
   to verify signatures on existing commits.
 
-# No backend shortcuts: SSH-agent forwarding is the shared mechanism; each
-# backend enables it natively (documented in README, not a spec shortcut).
+# No backend shortcuts: SSH-agent forwarding is the shared mechanism, resolved
+# at signing time. `acq` forwards the host SSH agent into the sandbox on each
+# backend (documented in the acq wrapper, not a spec shortcut).
 backend_shortcuts:
   sbx: {}
   msb: {}

--- a/integrations/isolation/acq-kits/kits.yaml
+++ b/integrations/isolation/acq-kits/kits.yaml
@@ -38,10 +38,11 @@ kits:
   git-ssh-sign:
     backends: [sbx, msb]
     parity: |
-      Both backends forward the host SSH agent (sbx forwards the agent socket;
-      msb uses `msb ssh authorize` + agent forwarding). The signing key is
-      resolved at signing time; no key material is written at create. No backend
-      shortcut — SSH-agent forwarding is the shared mechanism.
+      `acq` forwards the host SSH agent into the sandbox on both backends
+      whenever the host SSH_AUTH_SOCK is set (the per-backend plumbing is acq's
+      concern, not the kit's). The signing key is resolved at signing time; no
+      key material is written at create. No backend shortcut — SSH-agent
+      forwarding is the shared mechanism.
 
   openchamber:
     backends: [sbx, msb]


### PR DESCRIPTION
## Context

The `git-ssh-sign` kit already declares `backends: [sbx, msb]`, but its backend-parity prose spelled out **how** each backend forwards the host SSH agent. That plumbing is the `acq` wrapper's concern — `acq` abstracts the isolation backend, so the kit should not name backend-specific mechanisms (and the per-backend notes had drifted out of date besides).

## Change

Docs/comment-only. Replace the per-backend forwarding table/notes with a backend-neutral statement: `acq` forwards the host SSH agent into the sandbox on every supported backend whenever the host `SSH_AUTH_SOCK` is set; the signing key is resolved from the agent at signing time and the private key never enters the guest.

- `git-ssh-sign/spec.yaml` — header comments
- `git-ssh-sign/README.md` — backend-parity section
- `kits.yaml` — git-ssh-sign parity note

No spec keys changed (`schemaVersion`, `backends`, `files`, `commands`, `backend_shortcuts` untouched).

## Dependency

Kit-side half of the msb git-signing parity work tracked in GSA-TTS/agentic-coding-quickstart#303. Once merged, the quickstart repo bumps `PATTERNS_KIT_REF` to this commit (GSA-TTS/agentic-coding-quickstart#317).

## Verification

YAML parses for both edited YAML files. Docs-only; no code paths changed.

AI-assisted (OpenCode).