### PR TITLE
fix(ci): scope link-check GITHUB_TOKEN to real github hosts (host-boundary)

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -52,8 +52,8 @@
   "replacementPatterns": [],
   "httpHeaders": [
     {
-      "_comment": "Check github.com links AUTHENTICATED so CI uses the 5000/hr token rate limit instead of the ~60/hr anonymous limit that caused 0/503 throttling false-positives (#316). The CI step substitutes $MLC_GITHUB_TOKEN (the read-only workflow GITHUB_TOKEN) into this file before running; locally, with the env var unset, it becomes an inert 'Bearer ' header (github still answers anonymously).",
-      "urls": ["https://github.com", "https://api.github.com", "https://raw.githubusercontent.com"],
+      "_comment": "Check github.com links AUTHENTICATED so CI uses the 5000/hr token rate limit instead of the ~60/hr anonymous limit that caused 0/503 throttling false-positives (#316). The CI step substitutes $MLC_GITHUB_TOKEN (the read-only workflow GITHUB_TOKEN) into this file before running; locally, with the env var unset, it becomes an inert 'Bearer ' header (github still answers anonymously). SECURITY: the URLs MUST end in '/' — markdown-link-check matches by plain string prefix (link.startsWith(url)), with no host-boundary check, so a bare 'https://github.com' also matches 'https://github.com.evil.example/...' and would send the token to an attacker-controlled host reachable via a PR-added link. The trailing slash confines the match to the real host.",
+      "urls": ["https://github.com/", "https://api.github.com/", "https://raw.githubusercontent.com/"],
       "headers": { "Authorization": "Bearer ${MLC_GITHUB_TOKEN}" }
     }
   ],


### PR DESCRIPTION
## Summary
The link-check config injects the workflow `GITHUB_TOKEN` as an `Authorization: Bearer` header scoped to three github URLs. `markdown-link-check` matches those by **plain string prefix** (`link.startsWith(url)`) with **no host-boundary check** — so a bare `https://github.com` also prefixes `https://github.com.evil.example/...`. Because `ci.yml` runs the checker over the whole repo (`folder-path: "."`) on `pull_request`, **anyone who can open a PR can add a markdown link to an attacker-controlled lookalike host and receive the token.**

## Impact (stated accurately)
Bounded on this public repo — trigger is `pull_request` (not `_target`) so a fork PR gets a read-only token; `permissions: contents: read`; `persist-credentials: false`; action SHA-pinned. So what leaks is a short-lived read-only token. **But** it's still a credential sent to an arbitrary third-party host on demand, and the same config copied into a **private** repo would leak read access to private source.

## Fix — one character per entry
Add a trailing slash so the prefix match is confined to the real host: `https://github.com/`, `https://api.github.com/`, `https://raw.githubusercontent.com/`. `https://github.com.evil.example/...` no longer starts with `https://github.com/`.

## Verification
- Reproduced the prefix-match hazard and confirmed the fix: lookalike hosts (`.evil.example`, `comattacker.net`) no longer match; real repo/api/raw links still do (token still sent where intended).
- **No repo markdown uses a bare pathless github URL**, so no link loses the authenticated rate limit (the reason the token is configured, #316).
- Documented the prefix-match hazard in the config `_comment` so the trailing slashes aren't "tidied away" later.
- Confirmed the other two repos are unaffected (playbook `httpHeaders` is empty; quickstart has no link-check config).
- `make validate` green; JSON well-formed.

AI-assisted (OpenCode).