### PR TITLE
fix(openchamber): install @openchamber/web unprivileged (drop sudo/root)

### DIFF
--- a/docs/repository-ecosystem.md
+++ b/docs/repository-ecosystem.md
@@ -217,8 +217,8 @@ workflows where an agent can reference one repo while editing another.
 - **Playbook** defines standards that may be referenced from other repos
 
 For command syntax and examples, see the quickstart guide's
-[Quick Start](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/QUICKSTART.md)
-and its [Multiple Workspaces](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/QUICKSTART_SBX.md#multiple-workspaces)
+[Quick Start](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/howto/acq.md#quick-start)
+and its [Multiple Workspaces](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/howto/sbx.md#multiple-workspaces)
 section.
 
 ### Security Best Practice

--- a/integrations/isolation/acq-kits/openchamber/files/home/openchamber-start.sh
+++ b/integrations/isolation/acq-kits/openchamber/files/home/openchamber-start.sh
@@ -80,13 +80,14 @@ if ! command -v openchamber >/dev/null 2>&1; then
   # startup) so the full chain validates — the proxy CA alone is not sufficient
   # behind an inspecting proxy.
   #
-  # ACCEPTED RISK (trust surface): this bundle lives at an AGENT-WRITABLE path and
-  # is forwarded (via `sudo env NODE_EXTRA_CA_CERTS=...`) into the ROOT installer
-  # below. An actor who already controls the agent user could therefore add a
-  # trust anchor the root download honors. This is bounded — that actor already
-  # has agent-level code execution inside the sandbox (the security boundary), and
-  # the installer it feeds is independently SHA-256-pinned — so we accept it here
-  # rather than stage a root-owned bundle before the sudo hand-off.
+  # This bundle lives at an AGENT-WRITABLE path and is consumed (via
+  # NODE_EXTRA_CA_CERTS) by the AGENT-USER installer below — no privilege
+  # boundary is crossed. An actor who already controls the agent user could add
+  # a trust anchor this download honors, but that actor already has agent-level
+  # code execution inside the sandbox (the security boundary), and the installer
+  # it feeds is independently SHA-256-pinned, so this adds no new trust surface.
+  # (The install runs unprivileged under a per-user npm prefix; it does not run
+  # as root, so there is no root-download trust-elevation to guard against.)
   _ca="$HOME/.local/state/openchamber/ca-bundle.pem"
   mkdir -p "$(dirname "$_ca")"
   : > "$_ca"
@@ -106,38 +107,38 @@ if ! command -v openchamber >/dev/null 2>&1; then
     _got_sha="$( (sha256sum "$_installer" 2>/dev/null || shasum -a 256 "$_installer" 2>/dev/null) | cut -d' ' -f1)"
     if [ "$_got_sha" = "$_want_sha" ]; then
       # Run the (SHA-verified) installer, which internally does
-      # `npm install -g @openchamber/web`. On the sbx-template base the npm
-      # global prefix's lib/ dir is ROOT-owned (as on sbx: the template
-      # provisions global tooling as root), so the agent's `npm install -g`
-      # fails EACCES. Run the whole installer via `sudo -n` (the agent has
-      # passwordless sudo on the template). The sudoers env_keep covers
-      # HTTP(S)_PROXY/NO_PROXY but NOT NODE_EXTRA_CA_CERTS (bare sudo resets it
-      # to msb's default /.msb/tls/ca.pem, dropping the kit's assembled bundle),
-      # so forward proxy + CA + HOME explicitly via `sudo env`. HOME keeps npm
-      # cache/config in the agent home rather than /root. The `${VAR:+NAME=...}`
-      # idiom omits an arg entirely when the var is empty/unset (safe under
-      # set -u), so an empty proxy does not pass an empty npm_config_*. When
-      # sudo is unavailable (a plain-OCI override without the template's sudo),
-      # fall back to an agent-owned per-user npm prefix so the global install
-      # needs no root.
-      if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-        sudo -n env \
-          npm_config_user_agent="${npm_config_user_agent:-npm}" \
-          ${npm_config_https_proxy:+npm_config_https_proxy="$npm_config_https_proxy"} \
-          ${npm_config_proxy:+npm_config_proxy="$npm_config_proxy"} \
-          ${NODE_EXTRA_CA_CERTS:+NODE_EXTRA_CA_CERTS="$NODE_EXTRA_CA_CERTS"} \
-          HOME="$HOME" \
-          bash "$_installer" >>/tmp/openchamber-install.log 2>&1 || true
+      # `npm install -g @openchamber/web`. Install into an AGENT-OWNED per-user
+      # npm prefix ($HOME/.npm-global) rather than the system global prefix, so
+      # the whole install — including native-module lifecycle scripts like
+      # better-sqlite3's build step — runs UNPRIVILEGED as the agent user, never
+      # root. (Previously this ran via `sudo -n` to dodge the sbx-template's
+      # root-owned global lib/ EACCES; a per-user prefix sidesteps that without
+      # escalating, and removes root code-execution from a compromised dependency
+      # in the @openchamber/web tree.) The vendor install.sh honors
+      # npm_config_prefix and npm_config_user_agent (both exported here / above),
+      # so `npm install -g` lands in the per-user prefix. No `sudo env` CA/proxy
+      # forwarding is needed: the child inherits NODE_EXTRA_CA_CERTS + the
+      # npm_config_* proxy vars from this shell directly (no privilege boundary
+      # strips them).
+      export npm_config_prefix="$HOME/.npm-global"
+      export npm_config_user_agent="${npm_config_user_agent:-npm}"
+      mkdir -p "$HOME/.npm-global"
+      # NPM_BIN (line 58) was computed from the DEFAULT global prefix, so the
+      # `command -v openchamber` guard below and the supervisor probe would
+      # otherwise never see a package installed under this per-user prefix.
+      # Prepend the per-user bin so the whole install path is resolvable.
+      case ":$PATH:" in *":$HOME/.npm-global/bin:"*) : ;; *) PATH="$HOME/.npm-global/bin:$PATH" ;; esac
+      export PATH
+      if bash "$_installer" >>/tmp/openchamber-install.log 2>&1; then
+        :
       else
-        export npm_config_prefix="$HOME/.npm-global"
-        mkdir -p "$HOME/.npm-global"
-        # NPM_BIN (line 58) was computed from the DEFAULT global prefix, so the
-        # `command -v openchamber` guard below and the supervisor probe would
-        # otherwise never see a package installed under this per-user prefix.
-        # Prepend the per-user bin so the whole no-sudo path is resolvable.
-        case ":$PATH:" in *":$HOME/.npm-global/bin:"*) : ;; *) PATH="$HOME/.npm-global/bin:$PATH" ;; esac
-        export PATH
-        bash "$_installer" >>/tmp/openchamber-install.log 2>&1 || true
+        _rc=$?
+        # Surface the real exit code (the old `|| true` swallowed it, leaving the
+        # transient-vs-real ambiguity the `command -v openchamber` guard below
+        # cannot resolve). Still exit 0 later — an optional UI must not fail the
+        # sandbox — but a definite install failure is now visible in the log.
+        echo "openchamber: vendor install.sh exited $_rc (npm_config_prefix=$npm_config_prefix); UI unavailable this boot. See /tmp/openchamber-install.log" \
+          | tee -a /tmp/openchamber-install.log >&2
       fi
     else
       echo "openchamber: install.sh SHA-256 mismatch (got $_got_sha, want $_want_sha) at $_ref; refusing to run it" >>/tmp/openchamber-install.log 2>&1

--- a/integrations/isolation/acq-kits/openchamber/scripts/verify
+++ b/integrations/isolation/acq-kits/openchamber/scripts/verify
@@ -337,6 +337,19 @@ done
 
 if [ -n "$installed" ]; then
   ok "OpenChamber CLI installed by the startup step"
+  # Assert the install landed under the AGENT-OWNED per-user prefix
+  # ($HOME/.npm-global), i.e. ran UNPRIVILEGED — not the system/root prefix.
+  # This locks in the drop-sudo hardening: a silent regression back to a
+  # root install (or a system-prefix install) fails here instead of passing.
+  oc_bin="$(in_sbx 'command -v openchamber 2>/dev/null')"
+  case "$oc_bin" in
+    "$HOME/.npm-global/bin/openchamber"|*/.npm-global/bin/openchamber)
+      ok "openchamber installed under the unprivileged per-user prefix ($oc_bin)" ;;
+    "")
+      warn "could not resolve the openchamber path to confirm the unprivileged prefix" ;;
+    *)
+      bad "openchamber resolved to '$oc_bin', not \$HOME/.npm-global/bin — install may have used a root/system prefix (drop-sudo hardening regressed)" ;;
+  esac
 elif [ -n "$installed_off_path" ]; then
   bad "openchamber installed but not on the probe PATH — npm prefix mismatch"
   in_sbx 'echo "npm prefix -g => $(npm prefix -g 2>&1)"; ls -la "$(npm prefix -g 2>/dev/null)/bin" 2>/dev/null | grep -i openchamber' | sed 's/^/    | /'


### PR DESCRIPTION
## Problem
The openchamber kit SHA-verifies its pinned installer (good) — but that installer runs `npm install -g @openchamber/web` via **`sudo -n`** on the sbx-template base, so the package's lifecycle scripts (including **better-sqlite3's native build**) executed **as root** on every first boot. A compromise anywhere in that unpinned dependency tree was arbitrary **code execution as root** in the guest, defeating the integrity gate one layer above.

## Fix
Make the **agent-owned per-user npm prefix** (`$HOME/.npm-global`) the default and **remove the sudo branch**, so the whole install runs **unprivileged** as the agent user. This path already existed as the fallback (plain-OCI bases without the template's sudo) — promoting it to the default unifies both bases on one root-free path instead of escalating around a root-owned global `lib/`.
- Confirmed from the fetched vendor `install.sh` that it honors `npm_config_prefix` + `npm_config_user_agent` (both exported), so `npm install -g` lands in the per-user prefix.
- Removing sudo also removes the `sudo env` CA/proxy **forwarding hack** — the child now inherits `NODE_EXTRA_CA_CERTS` + `npm_config_*` proxy vars directly. The old "ACCEPTED RISK / forwarded into the ROOT installer" trust note is gone.
- **Surface the installer exit code** (was `|| true`, swallowing failures) — logged on failure, sandbox still `exit 0` (an optional UI must not fail the sandbox).
- **New verify assertion**: openchamber must resolve under `$HOME/.npm-global/bin` — locks in the hardening so a silent regression to a root/system install fails the check.

## Live verification
`RUN_ACQ=1 scripts/verify` on a **real sbx sandbox**: install succeeds unprivileged, the new per-user-prefix assertion **passes** (`/home/agent/.npm-global/bin/openchamber`), better-sqlite3 builds, and OpenChamber + the shared `opencode serve` both come up (127.0.0.1:3000 / :4096). `make validate` + 44 kit tests green.

## Not in this PR
- **The 0.0.0.0 in-guest bind** (the sibling loopback-hardening finding) is deliberately **separate** — its premise (that a loopback bind is still reachable via the published host port on msb) is contradicted by the paseo kit's own docs/verify, so it needs a live msb reachability test before it can be trusted. Tracking separately.
- Pre-existing, unrelated: verify steps 4 & 9 fail on this sbx base (a `$PATH` ordering issue where the system npm-global bin precedes `~/.local/bin`; the wrapper is present+executable but not first on PATH). Untouched here; filing separately.

AI-assisted (OpenCode).