### PR TITLE
fix: repair 11 dead skill links, align local audit to CI, doc-honesty fixes (#338/#340/#341/#343)

### DIFF
--- a/.agents/skills/agentic-actions-auditor/SKILL.md
+++ b/.agents/skills/agentic-actions-auditor/SKILL.md
@@ -331,4 +331,4 @@ and no irreversible write without a gate.
 - GitHub Actions security hardening for untrusted input, `pull_request_target`,
   and `GITHUB_TOKEN` permissions (see GitHub's official docs)
 - Governance model for security skills:
-  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)
+  [`docs/security-skill-governance.md`](../../../docs/security-skill-governance.md)

--- a/.agents/skills/backdoor-review/SKILL.md
+++ b/.agents/skills/backdoor-review/SKILL.md
@@ -334,4 +334,4 @@ All examples are **synthetic** and **conceptual**. Snippets describe a
   Integrity):
   [`SECURITY-CONTROLS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/SECURITY-CONTROLS.md)
 - Governance model for security skills:
-  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)
+  [`docs/security-skill-governance.md`](../../../docs/security-skill-governance.md)

--- a/.agents/skills/communications/agentic-value-analyst/SKILL.md
+++ b/.agents/skills/communications/agentic-value-analyst/SKILL.md
@@ -184,7 +184,7 @@ modeled levers. (See the measurement guidance §5.)
 
 - [`technical-concept-translator`](../technical-concept-translator/SKILL.md)
 - [`software-delivery-explainer`](../software-delivery-explainer/SKILL.md)
-- [`design-artifact`](../../../workflows/design-artifact/SKILL.md)
+- [`design-artifact`](../../../../workflows/design-artifact/SKILL.md)
 
 ## Human Review Checklist
 

--- a/.agents/skills/communications/software-delivery-explainer/SKILL.md
+++ b/.agents/skills/communications/software-delivery-explainer/SKILL.md
@@ -191,7 +191,7 @@ review, merge, and deploy as human-held gates.
 
 - [`technical-concept-translator`](../technical-concept-translator/SKILL.md)
 - [`agentic-value-analyst`](../agentic-value-analyst/SKILL.md)
-- [`design-artifact`](../../../workflows/design-artifact/SKILL.md)
+- [`design-artifact`](../../../../workflows/design-artifact/SKILL.md)
 
 ## Human Review Checklist
 

--- a/.agents/skills/communications/technical-concept-translator/SKILL.md
+++ b/.agents/skills/communications/technical-concept-translator/SKILL.md
@@ -169,7 +169,7 @@ specific task.
 
 - [`software-delivery-explainer`](../software-delivery-explainer/SKILL.md) — the whole process.
 - [`agentic-value-analyst`](../agentic-value-analyst/SKILL.md) — value framing.
-- [`design-artifact`](../../../workflows/design-artifact/SKILL.md) — render an artifact (`technical-explainer` profile).
+- [`design-artifact`](../../../../workflows/design-artifact/SKILL.md) — render an artifact (`technical-explainer` profile).
 - [`plain-language-review`](../../frontend/plain-language-review/SKILL.md) — readability check.
 
 **How this differs (not a duplicate):** `plain-language-review` *reviews existing

--- a/.agents/skills/compliance-claim-checker/SKILL.md
+++ b/.agents/skills/compliance-claim-checker/SKILL.md
@@ -288,4 +288,4 @@ and it describes an *effort/design* alignment, not a certification.
   [playbook `AGENTS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/AGENTS.md),
   [`SECURITY-CONTROLS.md`](https://github.com/GSA-TTS/agentic-coding-playbook/blob/main/docs/SECURITY-CONTROLS.md)
 - Governance model for security skills:
-  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)
+  [`docs/security-skill-governance.md`](../../../docs/security-skill-governance.md)

--- a/.agents/skills/incident-evidence-review/SKILL.md
+++ b/.agents/skills/incident-evidence-review/SKILL.md
@@ -313,4 +313,4 @@ Finding:
 - NIST SP 800-53 IR-4 (Incident Handling), IR-6 (Incident Reporting), AU-6
   (Audit Record Review) — controls this review supports
 - Governance model for security skills:
-  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)
+  [`docs/security-skill-governance.md`](../../../docs/security-skill-governance.md)

--- a/.agents/skills/least-privilege-review/SKILL.md
+++ b/.agents/skills/least-privilege-review/SKILL.md
@@ -313,4 +313,4 @@ comment) and adds nothing extra.
 - Boundary partner (trigger/injection surface):
   `agentic-actions-auditor`
 - Governance model for security skills:
-  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)
+  [`docs/security-skill-governance.md`](../../../docs/security-skill-governance.md)

--- a/.agents/skills/safe-shell-script-author/SKILL.md
+++ b/.agents/skills/safe-shell-script-author/SKILL.md
@@ -309,7 +309,7 @@ credentials from a secret store at runtime — never echoes them.
 
 ## References
 
-- The [clean-script standard](../../docs/clean-script-standard.md) — the
+- The [clean-script standard](../../../docs/clean-script-standard.md) — the
   authoritative required/prohibited checklist this skill emits to (enforced by
   the unsafe-pattern scanner).
 - Secure code generation (never restated here):
@@ -319,4 +319,4 @@ credentials from a secret store at runtime — never echoes them.
 - ShellCheck (static analysis for shell): <https://www.shellcheck.net/>
 - shfmt (shell formatter): <https://github.com/mvdan/sh>
 - Governance model for security skills:
-  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)
+  [`docs/security-skill-governance.md`](../../../docs/security-skill-governance.md)

--- a/.agents/skills/untrusted-input-boundary-review/SKILL.md
+++ b/.agents/skills/untrusted-input-boundary-review/SKILL.md
@@ -295,4 +295,4 @@ reach an instruction or privilege-granting position.
 - Sibling skills: `secure-code-review` (app-level SQLi/XSS),
   `agentic-actions-auditor` (CI trigger surface)
 - Governance model for security skills:
-  [`docs/security-skill-governance.md`](../../docs/security-skill-governance.md)
+  [`docs/security-skill-governance.md`](../../../docs/security-skill-governance.md)

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -29,7 +29,7 @@
       "pattern": "<[^>]+>"
     },
     {
-      "_comment": "Relative links that climb out of the current file's directory (../../docs, ../../../agentic-coding-playbook, ../other-pattern) are mis-resolved by the checker to a 400. Cross-file existence is validated by `make validate`; cross-repo targets live in a sibling repo not present in CI checkout.",
+      "_comment": "Relative links that climb out of the current file's directory (../../docs, ../../../agentic-coding-playbook, ../other-pattern) are mis-resolved by the checker to a 400, so they are skipped here. NOTE (#338): no validator currently resolves these on-disk, so a wrong relative depth is NOT caught by CI — author `../` links relative to the PHYSICAL path (files under .agents/skills/<skill>/ reach repo-root docs/ via ../../../docs/, not ../../docs/, because the skills/ path is a symlink). Cross-repo targets live in a sibling repo not present in CI checkout.",
       "pattern": "^\\.\\./"
     },
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ output:
   format: markdown
   contract:
     required_sections: ["Summary"]
-    prohibited_content: ["Secrets", "PII", "CUI"]
+    prohibited_content: ["Secrets", "PII", "CUI", "Internal URLs"]
 quality_gates:
   readability_max_grade: 10
   citations_required: false

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ search:  ## Search patterns (e.g., make search TAG=security)
 	fi
 
 security:  ## Run security audit (pip-audit for CVEs)
-	pip-audit
+	pip-audit --skip-editable
 
 test:  ## Run pytest test suite
 	@if [ -d "scripts/tests" ] && [ "$$(ls -A scripts/tests/*.py 2>/dev/null)" ]; then \
@@ -105,7 +105,7 @@ ci:  ## Full CI check (validate + security + test + pre-commit checks)
 	python integrations/isolation/acq-kits/validate-kits.py --strict
 	@echo ""
 	@echo "==> Running security audit..."
-	pip-audit
+	pip-audit --skip-editable
 	@echo ""
 	@echo "==> Running tests..."
 	@if [ -d "scripts/tests" ] && [ "$$(ls -A scripts/tests/*.py 2>/dev/null)" ]; then \

--- a/README.md
+++ b/README.md
@@ -109,8 +109,11 @@ make coverage
    # Search by tag
    python scripts/search_patterns.py --tag security
 
-   # Filter by status
-   python scripts/search_patterns.py --status recommended
+   # Filter by status (e.g. experimental — the default for new patterns).
+   # Note: `recommended` is populated only via the peer-review promotion gate
+   # (see docs/security-skill-promotion-checklist.md); no patterns are promoted yet,
+   # so `--status recommended` currently returns nothing.
+   python scripts/search_patterns.py --status experimental
 
    # Combined filters
    python scripts/search_patterns.py --tag security --tool opencode


### PR DESCRIPTION
Doc-accuracy + local/CI-parity portion of the "CI must enforce what the docs claim" audit epic (#336). The schema-strictness (#340) and CODEOWNERS-reviewer (#342) parts are **deferred** with issue comments so they get their own review; #344 is deferred to #275 (Phase-4 sbx-kits removal).

## #338 — 11 dead relative links (the audit found the wrong ones)
The audit cited `git-ssh-sign/docs/*.md` links that actually **resolve fine**. The real breakage: **11 relative links under `.agents/skills/`** pointed one level too shallow. The files live *physically* under `.agents/skills/` (`skills/` is a symlink), so `../../docs/...` resolved to `.agents/docs/` (missing) on GitHub **and** on disk — meaning the security-governance skills (compliance-claim-checker, least-privilege-review, backdoor-review, safe-shell-script-author, …) each had a **dead link to their own governance doc**. Fixed to `../../../docs/` (8) and `../../../../workflows/` (3); all 11 now resolve.
- These were invisible to CI because `.markdown-link-check.json` ignores `^\.\./`. Corrected that config's **false** "validated by `make validate`" comment (no validator resolves on-disk relative links) and documented the symlink-depth gotcha for authors.

## #340 — prohibited_content minimum (partial)
`AGENTS.md:132` example listed 3 items; the CONTRIBUTING MUST, both templates, and AGENTS.md's own frontmatter (`:16`) all require **4** (adds `Internal URLs`). Fixed the example to 4. **Deferred:** schema `minItems 1 → 4` enforcement (verified all 40 patterns already ship ≥4, so it's safe) — tracked on #340 for its own review.

## #341 — `make ci` can't pass on a dev machine
`make security`/`make ci` ran bare `pip-audit` (audits the whole interpreter env → fails on unrelated CVEs), while `ci.yml` runs `pip-audit --skip-editable` in a clean project venv. Aligned both Makefile sites to `--skip-editable`.

## #343 — empty 'recommended' lifecycle
README documented `search_patterns.py --status recommended`, which returns nothing (0 of 41 promoted; promotion is peer-review-gated, agents may not self-promote). Changed the example to `--status experimental` and explained the empty state + linked the promotion checklist.

## Verification
`make validate` · `generate-check` · **358 tests** · markdownlint (90 files, 0 errors) all green.

## Deferred (commented on the issues)
#340 schema minItems, #342 CODEOWNERS (needs a maintainer decision: create a security team vs doc-honesty reword), #344 → #275.

Refs #336 #338 #340 #341 #343

AI-assisted (OpenCode).