### PR TITLE
fix(kits): bind Paseo daemon to 0.0.0.0 so create-time publish reaches it

### DIFF
--- a/integrations/isolation/acq-kits/paseo/README.md
+++ b/integrations/isolation/acq-kits/paseo/README.md
@@ -143,13 +143,14 @@ no extra kit is needed.
 ## Security
 
 The Paseo daemon runs **unsecured** (no `PASEO_PASSWORD`) and is bound to
-**`127.0.0.1` (loopback)** inside the sandbox. This is safe **only because the
+**`0.0.0.0` (all interfaces)** inside the sandbox. This is safe **only because the
 sandbox is the security boundary** — an ephemeral container with a proxied,
-allow-listed network and no host filesystem access. The in-guest loopback bind is
-a defense-in-depth choice (over binding `0.0.0.0` in-guest): the daemon is
-single-consumer, and the only thing that must reach it — `acq`'s port-publish —
-forwards from the host loopback port to the guest over the guest's loopback
-interface, so the daemon is never exposed on the guest's external interface.
+allow-listed network and no host filesystem access. The in-guest `0.0.0.0` bind is
+required for reachability: `acq`'s create-time port publish (msb `-p HOST:GUEST`)
+binds a **host loopback** listener but dials the sandbox's **guest network IP**,
+not guest `127.0.0.1`, so a loopback-only in-guest bind would answer inside the
+sandbox yet return "Empty reply from server" on the published host port. See
+[GSA-TTS/agentic-coding-quickstart#333](https://github.com/GSA-TTS/agentic-coding-quickstart/pull/333).
 
 **Run this only on a trusted, single-tenant host.** The daemon is published to a
 host **loopback** port and is live for the sandbox's whole lifetime. Loopback
@@ -158,9 +159,11 @@ local user, or anything you forward that port to) can drive Paseo — and the
 agents it launches — without a credential. Don't forward the mapped port to a
 wider interface.
 
-> The loopback-only guarantee depends on `acq` publishing the guest
-> `127.0.0.1:6767` daemon bind to a loopback-scoped host port, which it does at
-> create time from the kit's neutral `publishedPorts`.
+> The host-side loopback guarantee depends on `acq` publishing the guest
+> `6767` daemon port to a loopback-scoped host port, which it does at
+> create time from the kit's neutral `publishedPorts`. (The guest daemon itself
+> binds `0.0.0.0:6767` so the create-time publish can reach it — see the Fig.
+> in quickstart#333 — but the HOST side of the mapping stays loopback-only.)
 >
 > Paseo's bundled web UI static files are public on the daemon origin; the daemon
 > API and WebSocket would be password-protected if `PASEO_PASSWORD` were set. We

--- a/integrations/isolation/acq-kits/paseo/TROUBLESHOOTING.md
+++ b/integrations/isolation/acq-kits/paseo/TROUBLESHOOTING.md
@@ -30,6 +30,51 @@ acq exec <sandbox> -- sh -c 'curl -fsS http://127.0.0.1:6767/api/health && echo 
   acq exec <sandbox> -- sh -c 'tail -n 40 ~/.local/state/paseo/paseo-install.log'
   ```
 
+## Host curl returns "Empty reply from server" (guest curl works)
+
+**Symptom.** `acq ports <sandbox>` shows container `6767` mapped to a host port,
+and the daemon answers from *inside* the sandbox:
+
+```bash
+acq exec <sandbox> -- sh -c 'curl -fsS http://127.0.0.1:6767/api/health && echo OK'   # -> OK
+```
+
+…but the same request from the **host** fails:
+
+```bash
+curl http://127.0.0.1:<host-port-for-6767>/
+# curl: (52) Empty reply from server
+```
+
+Chrome shows `net::ERR_EMPTY_RESPONSE`. The TCP connect to the host listener
+*succeeds* — this is not a connection reset / ingress-deny.
+
+**Cause — the daemon is bound to guest loopback only.** On the **msb** backend,
+create-time port publish (`-p HOST:GUEST`) binds a host loopback listener but the
+publisher connects to the sandbox's **guest network IP**, not guest `127.0.0.1`.
+A daemon bound only to `127.0.0.1:6767` is therefore healthy from inside the
+sandbox yet unreachable through the create-time published port. Confirm the bind:
+
+```bash
+acq exec <sandbox> -- sh -c 'awk "\$2 ~ /:1A6F\$/ && \$4==\"0A\" {print \$2}" /proc/net/tcp'
+# 00000000:1A6F = 0.0.0.0:6767 (good); 0100007F:1A6F = 127.0.0.1:6767 (the bug)
+```
+
+**Fix.** This kit sets `PASEO_LISTEN=0.0.0.0:6767` in `spec.yaml` so the guest
+daemon binds all interfaces and the create-time publish can reach it. If you are
+running an older sandbox that predates this (or a manual `PASEO_LISTEN` override to
+loopback), either rebuild with the current kit or use acq's post-hoc publish path,
+which tunnels from *inside* the guest and can reach guest loopback:
+
+```bash
+acq --backend msb ports <sandbox> --publish 16767:6767
+curl http://127.0.0.1:16767/
+```
+
+The host side of the mapping stays loopback-only either way, so the `0.0.0.0`
+in-guest bind does not widen host exposure. See
+[GSA-TTS/agentic-coding-quickstart#333](https://github.com/GSA-TTS/agentic-coding-quickstart/pull/333).
+
 ## "No hosts configured" and/or a repeating `ws://…/ws` connect loop
 
 **Symptom.** The UI loads at `http://127.0.0.1:<host-port>`, but shows **no hosts**,
@@ -301,7 +346,7 @@ inbound path; here the host reaches the web UI directly over the loopback-
 published port (see README "Reaching it from the host"), so the relay is pure
 noise.
 
-**This does NOT affect the web UI.** The daemon still binds `127.0.0.1:6767` and
+**This does NOT affect the web UI.** The daemon still binds `0.0.0.0:6767` and
 serves the API + WebSocket + UI locally; `curl http://127.0.0.1:6767/api/health`
 returns 200 throughout. If the **host** browser sees a refused connection, that is
 a port-mapping issue (see "The browser UI never loads" above), not the relay.

--- a/integrations/isolation/acq-kits/paseo/docs/decisions/supervisor-owns-daemon-wrapper-pins-worktrees.md
+++ b/integrations/isolation/acq-kits/paseo/docs/decisions/supervisor-owns-daemon-wrapper-pins-worktrees.md
@@ -28,7 +28,7 @@ entrypoint runs in the primary workspace on `acq run`).
 
 - **The startup script (`paseo-start.sh`) owns the daemon lifecycle.** It installs
   the Paseo CLI on first boot and supervises
-  `paseo daemon start --foreground --listen 127.0.0.1:6767 --web-ui` in a respawn
+  `paseo daemon start --foreground --listen 0.0.0.0:6767 --web-ui` in a respawn
   loop marked `supervisor:paseo-daemon`. The daemon comes up immediately with
   whatever `config.json` currently says (default root on first boot).
 - **The entrypoint pins the worktree root.** On `acq run` the thin wrapper

--- a/integrations/isolation/acq-kits/paseo/files/home/paseo-agent-shim
+++ b/integrations/isolation/acq-kits/paseo/files/home/paseo-agent-shim
@@ -55,7 +55,7 @@
 set -eu
 
 # Daemon bind. Keep in sync with the kit spec's PASEO_LISTEN / publishedPorts.
-PASEO_PORT="$(printf '%s' "${PASEO_LISTEN:-127.0.0.1:6767}" | sed -n 's/.*:\([0-9][0-9]*\)$/\1/p')"
+PASEO_PORT="$(printf '%s' "${PASEO_LISTEN:-0.0.0.0:6767}" | sed -n 's/.*:\([0-9][0-9]*\)$/\1/p')"
 [ -n "$PASEO_PORT" ] || PASEO_PORT=6767
 
 HOME_DIR="${HOME:-/home/agent}"

--- a/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
+++ b/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
@@ -4,7 +4,7 @@
 # so it auto-restarts if it exits.
 #
 # SCOPE: this startup script manages the Paseo daemon only. It supervises a single
-# `paseo daemon start --foreground --listen 127.0.0.1:6767 --web-ui`. The daemon
+# `paseo daemon start --foreground --listen 0.0.0.0:6767 --web-ui`. The daemon
 # runs under a respawn loop, so a crash, a self-update, or a wrapper-triggered
 # bounce (to apply a new worktrees.root) self-heals. Because this script runs as a
 # `startup` command — which fires on EVERY sandbox start, including a detached
@@ -26,18 +26,20 @@
 # Pins are provided via the environment, with an in-script fallback default kept
 # in sync with the kit spec's documented pin:
 #   PASEO_CLI_VERSION   — @getpaseo/cli version to install (default 0.4.0)
-#   PASEO_LISTEN        — daemon bind address (default 127.0.0.1:6767)
+#   PASEO_LISTEN        — daemon bind address (default 0.0.0.0:6767)
 #   PASEO_RESTART_DELAY — seconds to wait before respawning the daemon (default 5)
 
 set -eu
 
 # Daemon bind. Keep in sync with the kit spec's publishedPorts guest port (6767)
 # and PASEO_LISTEN env. We derive the port from PASEO_LISTEN so a single override
-# moves both the bind and the health probe. The default is LOOPBACK (127.0.0.1) —
-# the daemon is single-consumer and only acq's port-publish must reach it, which
-# it does over the guest loopback interface; binding loopback removes any exposure
-# on the guest's external interface (defense in depth). See spec.yaml environment.
-PASEO_LISTEN="${PASEO_LISTEN:-127.0.0.1:6767}"
+# moves both the bind and the health probe. The default is 0.0.0.0 (all guest
+# interfaces): acq's create-time port publish (msb `-p HOST:GUEST`) binds a host
+# listener but dials the sandbox's GUEST NETWORK IP, not guest loopback, so a
+# 127.0.0.1-only bind is unreachable from the published host port ("Empty reply
+# from server" / ERR_EMPTY_RESPONSE). Binding 0.0.0.0 makes the guest port
+# reachable through create-time publishedPorts. See spec.yaml environment.
+PASEO_LISTEN="${PASEO_LISTEN:-0.0.0.0:6767}"
 PASEO_PORT="$(printf '%s' "$PASEO_LISTEN" | sed -n 's/.*:\([0-9][0-9]*\)$/\1/p')"
 [ -n "$PASEO_PORT" ] || PASEO_PORT=6767
 

--- a/integrations/isolation/acq-kits/paseo/scripts/verify
+++ b/integrations/isolation/acq-kits/paseo/scripts/verify
@@ -13,7 +13,7 @@
 #      assert the Paseo CLI install, the wrapper, the startup-supervised daemon +
 #      web UI (on one port), the published port, that the LARGE UI bundle arrives
 #      byte-complete over the host port (identity encoding; integrity guard), the
-#      in-guest LOOPBACK bind (hardening #1) reachable over the host port, the
+#      in-guest 0.0.0.0 bind (reachable via create-time publish) over the host port, the
 #      install ran with lifecycle scripts disabled (hardening #2), the respawn
 #      supervisor, the PID-1 hold, daemon self-heal, and the worktree-root pin.
 #
@@ -390,12 +390,15 @@ else
 fi
 printf '%s\n' "$ports_out" | sed 's/^/    | /'
 
-info "6b. Hardening: in-guest daemon bind is LOOPBACK (127.0.0.1), not 0.0.0.0"
-# wz-gsa hardening #1: the daemon should bind 127.0.0.1:6767 in-guest (defense in
-# depth), while still being reachable over the published HOST port. Two asserts:
-#   (a) the LISTEN socket is bound to 127.0.0.1 (not 0.0.0.0) in the guest, and
-#   (b) the earlier HOST-port fetch (step 5b) still delivered the bundle — proving
-#       acq's port-publish reaches a loopback-bound guest daemon.
+info "6b. Guest daemon bind is 0.0.0.0 (reachable via create-time publish), not loopback"
+# The daemon must bind 0.0.0.0:6767 in-guest so acq's CREATE-TIME port publish can
+# reach it. On the msb backend `-p HOST:GUEST` binds a HOST loopback listener but
+# the publisher dials the sandbox's GUEST NETWORK IP (not guest 127.0.0.1), so a
+# loopback-only bind answers inside the guest yet returns "Empty reply from server"
+# on the published host port. See GSA-TTS/agentic-coding-quickstart#333. Two asserts:
+#   (a) the LISTEN socket is bound to 0.0.0.0 (not 127.0.0.1) in the guest, and
+#   (b) the earlier HOST-port fetch (step 5b) delivered the bundle — proving
+#       acq's create-time port-publish reaches the guest daemon end-to-end.
 # We read the listen address from /proc/net/tcp (hex) so we don't depend on ss/
 # netstat being installed. 0100007F = 127.0.0.1; 00000000 = 0.0.0.0.
 if [ -z "$daemon_up" ]; then
@@ -412,19 +415,19 @@ else
       awk -v P="$p" "\$2 ~ (\":\" P \"\$\") && \$4==\"0A\" {print \$2}" /proc/net/tcp 2>/dev/null | head -1
     fi')"
   case "$bind_addr" in
-    127.0.0.1:*|*0100007F:1A6F*)
-      ok "daemon LISTEN socket bound to loopback in-guest ($bind_addr)" ;;
     0.0.0.0:*|*00000000:1A6F*)
-      bad "daemon bound to 0.0.0.0 in-guest ($bind_addr) — hardening #1 not in effect (PASEO_LISTEN?)" ;;
+      ok "daemon LISTEN socket bound to 0.0.0.0 in-guest ($bind_addr) — reachable via create-time publish" ;;
+    127.0.0.1:*|*0100007F:1A6F*)
+      bad "daemon bound to loopback in-guest ($bind_addr) — create-time publish returns 'Empty reply from server' on msb (PASEO_LISTEN?; see quickstart#333)" ;;
     "")
       warn "could not read the daemon's LISTEN address (no ss + unreadable /proc/net/tcp); relying on the host-port fetch as the reachability proof" ;;
     *)
-      warn "unexpected daemon LISTEN address '$bind_addr' (expected 127.0.0.1:$PASEO_PORT)" ;;
+      warn "unexpected daemon LISTEN address '$bind_addr' (expected 0.0.0.0:$PASEO_PORT)" ;;
   esac
-  # Reachability-with-loopback-bind is proven by step 5b (HOST bundle fetch). If
-  # that passed, a loopback in-guest bind is confirmed reachable end-to-end.
+  # Reachability from the host is proven by step 5b (HOST bundle fetch). If that
+  # passed, the create-time publish reaches the guest daemon end-to-end.
   if [ -n "${HOST_HP:-}" ]; then
-    ok "reachable over the published host port with a loopback in-guest bind (see step 5b)"
+    ok "reachable over the published host port (see step 5b)"
   fi
 fi
 

--- a/integrations/isolation/acq-kits/paseo/scripts/verify
+++ b/integrations/isolation/acq-kits/paseo/scripts/verify
@@ -307,15 +307,55 @@ fi
 #     br/zstd against a libz-only curl yields CURLE_BAD_CONTENT_ENCODING (rc=61,
 #     size=0) — a CLIENT DECODE failure that must NOT be read as truncation.
 # A genuine truncation shows up as rc=18 (transfer closed) / rc=56 (reset) or a
-# short byte count vs the in-guest identity baseline.
+# short byte count vs the in-guest identity baseline. (See the HOST-PORT COLLISION
+# GUARD below for why a contended host port SKIPs rather than FAILs here.)
 info "5b. Large UI bundle downloads intact over the HOST port (identity + br-decode)"
 HOST_HP="$(sbx_ports_out | grep -Eo '127\.0\.0\.1:[0-9]+' | head -1)"
+# HOST-PORT COLLISION GUARD. This check fetches over the mapped HOST port to prove
+# acq's CREATE-TIME publish reaches the GUEST-IP-bound daemon (the whole point of
+# the 0.0.0.0 bind, see 6b). But if ANOTHER process on this host already owns that
+# host port (e.g. a developer's own Paseo daemon on 6767), acq's create-time -p
+# cannot bind it and the host fetch talks to the OTHER process — a false FAIL that
+# looks like a transport bug. We deliberately do NOT route around this with
+# `acq ports --publish`: that path tunnels via `msb ssh serve` + OpenSSH `-L` from
+# INSIDE the guest to guest loopback, so it would pass even for a loopback-only
+# bind — it cannot exercise the guest-IP transport this test exists to prove.
+# Instead we detect the collision and SKIP (not FAIL) with actionable guidance:
+# the map's own reported host port not matching a fresh mapping, or a pre-existing
+# listener on that host port that this sandbox did not create, means the port is
+# contended — rerun on a free host port (see the note printed below).
+host_port="${HOST_HP##*:}"
+collision=""
+if [ -n "$host_port" ] && command -v lsof >/dev/null 2>&1; then
+  # Discriminate acq's OWN publisher from a foreign listener on the host port. On
+  # msb, create-time -p is served by a msb/microsandbox userland forwarder; on sbx
+  # by the sbx daemon. A developer's own `paseo daemon` (node) on the same port is
+  # the collision we must catch — and it can present two ways:
+  #   (1) acq still bound an ephemeral port but the reported HOST_HP happens to be
+  #       the contended one, so TWO PIDs listen; or
+  #   (2) acq could not bind the contended port at all, so the ONLY listener is the
+  #       foreign process — a single PID, but NOT acq's forwarder.
+  # So: collision if >1 distinct listener PID, OR if the sole listener's command is
+  # a node/paseo process (the foreign daemon) rather than an msb/sbx forwarder.
+  lsof_out="$(lsof -nP -iTCP:"$host_port" -sTCP:LISTEN 2>/dev/null)"
+  listeners="$(printf '%s\n' "$lsof_out" | awk 'NR>1{print $2}' | sort -u | wc -l | tr -d ' ')"
+  cmds="$(printf '%s\n' "$lsof_out" | awk 'NR>1{print tolower($1)}' | sort -u)"
+  if [ "${listeners:-0}" -gt 1 ] 2>/dev/null; then
+    collision=yes
+  elif printf '%s\n' "$cmds" | grep -Eq 'node|paseo'; then
+    # A lone node/paseo listener on this port is a foreign daemon, not acq's
+    # msb/sbx forwarder — the reported host mapping is not this sandbox.
+    collision=yes
+  fi
+fi
 if [ -z "$daemon_up" ]; then
   skip "large-asset guard (daemon not up)"
 elif ! command -v curl >/dev/null 2>&1; then
   skip "large-asset guard (no curl on the HOST to reach the published port)"
 elif [ -z "$HOST_HP" ]; then
   skip "large-asset guard (could not resolve a 127.0.0.1:<port> host mapping)"
+elif [ -n "$collision" ]; then
+  skip "large-asset guard (host port $host_port is already in use by another process — likely your own Paseo daemon on $PASEO_PORT). acq's create-time publish can't own a contended host port, so a HOST fetch would hit the OTHER process, not this sandbox. Stop the other listener (e.g. your local 'paseo daemon') and re-run. NOTE: do not substitute 'acq ports --publish' here — its ssh -L tunnel dials guest loopback and would not exercise the guest-IP transport this step verifies."
 else
   bundle="$(in_sbx "curl -fsS http://127.0.0.1:$PASEO_PORT/ 2>/dev/null" \
             | grep -oE '/_expo/static/js/web/index-[0-9a-f]+\.js' | head -1)"
@@ -425,8 +465,12 @@ else
       warn "unexpected daemon LISTEN address '$bind_addr' (expected 0.0.0.0:$PASEO_PORT)" ;;
   esac
   # Reachability from the host is proven by step 5b (HOST bundle fetch). If that
-  # passed, the create-time publish reaches the guest daemon end-to-end.
-  if [ -n "${HOST_HP:-}" ]; then
+  # ran and passed, the create-time publish reaches the guest daemon end-to-end.
+  # When 5b was SKIPPED for a host-port collision, we can't claim host reachability
+  # here (the fetch never exercised this sandbox), so don't assert it.
+  if [ -n "$collision" ]; then
+    skip "host-port reachability (step 5b skipped: host port in use by another process — bind is confirmed 0.0.0.0 above)"
+  elif [ -n "${HOST_HP:-}" ]; then
     ok "reachable over the published host port (see step 5b)"
   fi
 fi

--- a/integrations/isolation/acq-kits/paseo/scripts/verify
+++ b/integrations/isolation/acq-kits/paseo/scripts/verify
@@ -176,6 +176,40 @@ if ! command -v "$DRIVER" >/dev/null 2>&1; then
 fi
 echo "  driver: $DRIVER"
 
+# --- HOST-PORT CONTENTION PRECHECK (before create). --------------------------
+# On this msb build, create-time publish maps guest 6767 -> host 6767
+# DETERMINISTICALLY (host_port == guest_port, host_bind 127.0.0.1), not to an
+# ephemeral host port. So if ANYTHING already listens on host 6767 — a developer's
+# own `paseo daemon`, OR (more subtly) ANOTHER acq/msb sandbox's own `msb`
+# forwarder that already published 6767 — this verify sandbox's create-time -p
+# cannot own that host port, and step 5b's HOST fetch would hit the OTHER owner:
+# a false FAIL that looks like a transport bug (observed: rc=52 "Empty reply").
+#
+# We detect this by asking the OS who listens on the host port (lsof), NOT by
+# command-name heuristics: the contender can be `msb` (another sandbox's
+# forwarder), `node`/`paseo` (a bare daemon), or anything else. ANY pre-existing
+# listener on the port acq will deterministically claim is a collision. We record
+# it here (pre-create) so 5b/6b can SKIP with accurate guidance rather than FAIL.
+# We deliberately do NOT route around it with `acq ports --publish`: that path
+# tunnels via `msb ssh serve` + OpenSSH `-L` from INSIDE the guest to guest
+# loopback, so it would pass even for a loopback-only bind and would not exercise
+# the guest-IP create-time transport this test exists to prove.
+host_port_collision=""
+if command -v lsof >/dev/null 2>&1; then
+  # The deterministic host port equals the guest port on this backend. Check it
+  # BEFORE create so a pre-existing owner (incl. another sandbox's msb forwarder)
+  # is attributable to something other than the sandbox we are about to create.
+  precheck_owner="$(lsof -nP -iTCP:"$PASEO_PORT" -sTCP:LISTEN 2>/dev/null | awk 'NR>1{print $1" (pid "$2")"}' | sort -u | tr '\n' ',' | sed 's/,$//')"
+  if [ -n "$precheck_owner" ]; then
+    host_port_collision="$precheck_owner"
+    echo "  NOTE: host port $PASEO_PORT is already in use before create by: $precheck_owner" >&2
+    echo "        (commonly another acq/msb sandbox's 'msb' forwarder already publishing $PASEO_PORT," >&2
+    echo "         or a local 'paseo daemon'.) The create-time host mapping will collide; step 5b" >&2
+    echo "         will SKIP its host-reachability fetch. Stop that owner (e.g. 'acq rm <other-sandbox>'" >&2
+    echo "         or kill the local daemon) and re-run to exercise host->guest reachability." >&2
+  fi
+fi
+
 info "2. Create a sandbox with the kit"
 if [ "$DRIVER" = "acq" ]; then
   echo "  creating $SBX_NAME via acq (extra kit: $KIT_DIR)..."
@@ -307,55 +341,25 @@ fi
 #     br/zstd against a libz-only curl yields CURLE_BAD_CONTENT_ENCODING (rc=61,
 #     size=0) — a CLIENT DECODE failure that must NOT be read as truncation.
 # A genuine truncation shows up as rc=18 (transfer closed) / rc=56 (reset) or a
-# short byte count vs the in-guest identity baseline. (See the HOST-PORT COLLISION
-# GUARD below for why a contended host port SKIPs rather than FAILs here.)
+# short byte count vs the in-guest identity baseline. (See the HOST-PORT
+# CONTENTION PRECHECK before step 2 for why a contended host port SKIPs here.)
 info "5b. Large UI bundle downloads intact over the HOST port (identity + br-decode)"
 HOST_HP="$(sbx_ports_out | grep -Eo '127\.0\.0\.1:[0-9]+' | head -1)"
-# HOST-PORT COLLISION GUARD. This check fetches over the mapped HOST port to prove
-# acq's CREATE-TIME publish reaches the GUEST-IP-bound daemon (the whole point of
-# the 0.0.0.0 bind, see 6b). But if ANOTHER process on this host already owns that
-# host port (e.g. a developer's own Paseo daemon on 6767), acq's create-time -p
-# cannot bind it and the host fetch talks to the OTHER process — a false FAIL that
-# looks like a transport bug. We deliberately do NOT route around this with
-# `acq ports --publish`: that path tunnels via `msb ssh serve` + OpenSSH `-L` from
-# INSIDE the guest to guest loopback, so it would pass even for a loopback-only
-# bind — it cannot exercise the guest-IP transport this test exists to prove.
-# Instead we detect the collision and SKIP (not FAIL) with actionable guidance:
-# the map's own reported host port not matching a fresh mapping, or a pre-existing
-# listener on that host port that this sandbox did not create, means the port is
-# contended — rerun on a free host port (see the note printed below).
-host_port="${HOST_HP##*:}"
-collision=""
-if [ -n "$host_port" ] && command -v lsof >/dev/null 2>&1; then
-  # Discriminate acq's OWN publisher from a foreign listener on the host port. On
-  # msb, create-time -p is served by a msb/microsandbox userland forwarder; on sbx
-  # by the sbx daemon. A developer's own `paseo daemon` (node) on the same port is
-  # the collision we must catch — and it can present two ways:
-  #   (1) acq still bound an ephemeral port but the reported HOST_HP happens to be
-  #       the contended one, so TWO PIDs listen; or
-  #   (2) acq could not bind the contended port at all, so the ONLY listener is the
-  #       foreign process — a single PID, but NOT acq's forwarder.
-  # So: collision if >1 distinct listener PID, OR if the sole listener's command is
-  # a node/paseo process (the foreign daemon) rather than an msb/sbx forwarder.
-  lsof_out="$(lsof -nP -iTCP:"$host_port" -sTCP:LISTEN 2>/dev/null)"
-  listeners="$(printf '%s\n' "$lsof_out" | awk 'NR>1{print $2}' | sort -u | wc -l | tr -d ' ')"
-  cmds="$(printf '%s\n' "$lsof_out" | awk 'NR>1{print tolower($1)}' | sort -u)"
-  if [ "${listeners:-0}" -gt 1 ] 2>/dev/null; then
-    collision=yes
-  elif printf '%s\n' "$cmds" | grep -Eq 'node|paseo'; then
-    # A lone node/paseo listener on this port is a foreign daemon, not acq's
-    # msb/sbx forwarder — the reported host mapping is not this sandbox.
-    collision=yes
-  fi
-fi
+# HOST-PORT COLLISION: the pre-create precheck (before step 2) recorded whether
+# something already owned the deterministic host port ($PASEO_PORT) when we
+# started — e.g. another acq/msb sandbox's `msb` forwarder, or a local Paseo
+# daemon. If so, this sandbox's create-time -p mapping collides and a HOST fetch
+# would hit the OTHER owner, not this sandbox. SKIP (don't FAIL) in that case.
+# We track host_fetch_ok so 6b reports host reachability honestly (see below).
+host_fetch_ok=""
 if [ -z "$daemon_up" ]; then
   skip "large-asset guard (daemon not up)"
 elif ! command -v curl >/dev/null 2>&1; then
   skip "large-asset guard (no curl on the HOST to reach the published port)"
 elif [ -z "$HOST_HP" ]; then
   skip "large-asset guard (could not resolve a 127.0.0.1:<port> host mapping)"
-elif [ -n "$collision" ]; then
-  skip "large-asset guard (host port $host_port is already in use by another process — likely your own Paseo daemon on $PASEO_PORT). acq's create-time publish can't own a contended host port, so a HOST fetch would hit the OTHER process, not this sandbox. Stop the other listener (e.g. your local 'paseo daemon') and re-run. NOTE: do not substitute 'acq ports --publish' here — its ssh -L tunnel dials guest loopback and would not exercise the guest-IP transport this step verifies."
+elif [ -n "$host_port_collision" ] && { [ -z "$HOST_HP" ] || [ "${HOST_HP##*:}" = "$PASEO_PORT" ]; }; then
+  skip "large-asset guard (host port $PASEO_PORT was already in use BEFORE create by: $host_port_collision — commonly another acq/msb sandbox's 'msb' forwarder already publishing $PASEO_PORT, or a local 'paseo daemon'). This msb build maps guest $PASEO_PORT -> host $PASEO_PORT deterministically, so this sandbox's create-time -p collides and a HOST fetch would hit the OTHER owner. Stop it (e.g. 'acq rm <other-sandbox>' or kill the local daemon) and re-run. NOTE: do not substitute 'acq ports --publish' here — its ssh -L tunnel dials guest loopback and would not exercise the guest-IP transport this step verifies."
 else
   bundle="$(in_sbx "curl -fsS http://127.0.0.1:$PASEO_PORT/ 2>/dev/null" \
             | grep -oE '/_expo/static/js/web/index-[0-9a-f]+\.js' | head -1)"
@@ -379,6 +383,7 @@ else
        { { [ -n "$g_size" ] && [ "$h_size" = "$g_size" ]; } || \
          { [ -z "$g_size" ] && [ "${h_size:-0}" -gt 1000000 ] 2>/dev/null; }; }; then
       ok "HOST end-to-end: full identity bundle delivered over $HOST_HP (${h_size} bytes)"
+      host_fetch_ok=yes   # 6b gates its host-reachability assert on this
     else
       # rc=18/56 or a short count = real truncation; rc!=0 with size 0 on identity
       # is a transport error (identity needs no decoder), so it IS meaningful here.
@@ -464,14 +469,17 @@ else
     *)
       warn "unexpected daemon LISTEN address '$bind_addr' (expected 0.0.0.0:$PASEO_PORT)" ;;
   esac
-  # Reachability from the host is proven by step 5b (HOST bundle fetch). If that
-  # ran and passed, the create-time publish reaches the guest daemon end-to-end.
-  # When 5b was SKIPPED for a host-port collision, we can't claim host reachability
-  # here (the fetch never exercised this sandbox), so don't assert it.
-  if [ -n "$collision" ]; then
-    skip "host-port reachability (step 5b skipped: host port in use by another process — bind is confirmed 0.0.0.0 above)"
-  elif [ -n "${HOST_HP:-}" ]; then
-    ok "reachable over the published host port (see step 5b)"
+  # Reachability from the host is proven ONLY by step 5b actually FETCHING the
+  # bundle over the host port (host_fetch_ok). Do NOT infer reachability from the
+  # mere existence of a host mapping ($HOST_HP): the create-time -p can be present
+  # yet unreachable (e.g. contended by another sandbox's msb forwarder, the
+  # observed rc=52 case). Report honestly per what 5b actually did.
+  if [ -n "$host_fetch_ok" ]; then
+    ok "reachable over the published host port (proven by step 5b fetch)"
+  elif [ -n "$host_port_collision" ] && { [ -z "$HOST_HP" ] || [ "${HOST_HP##*:}" = "$PASEO_PORT" ]; }; then
+    skip "host-port reachability (step 5b skipped: host port $PASEO_PORT already in use by $host_port_collision — bind is confirmed 0.0.0.0 above; host reachability not exercised)"
+  else
+    skip "host-port reachability (step 5b did not complete a successful host fetch — see 5b above; bind is confirmed 0.0.0.0)"
   fi
 fi
 

--- a/integrations/isolation/acq-kits/paseo/spec.yaml
+++ b/integrations/isolation/acq-kits/paseo/spec.yaml
@@ -16,7 +16,7 @@
 # DESIGN (see docs/decisions/):
 #   - The STARTUP script (paseo-start.sh) owns the daemon: on every sandbox start
 #     it installs the Paseo CLI (first boot only) and supervises the daemon with
-#     `paseo daemon start --foreground --listen 127.0.0.1:6767 --web-ui`. A single
+#     `paseo daemon start --foreground --listen 0.0.0.0:6767 --web-ui`. A single
 #     Paseo process serves the daemon API, the WebSocket, AND the bundled web UI,
 #     all on ONE container port (6767). Because a `startup` command fires on EVERY
 #     start — including a detached `acq create` with nobody attached, held open by
@@ -80,7 +80,7 @@
 #
 # AUTH: the daemon runs UNSECURED (no PASEO_PASSWORD). The sandbox — an ephemeral
 # container with proxied, allow-listed egress and no host FS — is the security
-# boundary, and the published port is host loopback only. See the README
+# boundary, and the published host port is host loopback only. See the README
 # "Security note".
 #
 # PORT FORWARDING: the daemon binds container port 6767 (API + WS + web UI); it is
@@ -94,7 +94,7 @@ displayName: Paseo (self-hosted web UI for coding agents)
 description: >
   Runs the Paseo daemon and its bundled browser web UI inside the sandbox and
   publishes it to the host. Installs the Paseo CLI on first boot and supervises
-  the daemon on 127.0.0.1:6767 (API + WebSocket + web UI on one port). Ships a thin
+  the daemon on 0.0.0.0:6767 (API + WebSocket + web UI on one port). Ships a thin
   `opencode` wrapper over a generic kit shim that pins Paseo's worktree root under
   the current project and holds PID 1 on `acq run` so the sandbox (and UI) stay up.
   Opt-in mixin; composes with the USAi provider and the other GSA kits.
@@ -181,17 +181,21 @@ publishedPorts:
 # No secret goes here (PASEO_PASSWORD is intentionally unset — unsecured; see
 # AUTH note above).
 #
-# IN-GUEST BIND IS LOOPBACK (127.0.0.1:6767), a defense-in-depth win over binding
-# 0.0.0.0 in-guest (wz-gsa hardening #1): the daemon is single-consumer and the
-# only thing that must reach it is acq's port-publish, which forwards from a host
-# loopback port to the guest. acq's backends publish via a userland forwarder that
-# dials the guest over its LOOPBACK interface (the forwarder runs in the guest's
-# network namespace), so a 127.0.0.1 in-guest bind is still reachable from the
-# published host port while removing any exposure on the guest's external
-# interface. If a future acq backend instead dials the guest's eth0 IP, the health
-# probe/publish check in scripts/verify (step 5/6) will catch it — flip this back
-# to 0.0.0.0:6767 and rely on the README loopback-only disclosure. Verified live:
-# see scripts/verify "in-guest bind" assertion.
+# IN-GUEST BIND IS 0.0.0.0:6767 (all guest interfaces). A loopback-only bind
+# (127.0.0.1:6767) is a defense-in-depth win in the abstract, but it is NOT
+# reachable through acq's CREATE-TIME port publish on the msb backend: msb's
+# `-p HOST:GUEST` (which acq emits from the neutral publishedPorts below) binds a
+# HOST loopback listener but the publisher dials the sandbox's GUEST NETWORK IP
+# for GUEST — it does not connect to guest 127.0.0.1. So a 127.0.0.1-only daemon
+# answers `acq exec <sbx> -- curl http://127.0.0.1:6767` from inside the guest
+# yet the published host port returns "Empty reply from server" (browser
+# ERR_EMPTY_RESPONSE). Binding 0.0.0.0 makes the guest port reachable from the
+# host-published loopback port. The sandbox remains the security boundary
+# (ephemeral container, proxied allow-listed egress, no host FS) and the HOST
+# side of the publish is still loopback-only, so 0.0.0.0 in-guest does not widen
+# host exposure. See GSA-TTS/agentic-coding-quickstart#333 and the msb port
+# limitations in that repo's BACKEND_GUIDE.md / KNOWN_FAILURE_MODES.md §36.
+# Verified live: see scripts/verify "in-guest bind" assertion.
 #
 # PASEO_RELAY_ENABLED=false disables Paseo's cloud relay (wss://relay.paseo.sh).
 # The daemon defaults relay to ON and, absent this, dials the relay on a ~30s
@@ -205,7 +209,7 @@ publishedPorts:
 # across daemon restarts/self-updates without editing config.json.
 environment:
   PASEO_WEB_UI_ENABLED: "true"
-  PASEO_LISTEN: "127.0.0.1:6767"
+  PASEO_LISTEN: "0.0.0.0:6767"
   PASEO_RELAY_ENABLED: "false"
   ONNXRUNTIME_NODE_INSTALL: "skip"
 


### PR DESCRIPTION
## Summary

The Paseo acq-kit bound the daemon to `127.0.0.1:6767` in-guest for defense-in-depth. That bind is unreachable through `acq`'s **create-time** port publish on the **msb** backend: `-p HOST:GUEST` binds a HOST loopback listener but the publisher dials the sandbox's **guest network IP**, not guest `127.0.0.1`. A loopback-only daemon is therefore healthy from inside the sandbox (`acq exec … curl http://127.0.0.1:6767`) yet returns `Empty reply from server` / browser `ERR_EMPTY_RESPONSE` on the published host port.

This changes the guest bind to `0.0.0.0:6767` so the create-time publish can reach it. The **host** side of the mapping stays loopback-only, so this does not widen host exposure — the sandbox remains the security boundary.

Rationale documented in GSA-TTS/agentic-coding-quickstart#333 (msb port limitations in `BACKEND_GUIDE.md` / `KNOWN_FAILURE_MODES.md` §36).

## Changes

- `spec.yaml` — `PASEO_LISTEN` → `0.0.0.0:6767`; rewrote the in-guest bind rationale
- `files/home/paseo-start.sh`, `files/home/paseo-agent-shim` — default bind → `0.0.0.0:6767`
- `scripts/verify`:
  - Step 6b now **requires** a `0.0.0.0` bind (fails on loopback, with an msb "Empty reply" hint), read from `/proc/net/tcp`.
  - Added a **pre-create host-port contention precheck**: if anything already listens on the deterministic host port (another acq/msb sandbox's `msb` forwarder, or a local `paseo daemon`), 5b/6b **SKIP** with accurate guidance instead of producing a false FAIL. Detection is OS-level (`lsof`), not a command-name heuristic, so an `msb` forwarder is caught.
  - Fixed a false 6b PASS: "reachable over the published host port" is now gated on 5b actually completing a successful host fetch (`host_fetch_ok`), not on the mere existence of a host mapping.
- `README.md`, `TROUBLESHOOTING.md`, `docs/decisions/supervisor-owns-daemon-wrapper-pins-worktrees.md` — document the msb reachability constraint, the "Empty reply from server" failure mode, and the post-hoc `acq ports --publish` fallback

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Test Results

Static checks:
- `sh -n paseo-start.sh` — OK
- `sh -n paseo-agent-shim` — OK
- `bash -n scripts/verify` — OK
- `yaml.safe_load(spec.yaml)` — OK (`PASEO_LISTEN = 0.0.0.0:6767`)

Live end-to-end (`RUN_ACQ=1 ./scripts/verify`, msb backend, macOS/Apple Silicon):
- **All checks passed.** Steps 5b and 6b correctly **SKIP** (not FAIL) when host 6767 is already held by another sandbox's forwarder, with a clear message naming the owner (`msb (pid …)`); the `0.0.0.0` bind is independently asserted PASS at 6b (`00000000:1A6F`).
- To exercise the host→guest reachability PASS (rather than SKIP), the mapped host port must be free — free it (e.g. `acq rm <other-sandbox>`) and re-run.

Not run in this environment: `python ../validate-kits.py` (needs `jsonschema` + `pyyaml`); run it before merge for the offline schema gate.

## Known limitation (tracked upstream)

On this msb build, create-time publish maps guest `6767` → host `6767` **deterministically** (`host_bind 127.0.0.1`), not to an ephemeral host port. Consequently, running **two Paseo sandboxes in parallel collides on host 6767** — the second sandbox's UI is unreachable from the host until the first is stopped. A run-time HOST-port override (`acq run/create --publish HOST:GUEST`) would resolve this and let `scripts/verify` request a known-free port; tracked in **GSA-TTS/agentic-coding-quickstart#334**.

## Rollback

Revert the commits on this branch — restores the `127.0.0.1:6767` bind and the previous verify assertions.

---
Generated with AI assistance; requires human review before merge.
