### PR TITLE
docs(ecosystem): reframe Quickstart as local dev env for Low/Moderate work

### DIFF
--- a/docs/repository-ecosystem.md
+++ b/docs/repository-ecosystem.md
@@ -191,7 +191,7 @@ If you find patterns diverging between repos:
 |------------|------------|------------|-------|
 | Playbook | Moderate | ATO-ready guidance | Full SDLC |
 | Patterns | N/A (public) | Public patterns | Reusable patterns |
-| Quickstart | Low | Pre-ATO (development) | Local dev only |
+| Quickstart | Low/Moderate | Local development only | Local dev only |
 
 **When working across repos:** Default to **FIPS Moderate** constraints unless explicitly scoped to local development.
 


### PR DESCRIPTION
Companion to GSA-TTS/agentic-coding-quickstart#312 / GSA-TTS/agentic-coding-quickstart#326.

## Summary

Docs-only positioning change. Updates the impact-levels table so the Quickstart
row describes it as a **local development environment** for building **Low- and
Moderate-impact** code, dropping the "Pre-ATO (development)" framing to match the
refined positioning adopted in the Quickstart repo. No behavior change.

## Change

- `docs/repository-ecosystem.md` impact-levels table, Quickstart row:
  `Low | Pre-ATO (development) | Local dev only` → `Low/Moderate | Local development only | Local dev only`

## Verification

- `markdownlint-cli2` on `docs/repository-ecosystem.md`: **0 issues**

AI-assisted (OpenCode).