### PR TITLE
fix(ci): enforce pattern test-cases in CI + keep ruff pins in lockstep

### DIFF
--- a/.agents/skills/documentation-review/SKILL.md
+++ b/.agents/skills/documentation-review/SKILL.md
@@ -304,7 +304,7 @@ This installs packages listed in `package.json`.
 
 ## References
 
-- [Plain Language Act](https://www.plainlanguage.gov/law/)
+- [Plain Writing Act of 2010 (govinfo)](https://www.govinfo.gov/app/details/PLAW-111publ274)
 - [WCAG 2.2 Guidelines](https://www.w3.org/WAI/WCAG22/quickref/)
 - [Diátaxis documentation framework](https://diataxis.fr/)
 - [Write the Docs](https://www.writethedocs.org/)

--- a/.agents/skills/frontend/README.md
+++ b/.agents/skills/frontend/README.md
@@ -68,7 +68,7 @@ To add a new frontend skill:
 
 - [U.S. Web Design System](https://designsystem.digital.gov/)
 - [Section508.gov](https://www.section508.gov/)
-- [PlainLanguage.gov](https://www.plainlanguage.gov/)
+- [Plain Language (digital.gov)](https://digital.gov/topics/plain-language/)
 - [18F Content Guide (GitHub source)](https://github.com/18F/content-guide)
 - [WCAG 2.1 Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/)
 

--- a/.agents/skills/frontend/plain-language-review/SKILL.md
+++ b/.agents/skills/frontend/plain-language-review/SKILL.md
@@ -368,10 +368,10 @@ A human MUST:
 
 ## References
 
-- [PlainLanguage.gov](https://www.plainlanguage.gov/)
-- [Federal Plain Language Guidelines](https://www.plainlanguage.gov/guidelines/)
+- [Plain Language (digital.gov)](https://digital.gov/topics/plain-language/)
+- [An Introduction to Plain Language (digital.gov)](https://digital.gov/resources/an-introduction-to-plain-language/)
 - [18F Content Guide (GitHub source)](https://github.com/18F/content-guide)
-- [Plain Language Action and Information Network (PLAIN)](https://www.plainlanguage.gov/about/program-history/)
+- [Plain Language Action and Information Network (PLAIN, via digital.gov)](https://digital.gov/topics/plain-language/)
 - [Plain Writing Act of 2010](https://www.gpo.gov/fdsys/pkg/PLAW-111publ274/pdf/PLAW-111publ274.pdf)
 
 ## Deterministic Tools

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,24 @@ updates:
     commit-message:
       prefix: "chore(ci)"
 
+  # Pre-commit hook versions — keeps the ruff-pre-commit rev in lockstep with the
+  # pyproject `ruff==` pin (the pip ecosystem above only bumps the PyPI dep, so
+  # without this the two ruff versions drift apart after every release).
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "pre-commit"
+    commit-message:
+      prefix: "chore(deps)"
+
   # CI markdown-linter npm tree
   - package-ecosystem: "npm"
     directory: "/.github/linters"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,9 @@ jobs:
       - name: Run validation
         run: make validate
 
+      - name: Run pattern test cases (skill assertions)
+        run: make test-cases
+
       - name: Check generated files are current (INDEX.yaml + CATALOG.md)
         run: make generate-check
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: gitleaks
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 0671d8ab202c4ac093b78433ae5baf74f3fc7246  # v0.15.15
+    rev: 7c55798a78262d14b2074abf623d8a992ebb70d4  # v0.16.2
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ ci:  ## Full CI check (validate + security + test + pre-commit checks)
 	@echo "==> Running acq-kits node tests..."
 	@$(MAKE) --no-print-directory test-kits
 	@echo ""
+	@echo "==> Running pattern test cases..."
+	@$(MAKE) --no-print-directory test-cases
+	@echo ""
 	@echo "✓ All checks passed"
 
 clean:  ## Remove generated files and caches

--- a/agents/documentation/AGENTS.md
+++ b/agents/documentation/AGENTS.md
@@ -347,7 +347,7 @@ Before publishing:
 
 ## References
 
-- [Plain Language Act](https://www.plainlanguage.gov/)
+- [Plain Writing Act of 2010 (govinfo)](https://www.govinfo.gov/app/details/PLAW-111publ274)
 - [WCAG 2.2 Guidelines](https://www.w3.org/WAI/WCAG22/quickref/)
 - [Diátaxis framework](https://diataxis.fr/)
 - For complete rules, see [main AGENTS.md](../../AGENTS.md)

--- a/docs/test-cases-schema.md
+++ b/docs/test-cases-schema.md
@@ -377,22 +377,22 @@ test_cases:
 # Run all test cases
 python scripts/run_test_cases.py
 
-# Run tests for specific pattern
-python scripts/run_test_cases.py skills/your-skill/tests/test-cases.yml
+# Run tests for a specific pattern (by pattern ID, not a path)
+python scripts/run_test_cases.py --pattern your-skill-id
 
 # Verbose output
 python scripts/run_test_cases.py --verbose
 
-# Generate test report
-python scripts/run_test_cases.py --report
+# Run against an explicit repository root
+python scripts/run_test_cases.py --root .
 ```
 
 ## Integration with CI
 
 ```yaml
-# .github/workflows/test.yml
-- name: Run pattern test cases
-  run: python scripts/run_test_cases.py
+# .github/workflows/ci.yml — in the Pattern Validation job
+- name: Run pattern test cases (skill assertions)
+  run: make test-cases
 ```
 
 ## Best Practices

--- a/scripts/tests/test_ruff_pin_lockstep.py
+++ b/scripts/tests/test_ruff_pin_lockstep.py
@@ -1,0 +1,44 @@
+"""Guard (#339): the pyproject `ruff==` pin and the .pre-commit-config
+ruff-pre-commit rev must stay in lockstep.
+
+Divergent ruff versions mean the pre-commit hook lints/formats differently from
+CI, so files can pass `git commit` locally yet fail `ruff` in CI (or vice-versa).
+This test fails if the two pins drift, closing the gap even before the
+dependabot pre-commit ecosystem bumps the hook.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _pyproject_ruff_version() -> str:
+    text = (REPO / "pyproject.toml").read_text(encoding="utf-8")
+    m = re.search(r'"ruff==([0-9]+\.[0-9]+\.[0-9]+)"', text)
+    assert m, "could not find the ruff== pin in pyproject.toml"
+    return m.group(1)
+
+
+def _precommit_ruff_version() -> str:
+    text = (REPO / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    # The repo pins hooks by full SHA with a `# vX.Y.Z` comment; read the version
+    # from the ruff-pre-commit block's rev comment.
+    m = re.search(
+        r"astral-sh/ruff-pre-commit\s+rev:\s*\S+\s*#\s*v([0-9]+\.[0-9]+\.[0-9]+)",
+        text,
+    )
+    assert m, "could not find the ruff-pre-commit rev comment in .pre-commit-config.yaml"
+    return m.group(1)
+
+
+def test_ruff_pins_match():
+    py = _pyproject_ruff_version()
+    pc = _precommit_ruff_version()
+    assert py == pc, (
+        f"ruff version drift (#339): pyproject={py} vs ruff-pre-commit={pc}. "
+        "Bump .pre-commit-config.yaml rev (SHA + `# vX.Y.Z` comment) to match the "
+        "pyproject ruff pin."
+    )

--- a/scripts/tests/test_test_cases_ci_wired.py
+++ b/scripts/tests/test_test_cases_ci_wired.py
@@ -1,0 +1,38 @@
+"""Guard (#337): the pattern test-case assertions must run in CI, and the docs
+must describe the real runner CLI.
+
+The 12 test-case suites / 73 assertions are meaningless as a quality gate unless
+CI actually runs them. This test asserts (a) the runner exits 0, (b) ci.yml
+invokes it, and (c) the docs don't reference a nonexistent flag/workflow.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def test_runner_exits_zero():
+    result = subprocess.run(
+        [sys.executable, "scripts/run_test_cases.py"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_ci_workflow_invokes_test_cases():
+    ci = (REPO / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    assert "make test-cases" in ci or "run_test_cases.py" in ci, (
+        "ci.yml must invoke the pattern test-case runner (#337)"
+    )
+
+
+def test_docs_do_not_reference_unsupported_cli():
+    doc = (REPO / "docs/test-cases-schema.md").read_text(encoding="utf-8")
+    assert "--report" not in doc, "docs reference a nonexistent --report flag"
+    assert "workflows/test.yml" not in doc, "docs reference a nonexistent test.yml workflow"


### PR DESCRIPTION
Two validated audit findings from the **"CI must enforce what the docs claim"** epic (GSA-TTS/agentic-coding-patterns#336).

## #337 — the 73 test-case assertions ran in no CI workflow
The 12 suites / 73 skill assertions pass locally but were **unenforced** — no `.github/workflows/` file invoked the runner, `make ci` omitted it, and the docs described a CLI that doesn't exist. Fix:
- Add `make test-cases` to the `ci.yml` **Pattern Validation** job and to the local `make ci` aggregate.
- Correct `docs/test-cases-schema.md`: drop the unsupported positional-path arg, the nonexistent `--report` flag, and the nonexistent `.github/workflows/test.yml`; document the real `--pattern`/`--root`/`--verbose` CLI + `make test-cases`.

## #339 — ruff pinned to two versions, self-perpetuating
`pyproject.toml` had `ruff==0.16.2` but `.pre-commit-config.yaml` pinned `v0.15.15`, so the hook lints/formats differently from CI. Dependabot's `pip` ecosystem bumped only the PyPI dep, never the `ruff-pre-commit` rev — so the two drift apart after every release. Fix:
- Bump the `ruff-pre-commit` rev → **v0.16.2** (SHA `7c55798`, GitHub-tag-verified) to match `pyproject`.
- Add a **`pre-commit` dependabot ecosystem** so the hook rev auto-bumps in lockstep going forward.
- The repo is already clean under 0.16.2 (CI uses it today), so aligning the hook introduces no new findings.

## Guards (so neither regresses)
- `test_ruff_pin_lockstep.py` — fails if the `pyproject` and pre-commit ruff versions ever diverge.
- `test_test_cases_ci_wired.py` — asserts the runner exits 0, `ci.yml` invokes it, and the docs don't cite the removed CLI.

## Verification
- `make validate` ✓ · `make test-cases` **73/73** ✓ · 358 pytest pass · `ruff 0.16.2` check + format clean.

Refs #337 #339

AI-assisted (OpenCode).