### PR TITLE
feat(kits): pre-populate Paseo projects from mounted host directories

### DIFF
--- a/integrations/isolation/acq-kits/paseo/.gitignore
+++ b/integrations/isolation/acq-kits/paseo/.gitignore
@@ -1,4 +1,10 @@
-# Throwaway sandbox workspaces created by scripts/verify (WORK dir). These are
-# only present transiently (removed on exit unless KEEP=1); ignore them so an
-# interrupted run or a KEEP=1 inspection never gets committed.
+# Throwaway sandbox workspaces + mount fixtures created by scripts/verify. These
+# are only present transiently (removed on exit unless KEEP=1); ignore them so an
+# interrupted run or a KEEP=1 inspection never gets committed. The workspace name
+# must NOT start with "." (the project registrar skips dot-leading mount targets),
+# so these use plain "verify-*" prefixes.
+verify-workspace.*/
+verify-rw-mount.*/
+verify-ro-mount.*/
+# Legacy dot-prefixed name from before the registrar's dotdir-skip rule.
 .verify-workspace.*/

--- a/integrations/isolation/acq-kits/paseo/README.md
+++ b/integrations/isolation/acq-kits/paseo/README.md
@@ -90,6 +90,29 @@ acq ports <sandbox> --publish 6767:6767          # this sandbox → host 6767
 acq ports <other-sandbox> --publish 6868:6767    # another → host 6868
 ```
 
+## Projects are pre-populated from your mounts
+
+Every **read-write** host directory you mount into the sandbox is registered with
+the Paseo daemon at startup, so the web UI already lists your repos when you
+connect — no manual **Add project** per directory. This runs on every start
+(idempotent) and covers all mounts, not just the primary one the `acq run`
+entrypoint opens.
+
+- **Read-only mounts are skipped.**
+- The backend runtime dir (`/.msb`) and system mounts (`/etc`, `/run`, …) are
+  excluded.
+- Discovery reads `/proc/mounts` and keys only on portable mount properties
+  (fstype `virtiofs`, read-write, a real directory, non-system path, non-dot
+  basename), so it works on both the `sbx` and `msb` isolation backends without
+  relying on backend-specific mount names.
+- It is **fail-open**: if the daemon is briefly unreachable, the sandbox is
+  unaffected and the UI simply shows fewer projects until the next start. See the
+  registrar log at `~/.local/state/paseo/paseo-register.log`.
+
+This is separate from worktree placement below — pre-population only adds
+projects; it never edits `config.json` / `worktrees.root`. See
+`docs/decisions/prepopulate-projects-from-mounts.md`.
+
 ## Worktrees
 
 Paseo keeps agent git worktrees under a **single global root**
@@ -204,8 +227,9 @@ paseo/
 ├── files/home/
 │   ├── .local/bin/opencode         # thin agent-named wrapper: passthrough to real opencode, else exec the shim
 │   ├── paseo-agent-shim            # generic kit logic: pins worktree root, prints connect info, holds PID 1 on acq run
-│   ├── paseo-start.sh              # installs + supervises the Paseo daemon + web UI
-│   └── paseo-set-worktrees-root.mjs # idempotent worktrees.root merge into config.json
+│   ├── paseo-start.sh              # installs + supervises the Paseo daemon + web UI; runs the mount registrar
+│   ├── paseo-set-worktrees-root.mjs # idempotent worktrees.root merge into config.json
+│   └── paseo-register-mounts.mjs   # registers each read-write host mount as a Paseo project (fail-open, idempotent)
 ├── README.md                       # this file
 ├── TROUBLESHOOTING.md              # failure modes and fixes
 ├── scripts/verify                  # host-side live check

--- a/integrations/isolation/acq-kits/paseo/docs/decisions/prepopulate-projects-from-mounts.md
+++ b/integrations/isolation/acq-kits/paseo/docs/decisions/prepopulate-projects-from-mounts.md
@@ -1,0 +1,122 @@
+# Decision: pre-populate Paseo projects from the mounted host directories
+
+**Status:** accepted
+
+## Context
+
+The kit should make every host project directory mounted into the sandbox show
+up in Paseo's web UI on its own, so a user connecting to the UI sees their repos
+already listed instead of adding each one by hand.
+
+Two facts shape the solution:
+
+1. **Paseo only learns about a project when something registers it.** The `acq
+   run` entrypoint opens the *primary* (first) mount via the shim; every other
+   mounted directory is invisible to the daemon until it is explicitly added.
+2. **The two acq isolation backends mount host directories differently at the
+   source level.** Inside the guest, `mount` shows (verified live):
+   - **sbx** — one `virtiofs` mount per host dir with the literal source `host`
+     (e.g. `host on /Users/.../repo type virtiofs (rw,...)`), plus read-only
+     `virtiofs` bind *files* for `/etc/resolv.conf` and `/etc/hosts`.
+   - **msb** — one `virtiofs` mount per host dir whose source is a **per-path
+     hash** (e.g. `Users_breta_754e1f1f`), plus the backend runtime mount
+     `msb_runtime on /.msb`.
+
+   The msb source token (`Users_breta_<hex>`) is a hash derived from the leading
+   path elements; it is **not stable across users or paths**, and sbx uses the
+   unrelated literal `host`. So the mount **source name cannot be used as a key**.
+
+## Decision
+
+Ship `paseo-register-mounts.mjs`, run from the startup supervisor after the
+daemon answers `/api/health`, which registers each qualifying host directory with
+the daemon.
+
+### How it registers a project
+
+There is **no `paseo project add` CLI verb.** The only side-effect-free
+registration path is the daemon message `project.add.request`, exposed by the
+bundled client as `client.addProject(cwd)`. Verified live: it is **idempotent**
+(same root ⇒ same `projectId`, no duplicate), works for **non-git** dirs
+(`kind: "non_git"`), and returns `{ project: null, errorCode: "directory_not_found" }`
+for a bad path instead of throwing.
+
+The helper imports the CLI's **own** connector
+(`<cli-pkg>/dist/utils/client.js` → `connectToDaemon`), resolving the CLI package
+dir portably from the `paseo` bin symlink (`readlink`/`realpath` of
+`command -v paseo`, then two levels up). This works under both the sudo-global
+npm prefix and the no-sudo `~/.npm-global` fallback the install path uses, and
+reuses the same socket/localhost daemon resolution the CLI itself uses (no
+host/port needed here).
+
+### Which mounts qualify (backend-agnostic, no source-name reliance)
+
+Read from `/proc/mounts`; a mount qualifies when **all** hold:
+
+1. fstype is `virtiofs` (the host-share fstype both backends use);
+2. it is mounted **read-write** — **read-only mounts are skipped** (requirement);
+3. its target is an existing **directory** (excludes sbx's `/etc/resolv.conf`,
+   `/etc/hosts` bind *files*);
+4. its target is **not** under a system prefix — `/etc`, `/run`, `/proc`, `/sys`,
+   `/dev`, or `/` itself;
+5. its target **basename does not start with `.`** — skips the backend runtime
+   dir (`/.msb` today, and any future `/.<backend>` by convention) without
+   hard-coding a name.
+
+This keys entirely on portable mount properties, so it captures the three repos
+on both sbx and msb and needs no per-backend tokens. A future backend that
+bind-mounts host dirs as read-write `virtiofs` is covered automatically.
+
+### Timing and cadence
+
+Runs on **every** sandbox start, in the background, after a bounded wait for
+`/api/health`. It is not gated on a marker file: because `addProject` dedups,
+re-running is free, and a mount added on a later start is still picked up. It
+neither blocks the daemon supervisor loop nor races the daemon's first listen.
+
+### Fail-open
+
+Project pre-population is a convenience, never a reason to break the sandbox.
+Every per-directory add is isolated in `try/catch`, the daemon connection is
+always closed, and the process **always exits 0** — even if the daemon is
+unreachable or the CLI client module cannot be loaded. A transient failure just
+means the UI shows fewer projects until the next start.
+
+## Alternatives considered
+
+- **`paseo workspace create --isolation local --path X`.** Rejected: it mints a
+  **new workspace record every call** (the `workspace.create.request` explicitly
+  never dedups by directory), so it would spam workspaces across restarts.
+- **`paseo terminal create --cwd X`.** It *does* register + dedup the project
+  (via `open_project`), but as a side effect leaves a **stray terminal** behind
+  per directory. Rejected in favor of the clean `project.add`.
+- **Raw WebSocket to `ws://localhost:6767/ws`.** Rejected: we would hand-roll the
+  protocol framing/handshake; importing the shipped client is simpler and stays
+  in sync with the pinned CLI version.
+- **Keying on the mount source name / `MSB_DIR_MOUNTS` env.** Rejected: the source
+  token is a non-portable per-path hash on msb and the literal `host` on sbx, and
+  `MSB_DIR_MOUNTS` is msb-only — none survive a different backend or user.
+- **Requiring a project marker (`.git`, `package.json`, …) in the dir.** Rejected
+  as unnecessary: it would skip intentionally-mounted non-standard working dirs,
+  and Paseo already records non-git dirs cleanly as `kind: "non_git"`.
+
+## Consequences
+
+- Every read-write host project mount is listed in the Paseo UI after any start
+  (detached `acq create` or interactive `acq run`), with no manual "Add project".
+- Read-only mounts and the backend runtime dir are excluded.
+- The behavior is orthogonal to the worktrees-root pin (which still targets only
+  the primary/first mount via the shim); this helper touches projects only, never
+  `config.json`/`worktrees.root`.
+- Depends on the CLI internal path `dist/utils/client.js` (`connectToDaemon`);
+  the kit pins `@getpaseo/cli` to a specific version, and verify's `node --check`
+  plus the live registration assertion catch a break if a future bump moves it.
+
+## Links
+
+- `../../../paseo/files/home/paseo-register-mounts.mjs` — the registrar.
+- `../../../paseo/files/home/paseo-start.sh` — invokes it after `/api/health`.
+- `supervisor-owns-daemon-wrapper-pins-worktrees.md` — the daemon lifecycle it
+  attaches to.
+- `worktrees-root-global-only.md` — the separate worktrees-root pin (primary
+  mount only), which this does not touch.

--- a/integrations/isolation/acq-kits/paseo/docs/decisions/prepopulate-projects-from-mounts.md
+++ b/integrations/isolation/acq-kits/paseo/docs/decisions/prepopulate-projects-from-mounts.md
@@ -111,6 +111,15 @@ means the UI shows fewer projects until the next start.
 - Depends on the CLI internal path `dist/utils/client.js` (`connectToDaemon`);
   the kit pins `@getpaseo/cli` to a specific version, and verify's `node --check`
   plus the live registration assertion catch a break if a future bump moves it.
+- The live verify (`scripts/verify` step 10) checks registration through the
+  daemon's **API** (`client.listProjects()`, the supported surface — the same
+  connector the registrar uses), not by scraping the daemon's on-disk
+  `projects/projects.json`. Reading the file would couple the test to Paseo's
+  internal storage layout (path, key name, JSON serialization), so that a compact
+  reserialization or a renamed key would flip step 10 to a false FAIL that looks
+  like a real regression. The API query shares the same CLI-internal-path
+  dependency already noted above (nothing new), and reuses the portable
+  `paseo`-bin resolution.
 - **Footgun:** the dotdir-skip rule (item 5) also excludes any *workspace* whose
   own directory name begins with `.`. A user who mounts, say, `~/.config/foo` as
   a project would find it silently un-registered. This is an accepted trade-off

--- a/integrations/isolation/acq-kits/paseo/docs/decisions/prepopulate-projects-from-mounts.md
+++ b/integrations/isolation/acq-kits/paseo/docs/decisions/prepopulate-projects-from-mounts.md
@@ -111,6 +111,14 @@ means the UI shows fewer projects until the next start.
 - Depends on the CLI internal path `dist/utils/client.js` (`connectToDaemon`);
   the kit pins `@getpaseo/cli` to a specific version, and verify's `node --check`
   plus the live registration assertion catch a break if a future bump moves it.
+- **Footgun:** the dotdir-skip rule (item 5) also excludes any *workspace* whose
+  own directory name begins with `.`. A user who mounts, say, `~/.config/foo` as
+  a project would find it silently un-registered. This is an accepted trade-off
+  to keep backend runtime dirs out without a name allowlist; it surfaced in
+  `scripts/verify`, whose throwaway workspace was originally named
+  `.verify-workspace.*` and was therefore skipped — the fixtures are now named
+  `verify-workspace.*` / `verify-rw-mount.*` / `verify-ro-mount.*` (no leading
+  dot). Documented here so the behavior is not mistaken for a bug.
 
 ## Links
 

--- a/integrations/isolation/acq-kits/paseo/files/home/paseo-register-mounts.mjs
+++ b/integrations/isolation/acq-kits/paseo/files/home/paseo-register-mounts.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+// paseo-register-mounts.mjs — pre-populate Paseo PROJECTS from the host
+// directories mounted into this sandbox, so the web UI already lists them the
+// moment you connect (no manual "Add project" per repo).
+//
+// WHY THIS EXISTS: acq bind-mounts one or more host project directories into the
+// guest. Paseo, however, only learns about a project when something opens it
+// (the `acq run` entrypoint opens the FIRST/primary mount via the shim; the
+// others are invisible until you add them by hand). This helper registers EVERY
+// mounted host project directory with the daemon at startup, idempotently.
+//
+// HOW IT TALKS TO THE DAEMON: there is no `paseo project add` CLI verb. The only
+// side-effect-free registration path is the daemon's `project.add.request`,
+// exposed by the bundled client as `client.addProject(cwd)`:
+//   * idempotent — the same rootPath returns the same projectId (no duplicates),
+//   * works for non-git dirs (registered as kind "non_git"),
+//   * returns { project: null, errorCode: "directory_not_found" } for a bad path
+//     instead of throwing.
+// (Alternatives were rejected: `workspace create` mints a NEW workspace record
+// every call — workspace spam across restarts — and `terminal create` leaves a
+// stray terminal behind. See docs/decisions/prepopulate-projects-from-mounts.md.)
+//
+// We import the CLI's OWN connector (dist/utils/client.js -> connectToDaemon) so
+// we reuse its socket/localhost resolution and need no host/port here. The CLI
+// package dir is resolved portably from the `paseo` bin symlink, so this works
+// whether the CLI was installed into the sudo-global npm prefix OR the no-sudo
+// per-user ~/.npm-global fallback (see paseo-start.sh).
+//
+// WHICH MOUNTS COUNT (backend-agnostic — no reliance on the source-name token,
+// which is a per-path hash on msb and the literal "host" on sbx, i.e. NOT a
+// stable key across users or backends): a mount is treated as a host project
+// directory when ALL of these hold, read from /proc/mounts:
+//   1. fstype == "virtiofs"                      (the host-share fstype both
+//                                                 acq backends use)
+//   2. mounted read-write                        (ro mounts are SKIPPED by
+//                                                 requirement)
+//   3. the target is an existing DIRECTORY       (excludes sbx's /etc/resolv.conf
+//                                                 and /etc/hosts, which are bind
+//                                                 FILES over virtiofs)
+//   4. the target is NOT under a system prefix    (/etc /run /proc /sys /dev, or
+//                                                 "/" itself)
+//   5. the target's basename does NOT start "."   (skips the backend runtime dir
+//                                                 — /.msb today, and any future
+//                                                 /.<backend> by convention —
+//                                                 without hard-coding a name)
+//
+// FAIL-OPEN: project pre-population is a convenience, never a reason to break the
+// sandbox. Every per-directory add is isolated in try/catch, the daemon
+// connection is always closed, and the process ALWAYS exits 0 — even if the
+// daemon is unreachable or some adds fail. Errors are logged for diagnosis.
+
+import { readFileSync, realpathSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { dirname, basename, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Target-path prefixes we never treat as a host project (system / pseudo mounts).
+// Matching is prefix-aware: an exact match or a "<prefix>/" child both count.
+const SYSTEM_PREFIXES = ["/etc", "/run", "/proc", "/sys", "/dev"];
+
+function log(msg) {
+  process.stdout.write(`paseo-register-mounts: ${msg}\n`);
+}
+
+// Resolve the @getpaseo/cli package directory from the `paseo` bin on PATH, so
+// we can import its connector regardless of the install prefix. `paseo` is a
+// symlink to <pkg>/bin/paseo; the package root is two levels up from that.
+function resolveCliClientModuleUrl() {
+  let binPath;
+  try {
+    binPath = execFileSync("sh", ["-c", "command -v paseo"], {
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    binPath = "";
+  }
+  if (!binPath) {
+    throw new Error("could not locate the `paseo` CLI on PATH");
+  }
+  const realBin = realpathSync(binPath); // <pkg>/bin/paseo
+  const pkgDir = dirname(dirname(realBin)); // <pkg>
+  const clientPath = resolve(pkgDir, "dist/utils/client.js");
+  // Fail early with a clear message if the internal path moved in a CLI bump.
+  statSync(clientPath);
+  return pathToFileURL(clientPath).href;
+}
+
+function isUnderSystemPrefix(target) {
+  if (target === "/") return true;
+  return SYSTEM_PREFIXES.some(
+    (prefix) => target === prefix || target.startsWith(`${prefix}/`),
+  );
+}
+
+// Un-escape the octal escapes the kernel uses in /proc/mounts fields (space =
+// \040, tab = \011, newline = \012, backslash = \134).
+function unescapeMountField(field) {
+  return field.replace(/\\(\d{3})/g, (_, oct) =>
+    String.fromCharCode(parseInt(oct, 8)),
+  );
+}
+
+// Parse /proc/mounts and return the set of host-project target directories,
+// applying the backend-agnostic rule documented in the header.
+function discoverProjectMounts() {
+  let raw;
+  try {
+    raw = readFileSync("/proc/mounts", "utf8");
+  } catch (err) {
+    log(`cannot read /proc/mounts: ${err.message}`);
+    return [];
+  }
+
+  const seen = new Set();
+  const targets = [];
+  for (const line of raw.split("\n")) {
+    if (!line) continue;
+    // fields: source target fstype options dump pass
+    const parts = line.split(/\s+/);
+    if (parts.length < 4) continue;
+    const fstype = parts[2];
+    if (fstype !== "virtiofs") continue;
+
+    const options = parts[3].split(",");
+    // The first option token is the ro/rw flag on Linux mounts. Skip ro.
+    if (options[0] !== "rw") continue;
+
+    const target = unescapeMountField(parts[1]);
+    if (isUnderSystemPrefix(target)) continue;
+    // Skip backend runtime dirs by convention (/.msb, future /.<backend>).
+    if (basename(target).startsWith(".")) continue;
+
+    // Must be a real directory (excludes bind-mounted files like /etc/hosts,
+    // already covered by the prefix rule, but also any odd file-over-virtiofs).
+    let isDir = false;
+    try {
+      isDir = statSync(target).isDirectory();
+    } catch {
+      isDir = false;
+    }
+    if (!isDir) continue;
+
+    if (seen.has(target)) continue;
+    seen.add(target);
+    targets.push(target);
+  }
+  return targets;
+}
+
+async function main() {
+  const mounts = discoverProjectMounts();
+  if (mounts.length === 0) {
+    log("no read-write host project mounts found; nothing to register");
+    return;
+  }
+  log(`found ${mounts.length} host project mount(s): ${mounts.join(", ")}`);
+
+  let connectToDaemon;
+  try {
+    ({ connectToDaemon } = await import(resolveCliClientModuleUrl()));
+  } catch (err) {
+    log(`could not load the Paseo CLI daemon client: ${err.message}`);
+    return; // fail-open
+  }
+
+  let client;
+  try {
+    client = await connectToDaemon({});
+  } catch (err) {
+    log(`could not connect to the Paseo daemon: ${err.message}`);
+    return; // fail-open (daemon may still be coming up on a very early boot)
+  }
+
+  try {
+    for (const dir of mounts) {
+      try {
+        const res = await client.addProject(dir);
+        if (res && res.project && res.project.projectId) {
+          log(`registered ${res.project.projectId}  ${dir}`);
+        } else {
+          const reason =
+            (res && (res.error || res.errorCode)) || "unknown error";
+          log(`skipped ${dir}: ${reason}`);
+        }
+      } catch (err) {
+        log(`skipped ${dir}: ${err.message}`);
+      }
+    }
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+// Always exit 0 — never let project pre-population fail the sandbox.
+main()
+  .catch((err) => {
+    log(`unexpected error: ${err && err.message ? err.message : String(err)}`);
+  })
+  .finally(() => {
+    process.exit(0);
+  });

--- a/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
+++ b/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
@@ -12,6 +12,12 @@
 # (PID 1), independent of any interactive session — the daemon + UI come up on
 # their own. No `acq exec` / no `acq run` is needed to bring the daemon up.
 #
+# It ALSO pre-populates Paseo projects from the mounted host directories: after
+# the daemon answers /api/health it runs paseo-register-mounts.mjs in the
+# background (fail-open, idempotent) so every read-write host project mount is
+# registered with the daemon and shows up in the web UI without a manual "Add
+# project". See docs/decisions/prepopulate-projects-from-mounts.md.
+#
 # The kit's `opencode` WRAPPER (files/home/.local/bin/opencode) does NOT own the
 # daemon. It is only the entrypoint on the interactive `acq run` path, where it
 # pins Paseo's worktree root under the current project, prints connect info, and
@@ -42,6 +48,11 @@ set -eu
 PASEO_LISTEN="${PASEO_LISTEN:-0.0.0.0:6767}"
 PASEO_PORT="$(printf '%s' "$PASEO_LISTEN" | sed -n 's/.*:\([0-9][0-9]*\)$/\1/p')"
 [ -n "$PASEO_PORT" ] || PASEO_PORT=6767
+
+# The mount-based project registrar (registers each read-write host project
+# directory with the daemon so the web UI pre-lists them). Backend-agnostic; see
+# the file header and docs/decisions/prepopulate-projects-from-mounts.md.
+REGISTER_MOUNTS_SCRIPT="${HOME}/paseo-register-mounts.mjs"
 
 # npm global installs land in this prefix's bin, which is NOT on the startup
 # shell's PATH by default. Put it on PATH up front so a freshly-installed `paseo`
@@ -173,4 +184,30 @@ if ! supervisor_running paseo-daemon; then
       done
     ' "supervisor:paseo-daemon" "$RESTART_DELAY" "$PASEO_LISTEN" \
     >>"$DAEMON_LOG" 2>&1 ) &
+fi
+
+# --- Pre-populate projects from the mounted host directories (every boot). -----
+# Register each read-write host project directory mounted into this sandbox with
+# the daemon so the web UI pre-lists them (no manual "Add project" per repo).
+# This runs on EVERY start (idempotent — the daemon dedups by root path), so a
+# mount added on a later start is picked up too. It is intentionally NOT gated on
+# a marker file. We run it in the BACKGROUND after waiting (bounded) for the
+# daemon to answer /api/health, so it neither blocks the supervisor loop nor
+# races the daemon's first listen. The helper itself is fully fail-open (it never
+# exits non-zero and never throws out of its loop), so this can never break the
+# sandbox; a transient failure just means the UI shows fewer projects until the
+# next start. Log to its own file for diagnosis.
+REGISTER_LOG="$HOME/.local/state/paseo/paseo-register.log"
+if [ -f "$REGISTER_MOUNTS_SCRIPT" ] && command -v node >/dev/null 2>&1; then
+  (
+    _i=0
+    while [ "$_i" -lt 60 ]; do
+      if curl -fsS "http://127.0.0.1:$PASEO_PORT/api/health" >/dev/null 2>&1; then
+        break
+      fi
+      _i=$((_i + 1))
+      sleep 2
+    done
+    node "$REGISTER_MOUNTS_SCRIPT" >>"$REGISTER_LOG" 2>&1 || true
+  ) &
 fi

--- a/integrations/isolation/acq-kits/paseo/scripts/verify
+++ b/integrations/isolation/acq-kits/paseo/scripts/verify
@@ -673,13 +673,36 @@ info "10. Projects pre-populated from the mounted host directories"
 # SKIPPED and a READ-WRITE one is REGISTERED. We derive the expected set the same
 # backend-agnostic way the helper does — from /proc/mounts inside the guest — so
 # the test does not hard-code msb/sbx mount source names.
+#
+# We read the registered projects from the daemon's own API (the same
+# `client.listProjects()` the registrar's client library speaks), NOT from the
+# on-disk projects.json. Scraping the file would couple this test to Paseo's
+# internal storage layout (path, key name, JSON spacing); querying the API is the
+# supported surface and returns each project's root as `projectRootPath`. See the
+# ADR "Consequences" note on this coupling.
 if [ -z "$daemon_up" ]; then
   skip "project pre-population check (daemon not up)"
 else
-  # Resolve the fixtures to their in-guest paths. acq/msb mount each workspace at
-  # its own absolute host path in the guest, but macOS canonicalizes /var ->
-  # /private/var etc., so ask the guest to canonicalize the paths it actually has.
-  # We match by basename (unique per fixture) against the guest's rw virtiofs set.
+  # Fetch the set of registered project root paths from the daemon API, one per
+  # line. Runs in-guest via the CLI's bundled client (connectToDaemon), resolved
+  # portably from the `paseo` bin — the same connector the registrar uses.
+  list_project_roots() {
+    in_sbx '
+      CLIENT="$(node -e "process.stdout.write(require(\"path\").dirname(require(\"path\").dirname(require(\"fs\").realpathSync(require(\"child_process\").execFileSync(\"sh\",[\"-c\",\"command -v paseo\"]).toString().trim()))))" 2>/dev/null)/dist/utils/client.js"
+      [ -f "$CLIENT" ] || exit 0
+      CLIENT_URL="file://$CLIENT" node --input-type=module -e "
+        const { connectToDaemon } = await import(process.env.CLIENT_URL);
+        const c = await connectToDaemon({});
+        try {
+          const r = await c.listProjects();
+          for (const p of r.projects ?? []) {
+            const root = p.projectRootPath ?? p.rootPath;
+            if (root) process.stdout.write(root + \"\n\");
+          }
+        } finally { await c.close().catch(() => {}); }
+      " 2>/dev/null'
+  }
+
   rw_base="$(basename "$RW_FIXTURE")"
   ro_base="$(basename "$RO_FIXTURE")"
 
@@ -697,15 +720,15 @@ else
     in_sbx 'grep virtiofs /proc/mounts' | sed 's/^/    | /'
   else
     # The registrar runs in the background after /api/health; give it a bounded
-    # window to finish before reading the project list.
+    # window to finish, then read the registered projects from the daemon API.
     reg_deadline=$(( $(date +%s) + 60 ))
-    projects_json=""
+    project_roots=""
     missing=""
     while :; do
-      projects_json="$(in_sbx 'cat "${PASEO_HOME:-$HOME/.paseo}/projects/projects.json" 2>/dev/null')"
+      project_roots="$(list_project_roots)"
       missing=""
       for m in $expected_mounts; do
-        printf '%s' "$projects_json" | grep -q "\"rootPath\": \"$m\"" || missing="$missing $m"
+        printf '%s\n' "$project_roots" | grep -qx "$m" || missing="$missing $m"
       done
       [ -z "$missing" ] && break
       [ "$(date +%s)" -ge "$reg_deadline" ] && break
@@ -713,14 +736,14 @@ else
     done
     if [ -z "$missing" ]; then
       _n="$(printf '%s\n' "$expected_mounts" | grep -c .)"
-      ok "all $_n read-write host project mount(s) registered as projects"
+      ok "all $_n read-write host project mount(s) registered as projects (via daemon API)"
     else
       bad "some host project mounts were not registered:$missing"
       in_sbx 'tail -n 20 ~/.local/state/paseo/paseo-register.log 2>/dev/null' | sed 's/^/    | /'
     fi
 
     # POSITIVE: the read-write fixture must be registered.
-    if printf '%s' "$projects_json" | grep -q "\"rootPath\": \"[^\"]*${rw_base}\""; then
+    if printf '%s\n' "$project_roots" | grep -q "${rw_base}\$"; then
       ok "read-write fixture ($rw_base) registered as a project"
     else
       bad "read-write fixture ($rw_base) was NOT registered"
@@ -731,7 +754,7 @@ else
     # :ro — in which case we skip rather than falsely fail).
     ro_is_ro="$(in_sbx "awk '\$3==\"virtiofs\" && \$4 ~ /^ro/ && \$2 ~ /${ro_base}\$/ {print \"yes\"}' /proc/mounts | head -1")"
     if [ "$ro_is_ro" = "yes" ]; then
-      if printf '%s' "$projects_json" | grep -q "\"rootPath\": \"[^\"]*${ro_base}\""; then
+      if printf '%s\n' "$project_roots" | grep -q "${ro_base}\$"; then
         bad "read-only fixture ($ro_base) was wrongly registered (should be skipped)"
       else
         ok "read-only fixture ($ro_base) correctly skipped"
@@ -741,7 +764,7 @@ else
     fi
 
     # NEGATIVE: the backend runtime dir (/.msb, a dotdir) must NOT be a project.
-    if printf '%s' "$projects_json" | grep -q '"rootPath": "/.msb"'; then
+    if printf '%s\n' "$project_roots" | grep -qx "/.msb"; then
       bad "backend runtime dir /.msb was wrongly registered as a project"
     else
       ok "backend runtime dir (/.msb) correctly excluded"

--- a/integrations/isolation/acq-kits/paseo/scripts/verify
+++ b/integrations/isolation/acq-kits/paseo/scripts/verify
@@ -152,6 +152,19 @@ else
   fi
 fi
 
+# --- Offline check of the mount registrar helper (no sandbox needed). ----------
+info "1c. mount registrar helper parses (offline)"
+REGMOUNTS="$KIT_DIR/files/home/paseo-register-mounts.mjs"
+if ! command -v node >/dev/null 2>&1; then
+  skip "node not on PATH — cannot exercise paseo-register-mounts.mjs"
+elif [ ! -f "$REGMOUNTS" ]; then
+  bad "paseo-register-mounts.mjs missing at $REGMOUNTS"
+elif node --check "$REGMOUNTS" >/dev/null 2>&1; then
+  ok "paseo-register-mounts.mjs parses (node --check)"
+else
+  bad "paseo-register-mounts.mjs failed node --check"
+fi
+
 # --- Select the live driver. -------------------------------------------------
 DRIVER=""
 if [ "$RUN_ACQ" = "1" ]; then
@@ -628,6 +641,58 @@ else
   else
     bad "daemon did NOT come back after being killed — supervisor:paseo-daemon not respawning"
     in_sbx 'tail -n 20 ~/.local/state/paseo/paseo-daemon.log' | sed 's/^/    | /'
+  fi
+fi
+
+info "10. Projects pre-populated from the mounted host directories"
+# The startup registrar (paseo-register-mounts.mjs) registers each read-write
+# host project directory mounted into the sandbox with the daemon. Assert that
+# EVERY such mount shows up as a project in the daemon's registry. We derive the
+# expected set the same backend-agnostic way the helper does — from /proc/mounts
+# inside the guest — so the test does not hard-code msb/sbx mount source names.
+if [ -z "$daemon_up" ]; then
+  skip "project pre-population check (daemon not up)"
+else
+  # Expected set: fstype virtiofs, rw, target is a dir, not under a system prefix,
+  # basename not starting with "." (matches the registrar's rule).
+  expected_mounts="$(in_sbx '
+    awk "\$3==\"virtiofs\" && \$4 ~ /^rw/ {print \$2}" /proc/mounts \
+      | while read -r t; do
+          case "$t" in /etc|/etc/*|/run|/run/*|/proc|/proc/*|/sys|/sys/*|/dev|/dev/*|/) continue ;; esac
+          case "$(basename "$t")" in .*) continue ;; esac
+          [ -d "$t" ] && echo "$t"
+        done | sort -u')"
+  if [ -z "$expected_mounts" ]; then
+    warn "no read-write host project mounts found in the guest; nothing to assert"
+  else
+    # The registrar runs in the background after /api/health; give it a bounded
+    # window to finish before reading the project list.
+    reg_deadline=$(( $(date +%s) + 60 ))
+    projects_json=""
+    missing=""
+    while :; do
+      projects_json="$(in_sbx 'cat "${PASEO_HOME:-$HOME/.paseo}/projects/projects.json" 2>/dev/null')"
+      missing=""
+      for m in $expected_mounts; do
+        printf '%s' "$projects_json" | grep -q "\"rootPath\": \"$m\"" || missing="$missing $m"
+      done
+      [ -z "$missing" ] && break
+      [ "$(date +%s)" -ge "$reg_deadline" ] && break
+      sleep "$POLL_INTERVAL"
+    done
+    if [ -z "$missing" ]; then
+      _n="$(printf '%s\n' "$expected_mounts" | grep -c .)"
+      ok "all $_n read-write host project mount(s) registered as projects"
+    else
+      bad "some host project mounts were not registered:$missing"
+      in_sbx 'tail -n 20 ~/.local/state/paseo/paseo-register.log 2>/dev/null' | sed 's/^/    | /'
+    fi
+    # Negative assertion: the backend runtime dir (/.msb, a dotdir) must NOT be a project.
+    if printf '%s' "$projects_json" | grep -q '"rootPath": "/.msb"'; then
+      bad "backend runtime dir /.msb was wrongly registered as a project"
+    else
+      ok "backend runtime dir (/.msb) correctly excluded"
+    fi
   fi
 fi
 

--- a/integrations/isolation/acq-kits/paseo/scripts/verify
+++ b/integrations/isolation/acq-kits/paseo/scripts/verify
@@ -15,7 +15,9 @@
 #      byte-complete over the host port (identity encoding; integrity guard), the
 #      in-guest 0.0.0.0 bind (reachable via create-time publish) over the host port, the
 #      install ran with lifecycle scripts disabled (hardening #2), the respawn
-#      supervisor, the PID-1 hold, daemon self-heal, and the worktree-root pin.
+#      supervisor, the PID-1 hold, the worktree-root pin, daemon self-heal, and
+#      that projects are pre-populated from the mounted host dirs — including that
+#      a read-write extra workspace IS registered and a ":ro" one is SKIPPED.
 #
 #      Preferred driver — RUN_ACQ=1: drive the `acq` CLI. acq translates the
 #      neutral hybrid/v1 spec to an sbx-v2 kit (kit_translate_to_sbx) and applies
@@ -49,8 +51,18 @@ SBX_NAME="paseo-verify-$$"
 # inspect` and, because the guest mounts it at the SAME host path, doesn't match
 # the fixed guest workspace — obscuring where worktrees actually land. Keeping it
 # under the kit dir avoids both. Cleaned up on exit (unless KEEP=1).
-WORK="$(mktemp -d "$KIT_DIR/.verify-workspace.XXXXXX")"
+# NOTE: the workspace directory name must NOT begin with "." — the project
+# registrar (paseo-register-mounts.mjs) deliberately skips mounts whose target
+# basename starts with "." (to exclude backend runtime dirs like /.msb). A
+# dot-leading workspace name would make the PRIMARY mount ineligible and defeat
+# step 10. Use a plain "verify-workspace." prefix.
+WORK="$(mktemp -d "$KIT_DIR/verify-workspace.XXXXXX")"
 CREATE_LOG="$WORK/create.log"
+# Extra workspaces mounted alongside the primary to exercise the registrar's
+# read-write vs read-only distinction in step 10: RO_FIXTURE is mounted ":ro"
+# (must be SKIPPED), RW_FIXTURE is mounted read-write (must be REGISTERED).
+RW_FIXTURE="$(mktemp -d "$KIT_DIR/verify-rw-mount.XXXXXX")"
+RO_FIXTURE="$(mktemp -d "$KIT_DIR/verify-ro-mount.XXXXXX")"
 KEEP="${KEEP:-0}"
 RUN_ACQ="${RUN_ACQ:-0}"
 RUN_SBX="${RUN_SBX:-0}"
@@ -82,7 +94,7 @@ cleanup() {
     acq) acq rm "$SBX_NAME" >/dev/null 2>&1 || true ;;
     *)   sbx rm -f "$SBX_NAME" >/dev/null 2>&1 || true ;;
   esac
-  rm -rf "$WORK" >/dev/null 2>&1 || true
+  rm -rf "$WORK" "$RW_FIXTURE" "$RO_FIXTURE" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
 
@@ -226,10 +238,17 @@ fi
 info "2. Create a sandbox with the kit"
 if [ "$DRIVER" = "acq" ]; then
   echo "  creating $SBX_NAME via acq (extra kit: $KIT_DIR)..."
+  echo "  extra workspaces: $RW_FIXTURE (rw), $RO_FIXTURE (ro) — exercises step 10"
   # Redirect stdin from /dev/null: `acq create` reads from the terminal (e.g. a
   # confirmation/consent prompt), which otherwise blocks the run until the user
   # hits ENTER. This script is non-interactive, so feed it EOF.
-  if ACQ_EXTRA_KITS="$KIT_DIR" acq create --name "$SBX_NAME" opencode "$WORK" </dev/null >"$CREATE_LOG" 2>&1; then
+  #
+  # Positional workspaces: <primary> [extra ...], with a trailing ":ro" marking a
+  # read-only extra workspace (sbx/acq multi-workspace semantics; each is mounted
+  # at its own absolute host path in the guest). We add one rw and one ro extra so
+  # step 10 can assert the registrar registers the rw mount and SKIPS the ro one.
+  if ACQ_EXTRA_KITS="$KIT_DIR" acq create --name "$SBX_NAME" opencode \
+       "$WORK" "$RW_FIXTURE" "$RO_FIXTURE:ro" </dev/null >"$CREATE_LOG" 2>&1; then
     ok "sandbox created via acq (kit translated + applied)"
   else
     bad "acq create failed (exit $?)"
@@ -279,8 +298,10 @@ else
     echo "        HTTPS-inspected network the Paseo CLI install may fail TLS." >&2
   fi
   echo "  creating $SBX_NAME (workspace $WORK) from translated kit $SBX_KIT_DIR..."
+  echo "  extra workspaces: $RW_FIXTURE (rw), $RO_FIXTURE (ro) — exercises step 10"
   dbg=(); [ "${DEBUG:-0}" = "1" ] && dbg=(-D)
-  if sbx ${dbg[@]+"${dbg[@]}"} create --name "$SBX_NAME" "${create_kits[@]}" opencode "$WORK" </dev/null >"$CREATE_LOG" 2>&1; then
+  if sbx ${dbg[@]+"${dbg[@]}"} create --name "$SBX_NAME" "${create_kits[@]}" opencode \
+       "$WORK" "$RW_FIXTURE" "$RO_FIXTURE:ro" </dev/null >"$CREATE_LOG" 2>&1; then
     ok "sandbox created with --kit"
   else
     bad "sbx create failed (exit $?)"
@@ -647,12 +668,21 @@ fi
 info "10. Projects pre-populated from the mounted host directories"
 # The startup registrar (paseo-register-mounts.mjs) registers each read-write
 # host project directory mounted into the sandbox with the daemon. Assert that
-# EVERY such mount shows up as a project in the daemon's registry. We derive the
-# expected set the same backend-agnostic way the helper does — from /proc/mounts
-# inside the guest — so the test does not hard-code msb/sbx mount source names.
+# EVERY such mount shows up as a project in the daemon's registry, and — using
+# the rw/ro fixtures we mounted at create (step 2) — that a READ-ONLY mount is
+# SKIPPED and a READ-WRITE one is REGISTERED. We derive the expected set the same
+# backend-agnostic way the helper does — from /proc/mounts inside the guest — so
+# the test does not hard-code msb/sbx mount source names.
 if [ -z "$daemon_up" ]; then
   skip "project pre-population check (daemon not up)"
 else
+  # Resolve the fixtures to their in-guest paths. acq/msb mount each workspace at
+  # its own absolute host path in the guest, but macOS canonicalizes /var ->
+  # /private/var etc., so ask the guest to canonicalize the paths it actually has.
+  # We match by basename (unique per fixture) against the guest's rw virtiofs set.
+  rw_base="$(basename "$RW_FIXTURE")"
+  ro_base="$(basename "$RO_FIXTURE")"
+
   # Expected set: fstype virtiofs, rw, target is a dir, not under a system prefix,
   # basename not starting with "." (matches the registrar's rule).
   expected_mounts="$(in_sbx '
@@ -663,7 +693,8 @@ else
           [ -d "$t" ] && echo "$t"
         done | sort -u')"
   if [ -z "$expected_mounts" ]; then
-    warn "no read-write host project mounts found in the guest; nothing to assert"
+    bad "no read-write host project mounts found in the guest — the primary + rw fixture should be present"
+    in_sbx 'grep virtiofs /proc/mounts' | sed 's/^/    | /'
   else
     # The registrar runs in the background after /api/health; give it a bounded
     # window to finish before reading the project list.
@@ -687,7 +718,29 @@ else
       bad "some host project mounts were not registered:$missing"
       in_sbx 'tail -n 20 ~/.local/state/paseo/paseo-register.log 2>/dev/null' | sed 's/^/    | /'
     fi
-    # Negative assertion: the backend runtime dir (/.msb, a dotdir) must NOT be a project.
+
+    # POSITIVE: the read-write fixture must be registered.
+    if printf '%s' "$projects_json" | grep -q "\"rootPath\": \"[^\"]*${rw_base}\""; then
+      ok "read-write fixture ($rw_base) registered as a project"
+    else
+      bad "read-write fixture ($rw_base) was NOT registered"
+    fi
+
+    # NEGATIVE: the read-only fixture must be SKIPPED. Only assert this if the
+    # guest actually mounted it read-only (guard against a backend that ignores
+    # :ro — in which case we skip rather than falsely fail).
+    ro_is_ro="$(in_sbx "awk '\$3==\"virtiofs\" && \$4 ~ /^ro/ && \$2 ~ /${ro_base}\$/ {print \"yes\"}' /proc/mounts | head -1")"
+    if [ "$ro_is_ro" = "yes" ]; then
+      if printf '%s' "$projects_json" | grep -q "\"rootPath\": \"[^\"]*${ro_base}\""; then
+        bad "read-only fixture ($ro_base) was wrongly registered (should be skipped)"
+      else
+        ok "read-only fixture ($ro_base) correctly skipped"
+      fi
+    else
+      skip "read-only skip assertion (guest did not mount $ro_base read-only; got: '${ro_is_ro:-not virtiofs}')"
+    fi
+
+    # NEGATIVE: the backend runtime dir (/.msb, a dotdir) must NOT be a project.
     if printf '%s' "$projects_json" | grep -q '"rootPath": "/.msb"'; then
       bad "backend runtime dir /.msb was wrongly registered as a project"
     else

--- a/integrations/isolation/acq-kits/paseo/spec.yaml
+++ b/integrations/isolation/acq-kits/paseo/spec.yaml
@@ -69,6 +69,24 @@
 # the value actually changes. See docs/decisions/worktrees-root-global-only.md and
 # supervisor-owns-daemon-wrapper-pins-worktrees.md.
 #
+# PROJECT PRE-POPULATION: at startup (after the daemon answers /api/health) the
+# supervisor script runs paseo-register-mounts.mjs, which registers EACH
+# read-write host project directory mounted into the sandbox with the daemon, so
+# the web UI pre-lists every mounted repo — not just the primary one the `acq run`
+# entrypoint opens. It talks to the daemon through the CLI's own client
+# (`client.addProject`, the only side-effect-free registration path — there is no
+# `paseo project add` verb), which is idempotent (dedups by root path). The set of
+# directories is derived from /proc/mounts in a BACKEND-AGNOSTIC way that does NOT
+# rely on the mount SOURCE name (a per-path hash on msb, the literal "host" on sbx
+# — neither is a stable key): a mount qualifies when it is fstype virtiofs, mounted
+# read-write (read-only mounts are SKIPPED), its target is an existing directory
+# (excludes sbx's /etc/{resolv.conf,hosts} bind files), the target is not under a
+# system prefix (/etc /run /proc /sys /dev or "/"), and the target basename does
+# not start with "." (skips the backend runtime dir — /.msb today, any future
+# /.<backend> by convention). The helper is fully fail-open: it never exits
+# non-zero, so a transient daemon/connection error just means fewer projects until
+# the next start. See docs/decisions/prepopulate-projects-from-mounts.md.
+#
 # Why install at STARTUP, not an install phase: the Paseo CLI is a plain npm
 # package (@getpaseo/cli, which pulls @getpaseo/server whose tarball BUNDLES the
 # web UI). Its only native dep (sherpa-onnx-node, for voice) resolves via
@@ -134,6 +152,10 @@ files:
     mode: "0755"
     source: files/home/paseo-set-worktrees-root.mjs
     description: Idempotently merge worktrees.root into $PASEO_HOME/config.json (used by the shim)
+  - path: /home/agent/paseo-register-mounts.mjs
+    mode: "0755"
+    source: files/home/paseo-register-mounts.mjs
+    description: Pre-populate Paseo projects from the read-write host directories mounted into the sandbox (run at startup, fail-open, idempotent)
 
 commands:
   # Run the startup script as the agent user at every start. The never-exiting
@@ -257,6 +279,12 @@ agentContext: |
   mounted project directory) when you run the `opencode` wrapper — it rewrites
   `$PASEO_HOME/config.json` and restarts the daemon so the change takes effect.
   Before you run the wrapper once, worktrees default to `$PASEO_HOME/worktrees`.
+
+  **Projects.** Every read-write host directory mounted into the sandbox is
+  registered as a Paseo project at startup, so the web UI pre-lists your repos
+  with no manual "Add project". Read-only mounts are skipped. This runs on every
+  start (idempotent) and is fail-open. Registrar log:
+  `~/.local/state/paseo/paseo-register.log`.
 
   **Auth.** The daemon runs **unsecured** (no `PASEO_PASSWORD`): the sandbox is
   the security boundary and the published port is host loopback only.


### PR DESCRIPTION
## Summary

Pre-populate Paseo projects from the host directories mounted into the sandbox, so the web UI already lists every mounted repo when you connect — instead of only the primary one the `acq run` entrypoint opens, with the rest requiring a manual **Add project**.

A new startup helper (`paseo-register-mounts.mjs`) discovers the mounted host directories and registers each with the daemon after it answers `/api/health`. It works on both the `sbx` and `msb` acq isolation backends, and is designed to keep working if another backend is added later.

## How it works

**Discovery — backend-agnostic, from `/proc/mounts`.** A mount qualifies when it is:
- fstype `virtiofs` (the host-share fstype both backends use),
- mounted **read-write** (read-only mounts are **skipped**, as requested),
- a real **directory** (excludes sbx's `/etc/resolv.conf` / `/etc/hosts` bind files),
- not under a system prefix (`/etc`, `/run`, `/proc`, `/sys`, `/dev`, `/`),
- and its basename does not start with `.` (skips the backend runtime dir — `/.msb` today, any future `/.<backend>` by convention).

It deliberately does **not** key on the mount **source** name: that is a per-path hash on msb (e.g. `Users_breta_754e1f1f`) and the literal `host` on sbx — neither is a stable key across users, paths, or backends. Keying purely on portable mount properties means a future backend that bind-mounts host dirs as read-write `virtiofs` is covered automatically.

**Registration.** There is no `paseo project add` CLI verb. The only side-effect-free path is the daemon's `project.add` message, exposed by the bundled client as `client.addProject(cwd)` (verified live: idempotent, dedups by root, handles non-git dirs, returns an error code instead of throwing on a bad path). The helper imports the CLI's own `connectToDaemon` from `dist/utils/client.js`, resolving the package dir portably from the `paseo` bin symlink so it works under both the sudo-global and no-sudo npm prefixes. Alternatives were rejected: `workspace create` mints a new workspace record every call (workspace spam), and `terminal create` leaves a stray terminal behind.

**Timing / fail-open.** Runs on every boot (idempotent → picks up mounts added on a later start), in the background after `/api/health`. Fully fail-open: per-dir `try/catch`, always closes the client, **always exits 0** — project pre-population can never break the sandbox. Logs to `~/.local/state/paseo/paseo-register.log`.

This is orthogonal to the existing worktrees-root pin (still primary-mount only); the helper touches projects only, never `config.json` / `worktrees.root`.

## Verification

Offline gate (`scripts/verify`, no sandbox): `node --check` on the registrar; `validate-kits.py --strict` clean; unsafe-shell scan clean.

Live end-to-end (`RUN_ACQ=1 scripts/verify`) — new step 10 mounts one read-write and one `:ro` extra workspace and asserts the distinction. Host run result:

```
10. Projects pre-populated from the mounted host directories
  PASS all 2 read-write host project mount(s) registered as projects
  PASS read-write fixture (verify-rw-mount.ka6kHB) registered as a project
  PASS read-only fixture (verify-ro-mount.t6Ssiv) correctly skipped
  PASS backend runtime dir (/.msb) correctly excluded

Summary
  All checks passed.
```

## Content type

- [ ] Skill
- [ ] Prompt
- [ ] Workflow
- [ ] Agent instructions
- [ ] Lesson learned
- [x] Other: acq isolation kit (tooling)

## Safety checklist

- [x] No secrets, tokens, credentials, or private keys
- [x] No PII, CUI, customer data, or sensitive info
- [x] No internal URLs or system details (paths shown are the reporter's local dev paths in verify output)
- [x] Examples use placeholders

## Rollback

Revert this PR. The change is additive: the new file plus a background invocation in `paseo-start.sh` guarded by `[ -f ... ]`. With the file absent, startup behaves exactly as before (daemon + worktrees-root pin unchanged).

## Security impact

No change to auth, network exposure, or the daemon's bind. The helper only connects to the already-running local daemon over its existing socket/localhost and calls `project.add` for directories that are already mounted into the sandbox. It reads `/proc/mounts` and never writes outside the daemon's registry.

## AI assistance

AI-assisted (OpenCode). Investigation of the Paseo CLI/daemon internals, the mount-shape analysis across sbx/msb, the helper, wiring, docs, and verify checks were developed with agent assistance and reviewed by the author.

Co-authored-by: OpenCode Agent <agent@gsa.gov>
