### PR TITLE
docs(openchamber): document why the in-guest bind is 0.0.0.0, not loopback

### DIFF
--- a/docs/repository-ecosystem.md
+++ b/docs/repository-ecosystem.md
@@ -217,8 +217,8 @@ workflows where an agent can reference one repo while editing another.
 - **Playbook** defines standards that may be referenced from other repos
 
 For command syntax and examples, see the quickstart guide's
-[Quick Start](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/QUICKSTART.md)
-and its [Multiple Workspaces](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/QUICKSTART_SBX.md#multiple-workspaces)
+[Quick Start](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/howto/acq.md#quick-start)
+and its [Multiple Workspaces](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/howto/sbx.md#multiple-workspaces)
 section.
 
 ### Security Best Practice

--- a/integrations/isolation/acq-kits/openchamber/spec.yaml
+++ b/integrations/isolation/acq-kits/openchamber/spec.yaml
@@ -223,6 +223,20 @@ agentContext: |
   The shared server is **unsecured** (no password): the sandbox is the security
   boundary and the published ports are host loopback only.
 
+  IN-GUEST BIND IS 0.0.0.0 (both :3000 and :4096), NOT 127.0.0.1 — deliberately,
+  matching the paseo kit. A loopback-only in-guest bind is a defense-in-depth win
+  in the abstract, but it is NOT reachable through acq's create-time port publish
+  on the msb backend: msb's `-p HOST:GUEST` binds a HOST loopback listener while
+  the publisher dials the sandbox's GUEST NETWORK IP, not guest 127.0.0.1. So a
+  127.0.0.1-only service answers `acq exec <sbx> -- curl http://127.0.0.1:<port>`
+  from inside the guest yet the published host port returns "Empty reply from
+  server" (browser ERR_EMPTY_RESPONSE). This was verified empirically (a guest
+  loopback listener is unreachable via the published host port) and is documented
+  for paseo's single daemon and in quickstart's KNOWN_FAILURE_MODES. Binding
+  0.0.0.0 is required for the host-published loopback port to reach the service;
+  the sandbox (ephemeral microVM, deny-default egress, no host FS) remains the
+  security boundary, and the published ports are host-loopback-only.
+
   Logs: `/tmp/openchamber.log` (OpenChamber) and
   `~/.local/state/openchamber/opencode-serve.log` (the shared server). Both run
   under respawn loops (`supervisor:opencode-serve`, `supervisor:openchamber`), so


### PR DESCRIPTION
Documents (in `spec.yaml`) **why** the openchamber kit binds `0.0.0.0` in-guest rather than `127.0.0.1`, so a future review doesn't re-raise a loopback "hardening" that would actually break the kit.

**Empirically verified** (live sbx test): a guest **loopback-only** listener on a published port is **unreachable** from the host via the published port. This matches the mechanism paseo already documents (and quickstart's KNOWN_FAILURE_MODES / the merged quickstart #333): acq's create-time `-p HOST:GUEST` binds a host loopback listener but the publisher dials the sandbox's **guest network IP**, not guest `127.0.0.1` — so a `127.0.0.1`-only service answers an in-guest curl yet returns `ERR_EMPTY_RESPONSE` on the published host port.

So `0.0.0.0` is **required** for the host-published loopback port to reach the service; the ephemeral microVM (deny-default egress, no host FS, host-loopback-only published ports) remains the security boundary. Matches paseo's deliberate choice.

Docs only, no behavior change. Companion to the openchamber unprivileged-install hardening (#355).

AI-assisted (OpenCode).