### PR TITLE
feat(kits): add neutral volumes to hybrid/v1 schema

### DIFF
--- a/integrations/isolation/acq-kits/validate-kits.py
+++ b/integrations/isolation/acq-kits/validate-kits.py
@@ -27,6 +27,7 @@ Exit status is non-zero if any kit has ERRORS. With --strict, WARN advisories
 also fail the run. No network, no sandbox — this is the backend-agnostic gate;
 live per-backend verification is each kit's scripts/verify.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -67,6 +68,22 @@ _PORT_NAME_RE = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
 # Valid transport protocols for a published port (mirrors the schema enum).
 _PORT_PROTOCOLS = {"tcp", "udp"}
+
+# Portable byte-size grammar for a volumes[].size (integer or decimal + optional
+# bare k/m/g/t/p unit: "20G", "512m", "1.5G"). Mirrors the schema's size
+# pattern. Deliberately NO b/ib suffixes ("256MB", "2gib"): sbx's
+# units.RAMInBytes accepts them but msb's size parser rejects them (verified on
+# msb 0.6.12), so the neutral grammar is the INTERSECTION of the two. A
+# volumes[].path reuses _SAFE_PATH_RE above — same charset rule as files[].path
+# (#225).
+_VOL_SIZE_RE = re.compile(r"^[0-9]+(\.[0-9]+)?[kKmMgGtTpP]?$")
+
+# A size that parses but is zero ("0", "0G", "0.0"). The schema pattern alone
+# cannot express non-zero cleanly, so the validator rejects it here.
+_VOL_SIZE_ZERO_RE = re.compile(r"^0+(\.0+)?[kKmMgGtTpP]?$")
+
+# Valid backing-storage types for a volume (mirrors the schema enum).
+_VOL_TYPES = {"", "tmpfs"}
 
 # Extensions that indicate a kit-provided payload/script a command expects to
 # have been dropped by files[] (as opposed to a base-image binary, a runtime-
@@ -143,7 +160,7 @@ def validate_kit(kit_dir: Path, schema: dict) -> tuple[list[str], list[str]]:
             )
 
     for section in ("backend_shortcuts", "backend_extras"):
-        for backend in (spec.get(section) or {}):
+        for backend in spec.get(section) or {}:
             if backend not in KNOWN_BACKENDS:
                 errors.append(f"{kit_dir.name}: {section}: unknown backend '{backend}'")
 
@@ -154,13 +171,11 @@ def validate_kit(kit_dir: Path, schema: dict) -> tuple[list[str], list[str]]:
         for name, value in environment.items():
             if not _ENV_NAME_RE.match(str(name)):
                 errors.append(
-                    f"{kit_dir.name}: environment: invalid env var name '{name}' "
-                    f"(must match [A-Za-z_][A-Za-z0-9_]*)"
+                    f"{kit_dir.name}: environment: invalid env var name '{name}' (must match [A-Za-z_][A-Za-z0-9_]*)"
                 )
             if not isinstance(value, str):
                 errors.append(
-                    f"{kit_dir.name}: environment['{name}']: value must be a string "
-                    f"(got {type(value).__name__})"
+                    f"{kit_dir.name}: environment['{name}']: value must be a string (got {type(value).__name__})"
                 )
 
     if not (kit_dir / "README.md").exists():
@@ -181,10 +196,7 @@ def validate_kit(kit_dir: Path, schema: dict) -> tuple[list[str], list[str]]:
         else:
             for i, entry in enumerate(published_ports):
                 if not isinstance(entry, dict):
-                    errors.append(
-                        f"{kit_dir.name}: publishedPorts[{i}] must be an object "
-                        f"(got {type(entry).__name__})"
-                    )
+                    errors.append(f"{kit_dir.name}: publishedPorts[{i}] must be an object (got {type(entry).__name__})")
                     continue
                 # guest: required int in 1..65535.
                 if "guest" not in entry:
@@ -193,14 +205,12 @@ def validate_kit(kit_dir: Path, schema: dict) -> tuple[list[str], list[str]]:
                     guest = entry["guest"]
                     if not _is_valid_port(guest):
                         errors.append(
-                            f"{kit_dir.name}: publishedPorts[{i}].guest must be an integer 1..65535 "
-                            f"(got {guest!r})"
+                            f"{kit_dir.name}: publishedPorts[{i}].guest must be an integer 1..65535 (got {guest!r})"
                         )
                 # host: optional int in 1..65535 (defaults to guest when omitted).
                 if "host" in entry and not _is_valid_port(entry["host"]):
                     errors.append(
-                        f"{kit_dir.name}: publishedPorts[{i}].host must be an integer 1..65535 "
-                        f"(got {entry['host']!r})"
+                        f"{kit_dir.name}: publishedPorts[{i}].host must be an integer 1..65535 (got {entry['host']!r})"
                     )
                 # protocol: optional, tcp|udp (defaults to tcp when omitted).
                 if "protocol" in entry and entry["protocol"] not in _PORT_PROTOCOLS:
@@ -215,14 +225,54 @@ def validate_kit(kit_dir: Path, schema: dict) -> tuple[list[str], list[str]]:
                         f"(allowed: alphanumerics . _ -, 1-64 chars): {entry['name']!r}"
                     )
 
+    # volumes[] field-level checks (quickstart ADR-0022). The jsonschema pass
+    # above already enforces these; we ALSO check them here so a bad value is
+    # reported with a clear per-entry message at the gate. path/size reach a
+    # generated backend spec and an msb create argv (SI-10), so both are
+    # charset-gated; size is REQUIRED (no unsized default).
+    volumes = spec.get("volumes")
+    if volumes is not None:
+        if not isinstance(volumes, list):
+            errors.append(f"{kit_dir.name}: volumes must be an array of volume objects")
+        else:
+            for i, v in enumerate(volumes):
+                if not isinstance(v, dict):
+                    errors.append(f"{kit_dir.name}: volumes[{i}] must be an object")
+                    continue
+                path = v.get("path")
+                if not isinstance(path, str) or not _SAFE_PATH_RE.match(path):
+                    errors.append(
+                        f"{kit_dir.name}: volumes[{i}].path must be an absolute path "
+                        f"in the safe charset [A-Za-z0-9._/-] (got {path!r})"
+                    )
+                size = v.get("size")
+                if not isinstance(size, str) or not _VOL_SIZE_RE.match(size):
+                    errors.append(
+                        f"{kit_dir.name}: volumes[{i}].size is required and must be a "
+                        f'portable byte-size string like "20G" or "512m" — no b/ib '
+                        f"suffix, msb rejects them (got {size!r})"
+                    )
+                elif _VOL_SIZE_ZERO_RE.match(size):
+                    errors.append(f"{kit_dir.name}: volumes[{i}].size must be non-zero (got {size!r})")
+                vtype = v.get("type", "")
+                if vtype not in _VOL_TYPES:
+                    errors.append(f'{kit_dir.name}: volumes[{i}].type must be "" (block) or "tmpfs" (got {vtype!r})')
+            # Duplicate mount paths within one kit are an authoring error: the
+            # "union by path, last wins" composition rule exists for cross-kit
+            # merging, not for silently resolving a same-kit copy-paste typo.
+            vol_paths = [v.get("path") for v in volumes if isinstance(v, dict) and isinstance(v.get("path"), str)]
+            for dup in sorted({p for p in vol_paths if vol_paths.count(p) > 1}):
+                errors.append(
+                    f"{kit_dir.name}: volumes: duplicate path {dup!r} (declared {vol_paths.count(dup)} times)"
+                )
+
     # commands[].background field-level check (ADR-0014, quickstart repo). Marks
     # a startup command that must be detached rather than awaited. Optional; when
     # present it MUST be a boolean (default false when omitted).
     for i, c in enumerate(spec.get("commands", []) or []):
         if isinstance(c, dict) and "background" in c and not isinstance(c["background"], bool):
             errors.append(
-                f"{kit_dir.name}: commands[{i}].background must be a boolean "
-                f"(got {type(c['background']).__name__})"
+                f"{kit_dir.name}: commands[{i}].background must be a boolean (got {type(c['background']).__name__})"
             )
 
     # caps.network.tier field-level check (#300). Optional; when present it MUST
@@ -231,11 +281,7 @@ def validate_kit(kit_dir: Path, schema: dict) -> tuple[list[str], list[str]]:
     # enum already rejects bad values — this adds a clearer, kit-scoped message.
     _net = (spec.get("caps") or {}).get("network") or {}
     if "tier" in _net and _net["tier"] not in ("strict", "balanced", "open"):
-        errors.append(
-            f"{kit_dir.name}: caps.network.tier must be one of "
-            f"strict|balanced|open (got {_net['tier']!r})"
-        )
-
+        errors.append(f"{kit_dir.name}: caps.network.tier must be one of strict|balanced|open (got {_net['tier']!r})")
 
     # a heuristic (a command could legitimately create a script at runtime), so
     # it flags for human eyes rather than failing the gate outright.

--- a/integrations/isolation/docs/decisions/0001-neutral-hybrid-v1-acq-kits.md
+++ b/integrations/isolation/docs/decisions/0001-neutral-hybrid-v1-acq-kits.md
@@ -206,6 +206,39 @@ The schema addition is additive and backward-compatible (existing kits without
 `environment` are unaffected). See quickstart#202 for the translate-layer
 implementation and ADR-0011 there.
 
+## Amendment: `volumes` vocabulary (quickstart ADR-0022)
+
+The neutral vocabulary gains a top-level `volumes` list — sized guest storage
+volumes, mounted at sandbox creation before any exec is possible. Each backend
+maps them to its native primitive (sbx: kit-spec v2 §5.7 volumes, a dedicated
+block device; msb: a per-sandbox derived named disk volume via `--mount-named`,
+or `--tmpfs`). The quickstart translate layer already consumes the field
+defensively (absence is a no-op), so this schema addition is additive and
+backward-compatible.
+
+Entry shape: `path` (required, absolute, same safe charset as `files[].path` —
+the path reaches a generated backend spec and an msb create argv; duplicate
+paths within one kit are rejected by the validator), `size` (required non-zero
+**portable** byte-size string — integer or decimal plus an optional bare
+`k`/`m`/`g`/`t`/`p` unit, e.g. `20G`, `512m`, `1.5G`. Deliberately no `b`/`ib`
+suffixes (`256MB`, `2gib`): sbx's units.RAMInBytes accepts them but msb's size
+parser rejects them, so the neutral grammar is the intersection of the two.
+Required because sbx's unsized-volume default changed between releases), `type`
+(optional, `""` = block-backed, the default, or `tmpfs` = RAM-backed). There is
+deliberately **no `mode` field** (msb has no equivalent); a kit that needs
+specific permissions chmods in a `startup` step.
+
+Authoring caveats:
+
+- **Volumes mount UNSEEDED on both backends.** An empty filesystem shadows any
+  image content at the mount path; a kit that needs that content ships its own
+  first-boot copy step.
+- **Block volumes should be >= ~256m.** msb refuses ext4 disk images under
+  128M ("image size is too small for ext4 formatting", verified on msb 0.6.12).
+
+See quickstart ADR-0022 for the translate-layer implementation and the
+per-backend mapping rationale.
+
 ## Follow-ups (tracked, not in this change)
 
 - **Part B (quickstart, blocked on this PR's merge SHA):** `msb.sh`,

--- a/schemas/kit-hybrid-v1.schema.json
+++ b/schemas/kit-hybrid-v1.schema.json
@@ -178,6 +178,33 @@
         }
       }
     },
+    "volumes": {
+      "type": "array",
+      "description": "Sized guest storage volumes, mounted at sandbox creation BEFORE any exec is possible (so storage layout never races startup commands or early agent use). Each backend maps these to its native primitive (sbx: kit-spec v2 §5.7 volumes, a dedicated block device; msb: a per-sandbox derived named disk volume via --mount-named, or --tmpfs). Creation-time only — in-place kit add cannot attach volumes. Volumes mount UNSEEDED: an empty filesystem shadows any image content at the path, so a kit needing that content ships its own first-boot copy step. Composition: union by path, last wins. There is deliberately no 'mode' field (no msb equivalent; chmod in a startup step instead) — see quickstart ADR-0022.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "size"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "pattern": "^/[A-Za-z0-9._/-]+$",
+            "description": "Absolute mount path inside the sandbox. Safe charset only (alphanumerics . _ / -): the path reaches a generated backend spec and an msb create argv, so it must not carry shell/YAML metacharacters. Same charset rule as files[].path (see #225)."
+          },
+          "size": {
+            "type": "string",
+            "pattern": "^[0-9]+(\\.[0-9]+)?[kKmMgGtTpP]?$",
+            "description": "Volume size as a non-zero, PORTABLE byte-size string (integer or decimal + optional bare k/m/g/t/p unit, e.g. \"20G\", \"512m\", \"1.5G\"). Deliberately NO b/ib suffixes (\"256MB\", \"2gib\"): sbx's units.RAMInBytes accepts them but msb's size parser rejects them (verified on msb 0.6.12), and a neutral size must work on every backend. REQUIRED: the neutral schema does not inherit sbx's unsized-volume default, which changed between sbx releases. Block volumes should be >= ~256m — msb refuses ext4 disk images below 128M (\"image size is too small for ext4 formatting\", verified on msb 0.6.12)."
+          },
+          "type": {
+            "type": "string",
+            "enum": ["", "tmpfs"],
+            "default": "",
+            "description": "Backing storage. \"\" (default) = block-backed volume (dedicated ext4 device); \"tmpfs\" = RAM-backed. Any other value is rejected."
+          }
+        }
+      }
+    },
     "environment": {
       "type": "object",
       "description": "Non-secret guest environment variables to set for the sandbox. A flat map of NAME -> value (both strings). Each backend maps these onto its native env mechanism (sbx: environment.variables; msb: create/exec --env NAME=value). SECRETS MUST NOT go here — use the backend credential/secret path instead (this block is plain, human-readable config that lands in the guest environment and may reach a shell).",

--- a/scripts/tests/test_validate_kits_volumes.py
+++ b/scripts/tests/test_validate_kits_volumes.py
@@ -1,0 +1,252 @@
+"""Tests for the hybrid/v1 volumes vocabulary.
+
+Quickstart ADR-0022 promotes sized guest storage volumes to the NEUTRAL kit
+vocabulary (sbx: kit-spec v2 §5.7 pass-through; msb: derived named disk volume
+or --tmpfs); acq consumes them. This locks in the schema shape and the
+validator's field-level enforcement:
+
+  - volumes[]: path (required, absolute, safe charset [A-Za-z0-9._/-] — same
+    rule as files[].path), size (required non-zero PORTABLE byte-size string,
+    e.g. "20G", "512m", "1.5G" — no b/ib suffixes, which msb rejects; no
+    unsized default; non-zero is validator-enforced), type (optional, ""
+    block | "tmpfs"), no additional properties. Duplicate paths within one
+    kit are a validator-level authoring error.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = ROOT / "schemas" / "kit-hybrid-v1.schema.json"
+VALIDATOR_PATH = ROOT / "integrations" / "isolation" / "acq-kits" / "validate-kits.py"
+
+
+def _load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def _load_validate_kit():
+    spec = importlib.util.spec_from_file_location("validate_kits", VALIDATOR_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.validate_kit
+
+
+def _base(**extra) -> dict:
+    d = {
+        "schemaVersion": "hybrid/v1",
+        "kind": "mixin",
+        "name": "t",
+        "displayName": "T",
+        "description": "d",
+    }
+    d.update(extra)
+    return d
+
+
+def _write_kit(kit_dir: Path, spec_yaml: str) -> Path:
+    kit_dir.mkdir(parents=True, exist_ok=True)
+    (kit_dir / "README.md").write_text("# t\n")
+    (kit_dir / "spec.yaml").write_text(spec_yaml)
+    return kit_dir
+
+
+# --- schema-level: volumes ----------------------------------------------------
+
+
+class TestVolumesSchema:
+    def test_absent_volumes_still_valid(self):
+        jsonschema.validate(instance=_base(), schema=_load_schema())
+
+    def test_block_and_tmpfs_entries_accepted(self):
+        inst = _base(
+            volumes=[
+                {"path": "/nix", "size": "20G"},  # type optional, defaults to block
+                {"path": "/scratch", "size": "512m", "type": "tmpfs"},
+                {"path": "/data", "size": "1.5G", "type": ""},
+            ]
+        )
+        jsonschema.validate(instance=inst, schema=_load_schema())  # must not raise
+
+    def test_path_required(self):
+        inst = _base(volumes=[{"size": "1G"}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=inst, schema=_load_schema())
+
+    def test_size_required(self):
+        inst = _base(volumes=[{"path": "/nix"}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=inst, schema=_load_schema())
+
+    @pytest.mark.parametrize("bad", ["nix", "relative/path", "/bad path", "/tick'"])
+    def test_bad_path_rejected(self, bad):
+        inst = _base(volumes=[{"path": bad, "size": "1G"}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=inst, schema=_load_schema())
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "G",
+            "2G; rm -rf /",
+            "20 G",
+            ".5G",
+            "1..5G",
+            # b/ib suffixes are deliberately non-portable: sbx accepts them,
+            # msb's size parser rejects them (verified on msb 0.6.12).
+            "256MB",
+            "2gib",
+            "3kB",
+            "4Ti",
+        ],
+    )
+    def test_bad_size_rejected(self, bad):
+        inst = _base(volumes=[{"path": "/nix", "size": bad}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=inst, schema=_load_schema())
+
+    @pytest.mark.parametrize("good", ["20G", "512m", "1.5G", "100", "3k", "4T"])
+    def test_good_size_accepted(self, good):
+        inst = _base(volumes=[{"path": "/nix", "size": good}])
+        jsonschema.validate(instance=inst, schema=_load_schema())
+
+    @pytest.mark.parametrize("bad", ["block", "disk", "ramfs", "TMPFS"])
+    def test_bad_type_rejected(self, bad):
+        inst = _base(volumes=[{"path": "/nix", "size": "1G", "type": bad}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=inst, schema=_load_schema())
+
+    def test_mode_field_rejected(self):
+        # There is deliberately NO mode field (no msb equivalent; kits chmod in
+        # a startup step) — additionalProperties: false must reject it.
+        inst = _base(volumes=[{"path": "/nix", "size": "1G", "mode": "0755"}])
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=inst, schema=_load_schema())
+
+
+# --- validate_kit field-level enforcement ------------------------------------
+
+
+class TestValidateKitVolumes:
+    def test_valid_kit_has_no_errors(self, tmp_path):
+        validate_kit = _load_validate_kit()
+        kit = _write_kit(
+            tmp_path / "volkit",
+            "schemaVersion: hybrid/v1\n"
+            "kind: mixin\n"
+            "name: volkit\n"
+            "displayName: Vol\n"
+            "description: d\n"
+            "volumes:\n"
+            "  - path: /nix\n"
+            "    size: 20G\n"
+            "  - path: /scratch\n"
+            "    size: 512m\n"
+            "    type: tmpfs\n",
+        )
+        errors, _warnings = validate_kit(kit, _load_schema())
+        assert errors == [], errors
+
+    def test_flags_relative_and_unsafe_paths(self, tmp_path):
+        validate_kit = _load_validate_kit()
+        kit = _write_kit(
+            tmp_path / "badpath",
+            "schemaVersion: hybrid/v1\n"
+            "kind: mixin\n"
+            "name: badpath\n"
+            "displayName: Bad\n"
+            "description: d\n"
+            "volumes:\n"
+            "  - path: relative/path\n"
+            "    size: 1G\n"
+            '  - path: "/bad;path"\n'
+            "    size: 1G\n",
+        )
+        errors, _warnings = validate_kit(kit, _load_schema())
+        path_errors = [e for e in errors if "path must be an absolute path" in e]
+        assert len(path_errors) == 2, errors
+        assert any("volumes[0].path" in e for e in path_errors), errors
+        assert any("volumes[1].path" in e for e in path_errors), errors
+
+    def test_flags_missing_metacharacter_and_nonportable_size(self, tmp_path):
+        validate_kit = _load_validate_kit()
+        kit = _write_kit(
+            tmp_path / "badsize",
+            "schemaVersion: hybrid/v1\n"
+            "kind: mixin\n"
+            "name: badsize\n"
+            "displayName: Bad\n"
+            "description: d\n"
+            "volumes:\n"
+            "  - path: /nix\n"
+            "  - path: /data\n"
+            '    size: "2G; rm -rf /"\n'
+            "  - path: /cache\n"
+            "    size: 2gib\n",
+        )
+        errors, _warnings = validate_kit(kit, _load_schema())
+        assert any("volumes[0].size is required" in e for e in errors), errors
+        assert any("volumes[1].size is required" in e for e in errors), errors
+        assert any("volumes[2].size is required" in e and "no b/ib suffix" in e for e in errors), errors
+
+    @pytest.mark.parametrize("zero", ["0", "0G", "0.0", "00m"])
+    def test_flags_zero_size(self, tmp_path, zero):
+        validate_kit = _load_validate_kit()
+        kit = _write_kit(
+            tmp_path / "zerosize",
+            "schemaVersion: hybrid/v1\n"
+            "kind: mixin\n"
+            "name: zerosize\n"
+            "displayName: Zero\n"
+            "description: d\n"
+            "volumes:\n"
+            "  - path: /nix\n"
+            f'    size: "{zero}"\n',
+        )
+        errors, _warnings = validate_kit(kit, _load_schema())
+        assert any("volumes[0].size must be non-zero" in e for e in errors), errors
+
+    def test_flags_duplicate_paths(self, tmp_path):
+        validate_kit = _load_validate_kit()
+        kit = _write_kit(
+            tmp_path / "duppath",
+            "schemaVersion: hybrid/v1\n"
+            "kind: mixin\n"
+            "name: duppath\n"
+            "displayName: Dup\n"
+            "description: d\n"
+            "volumes:\n"
+            "  - path: /data\n"
+            "    size: 1G\n"
+            "  - path: /data\n"
+            "    size: 20G\n"
+            "  - path: /scratch\n"
+            "    size: 512m\n",
+        )
+        errors, _warnings = validate_kit(kit, _load_schema())
+        assert any("volumes: duplicate path '/data' (declared 2 times)" in e for e in errors), errors
+        assert not any("'/scratch'" in e for e in errors), errors
+
+    def test_flags_bad_type(self, tmp_path):
+        validate_kit = _load_validate_kit()
+        kit = _write_kit(
+            tmp_path / "badtype",
+            "schemaVersion: hybrid/v1\n"
+            "kind: mixin\n"
+            "name: badtype\n"
+            "displayName: Bad\n"
+            "description: d\n"
+            "volumes:\n"
+            "  - path: /nix\n"
+            "    size: 1G\n"
+            "    type: block\n",
+        )
+        errors, _warnings = validate_kit(kit, _load_schema())
+        assert any('volumes[0].type must be "" (block) or "tmpfs"' in e for e in errors), errors


### PR DESCRIPTION
## Summary

Adds a neutral `volumes[]` field to the `hybrid/v1` kit vocabulary so a kit can declare sized guest storage volumes once, backend-neutrally (sbx: kit-spec v2 §5.7 pass-through, a dedicated block device; msb: derived named disk volume via `--mount-named`, or `--tmpfs`). This is the schema half of quickstart ADR-0022 / GSA-TTS/agentic-coding-quickstart#329 — the quickstart translator and both backend consumers already merged and read the field defensively (absence is a no-op), so this ships independently with no cross-repo ordering hazard. Enforced in `validate-kits.py` with per-entry field-level validation and tests.

## What changed

- **`schemas/kit-hybrid-v1.schema.json`** — `volumes[]` (optional, top-level), inserted after `publishedPorts`: each entry `additionalProperties: false`, `required: [path, size]`.
  - `path`: absolute, safe charset `^/[A-Za-z0-9._/-]+$` (same rule as `files[].path`, see #225) — the path reaches a generated backend spec and an msb create argv.
  - `size`: non-zero **portable** byte-size string `^[0-9]+(\.[0-9]+)?[kKmMgGtTpP]?$` (e.g. `20G`, `512m`, `1.5G`). Deliberately no `b`/`ib` suffixes: sbx's units.RAMInBytes accepts them but msb's size parser rejects them (verified on msb 0.6.12), so the neutral grammar is the intersection. Required because sbx's unsized-volume default changed between releases.
  - `type`: optional enum `""` (block-backed, default) | `tmpfs`.
  - No `mode` field, deliberately (no msb equivalent; kits chmod in a startup step).
- **`integrations/isolation/acq-kits/validate-kits.py`** — per-entry enforcement mirroring the existing publishedPorts/environment style: path charset (reuses `_SAFE_PATH_RE`), portable size grammar, non-zero size (the schema pattern alone can't express non-zero cleanly), type enum, and duplicate mount paths within one kit (the union-by-path composition rule is for cross-kit merging, not same-kit typos).
- **`scripts/tests/test_validate_kits_volumes.py`** — 38 cases: schema shape (including `mode` rejection and size-grammar edges) + validator per-entry messages for every invalid class.
- **ADR 0001 (isolation)** — `volumes` amendment documenting the vocabulary and the two authoring caveats: volumes mount **unseeded** on both backends (an empty filesystem shadows image content at the path; kits needing that content ship a first-boot copy step), and block volumes should be >= ~256m (msb refuses ext4 images under 128M).

## Test plan

- `validate-kits.py --strict`: all 6 existing kits pass unchanged (no kit adopts `volumes:` in this PR — adoption is separate follow-up with its own review).
- Full suite: 396 pass (`pytest scripts/tests/`); markdownlint clean.
- Fixture check: a throwaway kit with every invalid shape (relative path, unsafe charset, missing size, metacharacter size, non-portable `2gib`, zero size, bad type, duplicate path) produces each per-entry message; a valid block + tmpfs kit passes.

## Related

- Implements the schema half of GSA-TTS/agentic-coding-quickstart#329 (neutral `volumes` vocabulary)
- Companion to GSA-TTS/agentic-coding-quickstart#357 — the quickstart translator + both backend consumers (merged as quickstart ADR-0022; reads the field defensively, so no cross-repo ordering hazard; live-verified on sbx 0.39.0 and msb 0.6.12)
- Mirrors the publishedPorts/background precedent (#276) and the `files[].path` charset rule (#225)
- Known follow-ups deferred deliberately: `$`-anchor newline leniency and path-normalization tightening are under evaluation in the quickstart repo first, so the two repos' gates change together; test-helper consolidation into `conftest.py` tracked under #66

AI-assisted (Claude Code); requires human review.