### PR TITLE
fix(schema): enforce prohibited_content minimum + category coverage (#340)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,7 +280,7 @@ changelog:
 - `requires.anchors`: Dependencies (usually empty)
 - `output.format`: Output format (usually "markdown")
 - `output.contract.required_sections`: Must-have sections
-- `output.contract.prohibited_content`: Must NOT include (min: Secrets, PII, CUI, Internal URLs)
+- `output.contract.prohibited_content`: MUST list at least 4 items covering the four mandated categories — **Secrets, PII, CUI, Internal URLs** (richer phrasings like "Real PII" satisfy a category). Enforced by `schemas/skill.schema.json` (`minItems: 4`) + the validator's category-coverage check.
 - `quality_gates.readability_max_grade`: Max reading level (usually 10)
 - `quality_gates.citations_required`: Require citations? (usually false)
 

--- a/docs/AI-AGENT-GUIDE.md
+++ b/docs/AI-AGENT-GUIDE.md
@@ -692,7 +692,8 @@ output:
   format: markdown                # Output format
   contract:
     required_sections: []         # Must-have sections
-    prohibited_content: []        # Must-not-have content
+    # MUST list >=4 items covering Secrets, PII, CUI, Internal URLs (#340)
+    prohibited_content: ["Secrets", "PII", "CUI", "Internal URLs"]
 quality_gates:
   readability_max_grade: 10       # Flesch-Kincaid level
   citations_required: false       # Require sources?

--- a/docs/AI-AGENT-GUIDE.md
+++ b/docs/AI-AGENT-GUIDE.md
@@ -692,7 +692,7 @@ output:
   format: markdown                # Output format
   contract:
     required_sections: []         # Must-have sections
-    # MUST list >=4 items covering Secrets, PII, CUI, Internal URLs (#340)
+    # MUST list >=4 items covering Secrets, PII, CUI, Internal URLs
     prohibited_content: ["Secrets", "PII", "CUI", "Internal URLs"]
 quality_gates:
   readability_max_grade: 10       # Flesch-Kincaid level

--- a/schemas/skill.schema.json
+++ b/schemas/skill.schema.json
@@ -142,7 +142,7 @@
             "prohibited_content": {
               "type": "array",
               "items": {"type": "string"},
-              "minItems": 1
+              "minItems": 4
             },
             "max_length": {
               "type": "integer",

--- a/scripts/tests/test_validate_frontmatter.py
+++ b/scripts/tests/test_validate_frontmatter.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from scripts.validate_frontmatter import (
+    check_prohibited_content_coverage,
     check_routing_taxonomy,
     check_security_governance,
     extract_frontmatter,
@@ -337,7 +338,7 @@ class TestRealSchemaStrictness:
                 "format": "markdown",
                 "contract": {
                     "required_sections": ["Summary"],
-                    "prohibited_content": ["Secrets"],
+                    "prohibited_content": ["Secrets", "PII", "CUI", "Internal URLs"],
                 },
             },
             "quality_gates": {"readability_max_grade": 10, "citations_required": False},
@@ -459,7 +460,10 @@ class TestRealSchemaStrictness:
                 {"role": "source", "media_type": "text/html", "extension": "html"},
                 {"role": "export", "media_type": "application/pdf", "extension": "pdf"},
             ],
-            "contract": {"required_sections": ["Summary"], "prohibited_content": ["Secrets"]},
+            "contract": {
+                "required_sections": ["Summary"],
+                "prohibited_content": ["Secrets", "PII", "CUI", "Internal URLs"],
+            },
         }
         jsonschema.validate(instance=fm, schema=real_schema)
 
@@ -478,7 +482,10 @@ class TestRealSchemaStrictness:
         fm["output"] = {
             "format": "multi",
             "artifacts": [{"role": "bogus", "media_type": "text/html"}],
-            "contract": {"required_sections": ["Summary"], "prohibited_content": ["Secrets"]},
+            "contract": {
+                "required_sections": ["Summary"],
+                "prohibited_content": ["Secrets", "PII", "CUI", "Internal URLs"],
+            },
         }
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=fm, schema=real_schema)
@@ -509,7 +516,7 @@ class TestRealSchemaStrictness:
               format: multi
               contract:
                 required_sections: ["Summary"]
-                prohibited_content: ["Secrets"]
+                prohibited_content: ["Secrets", "PII", "CUI", "Internal URLs"]
             quality_gates: {readability_max_grade: 10, citations_required: false}
             ---
             # body
@@ -583,3 +590,35 @@ class TestSecurityGateUnaffectedByRouting:
         }
         errors, _ = check_security_governance(Path("skills/x/SKILL.md"), fm)
         assert errors == []
+
+
+class TestProhibitedContentCoverage:
+    """#340: prohibited_content must cover the 4 mandated categories (schema
+    enforces the >=4 count; this enforces the right categories)."""
+
+    def _fm(self, items):
+        return {"output": {"format": "markdown", "contract": {"prohibited_content": items}}}
+
+    def test_canonical_four_pass(self):
+        errs = check_prohibited_content_coverage(self._fm(["Secrets", "PII", "CUI", "Internal URLs"]))
+        assert errs == []
+
+    def test_richer_phrasings_pass(self):
+        # The real corpus uses "Real PII"/"Real CUI"/"Internal Hostnames".
+        errs = check_prohibited_content_coverage(
+            self._fm(["Real Secrets", "Real PII", "Real CUI", "Internal Hostnames", "Exploit Code"])
+        )
+        assert errs == []
+
+    def test_four_unrelated_items_fail_coverage(self):
+        # SAFETY: four items that DON'T cover the categories must be rejected —
+        # a skill can't satisfy the count with unrelated strings.
+        errs = check_prohibited_content_coverage(self._fm(["A", "B", "C", "D"]))
+        assert errs and "PII" in errs[0] and "CUI" in errs[0]
+
+    def test_missing_one_category_fails(self):
+        errs = check_prohibited_content_coverage(self._fm(["Secrets", "PII", "CUI", "Extra"]))
+        assert errs and "internal URLs" in errs[0]
+
+    def test_no_contract_is_noop(self):
+        assert check_prohibited_content_coverage({"title": "x"}) == []

--- a/scripts/tests/test_validate_frontmatter.py
+++ b/scripts/tests/test_validate_frontmatter.py
@@ -593,7 +593,7 @@ class TestSecurityGateUnaffectedByRouting:
 
 
 class TestProhibitedContentCoverage:
-    """#340: prohibited_content must cover the 4 mandated categories (schema
+    """prohibited_content must cover the 4 mandated categories (schema
     enforces the >=4 count; this enforces the right categories)."""
 
     def _fm(self, items):

--- a/scripts/validate_frontmatter.py
+++ b/scripts/validate_frontmatter.py
@@ -182,7 +182,7 @@ def find_pattern_files(root: Path) -> list[Path]:
     return sorted(patterns)
 
 
-# The four mandated prohibited_content categories (#340), each matched by a
+# The four mandated prohibited_content categories, each matched by a
 # substring so richer phrasings satisfy it ("Real PII" covers PII, "Internal
 # Hostnames" covers the internal-URL category). The CONTRIBUTING MUST and
 # AGENTS.md §5 name these four as the minimum; the schema enforces the >=4 count,
@@ -197,7 +197,7 @@ _PROHIBITED_CONTENT_CATEGORIES: dict[str, tuple[str, ...]] = {
 
 def check_prohibited_content_coverage(frontmatter: dict[str, Any]) -> list[str]:
     """Ensure output.contract.prohibited_content covers the four mandated
-    categories (#340). Case-insensitive substring match, so intentional richer
+    categories. Case-insensitive substring match, so intentional richer
     phrasings ("Real PII", "Real CUI", "Internal Hostnames") count. No-op if the
     pattern has no output contract."""
     output = frontmatter.get("output")
@@ -214,7 +214,7 @@ def check_prohibited_content_coverage(frontmatter: dict[str, Any]) -> list[str]:
     if missing:
         return [
             "output.contract.prohibited_content must cover the four mandated categories "
-            f"(secrets, PII, CUI, internal URLs); missing: {', '.join(missing)} (#340)"
+            f"(secrets, PII, CUI, internal URLs); missing: {', '.join(missing)}"
         ]
     return []
 
@@ -263,7 +263,7 @@ def validate_file(
                 gov_warnings,
             )
 
-    # prohibited_content coverage (#340): the schema enforces the COUNT (minItems
+    # prohibited_content coverage: the schema enforces the COUNT (minItems
     # 4); this enforces that the four mandated CATEGORIES are actually covered —
     # secrets, PII, CUI, and internal URLs — so a skill can't satisfy the count
     # with four unrelated items. Matches the richer phrasings in use ("Real PII",

--- a/scripts/validate_frontmatter.py
+++ b/scripts/validate_frontmatter.py
@@ -182,6 +182,43 @@ def find_pattern_files(root: Path) -> list[Path]:
     return sorted(patterns)
 
 
+# The four mandated prohibited_content categories (#340), each matched by a
+# substring so richer phrasings satisfy it ("Real PII" covers PII, "Internal
+# Hostnames" covers the internal-URL category). The CONTRIBUTING MUST and
+# AGENTS.md §5 name these four as the minimum; the schema enforces the >=4 count,
+# this enforces they are the RIGHT four categories.
+_PROHIBITED_CONTENT_CATEGORIES: dict[str, tuple[str, ...]] = {
+    "secrets": ("secret", "credential", "token", "password", "api key"),
+    "PII": ("pii",),
+    "CUI": ("cui",),
+    "internal URLs": ("internal url", "internal hostname", "internal host"),
+}
+
+
+def check_prohibited_content_coverage(frontmatter: dict[str, Any]) -> list[str]:
+    """Ensure output.contract.prohibited_content covers the four mandated
+    categories (#340). Case-insensitive substring match, so intentional richer
+    phrasings ("Real PII", "Real CUI", "Internal Hostnames") count. No-op if the
+    pattern has no output contract."""
+    output = frontmatter.get("output")
+    contract = output.get("contract") if isinstance(output, dict) else None
+    if not isinstance(contract, dict):
+        return []
+    items = contract.get("prohibited_content")
+    if not isinstance(items, list):
+        return []
+    haystack = " ".join(str(i).lower() for i in items)
+    missing = [
+        label for label, needles in _PROHIBITED_CONTENT_CATEGORIES.items() if not any(n in haystack for n in needles)
+    ]
+    if missing:
+        return [
+            "output.contract.prohibited_content must cover the four mandated categories "
+            f"(secrets, PII, CUI, internal URLs); missing: {', '.join(missing)} (#340)"
+        ]
+    return []
+
+
 def validate_file(
     file_path: Path, schema: dict[str, Any], taxonomy: dict[str, set[str]] | None = None
 ) -> tuple[bool, list[str], list[str]]:
@@ -225,6 +262,15 @@ def validate_file(
                 ["output.format is 'multi' but output.artifacts is empty (list at least one produced file)"],
                 gov_warnings,
             )
+
+    # prohibited_content coverage (#340): the schema enforces the COUNT (minItems
+    # 4); this enforces that the four mandated CATEGORIES are actually covered —
+    # secrets, PII, CUI, and internal URLs — so a skill can't satisfy the count
+    # with four unrelated items. Matches the richer phrasings in use ("Real PII",
+    # "Real CUI", "Internal Hostnames") rather than requiring literal bare strings.
+    pc_errors = check_prohibited_content_coverage(frontmatter)
+    if pc_errors:
+        return False, pc_errors, gov_warnings
 
     return True, [], gov_warnings
 


### PR DESCRIPTION
Closes #340. Part of epic #336. The `prohibited_content` minimum disagreed **three ways** and the schema enforced none of it (AGENTS.md example vs the CONTRIBUTING MUST vs `schema minItems: 1`).

Enforce it once, in two layers (maintainer-chosen: **minItems 4 + semantic category check**, not rigid exact strings):

- **`schemas/skill.schema.json`**: `prohibited_content` `minItems 1 → 4` (the count the MUST states). Verified **all 42 skills already ship ≥4**, so nothing breaks.
- **`validate_frontmatter.py`** — new `check_prohibited_content_coverage` requires the list to actually **cover the four categories** (secrets, PII, CUI, internal URLs) by case-insensitive substring, so the real corpus's richer phrasings — `"Real PII"`, `"Real CUI"`, `"Internal Hostnames"` — satisfy it, while **four unrelated strings do not**. This closes the gap `minItems` alone leaves.

**Docs reconciled** to state the minimum once: CONTRIBUTING now says "≥4 covering Secrets/PII/CUI/Internal URLs (richer phrasings satisfy a category), enforced by schema + validator"; the AI-AGENT-GUIDE skeleton's empty `prohibited_content: []` is filled to the canonical 4 (an empty list would now correctly fail). AGENTS.md examples were already 4-item.

**Tests:** canonical-4 pass · richer-phrasings pass · **four-unrelated-items FAIL** (the load-bearing safety assertion) · missing-one-category fails · no-contract no-op. Updated 4 in-test fixtures from the old 1-item list.

## Verification
`make validate` (all 42 skills) · **363 tests** · `make test-cases` (73) · ruff check/format · generate-check all green.

Closes #340

AI-assisted (OpenCode).