### PR TITLE
feat(usai-catalog): harness-neutral USAi model catalog — schema, build, emitters + byte-exact guarantee (#358/#359/#360/#361)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,12 @@ validate:  ## Run all validators (frontmatter + sensitive terms)
 validate-kits:  ## Validate neutral acq-kits specs against the hybrid/v1 schema (strict: warnings fail)
 	python integrations/isolation/acq-kits/validate-kits.py --strict
 
-test-kits:  ## Run the acq-kits node test suites (usai-provider generator + merge)
+test-kits:  ## Run the acq-kits node test suites (usai-provider generator + merge) + providers/usai emitters
 	@if command -v node >/dev/null 2>&1; then \
 		echo "==> usai-provider kit tests"; \
 		cd integrations/isolation/acq-kits/usai-provider && node --test 'tests/**/*.test.mjs'; \
+		echo "==> providers/usai catalog + emitter tests"; \
+		cd "$(CURDIR)/integrations/providers/usai" && node --test 'tests/**/*.test.mjs'; \
 	else \
 		echo "⚠️  node not installed — skipping acq-kits node tests"; \
 	fi

--- a/integrations/providers/usai/README.md
+++ b/integrations/providers/usai/README.md
@@ -1,0 +1,39 @@
+# USAi Model Catalog (harness-neutral)
+
+This directory holds the harness-neutral USAi model catalog: one source of
+truth for the models available through the GSA USAi gateway, independent of any
+single agent harness.
+
+## Data flow
+
+```
+live feeds -> build-catalog.mjs -> catalog.json -> per-harness emitters
+```
+
+- **live feeds** — the USAi models list plus enrichment metadata.
+- **build-catalog.mjs** — derives `catalog.json` (added in a later issue).
+- **catalog.json** — the generated catalog. **GENERATED — do not hand-edit.**
+- **per-harness emitters** — render `catalog.json` into each harness config
+  (e.g. the OpenCode `opencode.jsonc` model block).
+
+## Files
+
+- `catalog.schema.json` — JSON Schema (draft 2020-12), id
+  `usai-model-catalog/v1`. Defines the catalog shape.
+- `catalog.json` — the generated catalog (NOT in this scaffold; see epic
+  GSA-TTS/agentic-coding-patterns#357).
+
+## Safety guarantee
+
+A byte-exact round-trip test against the shipped `opencode.jsonc` is the safety
+guarantee: the emitter must reproduce the current, human-reviewed config exactly.
+That test is the gate that lets us treat `catalog.json` as the source of truth
+without silently changing any shipped kit.
+
+## `apiKeyEnv` is a name, not a secret
+
+The `gateway.apiKeyEnv` field holds the **name** of an environment variable
+(e.g. `USAI_API_KEY`), never a key value. It is validated to be an uppercase
+env-var identifier. Never place a secret in the catalog or the schema.
+
+Part of epic GSA-TTS/agentic-coding-patterns#357.

--- a/integrations/providers/usai/catalog.json
+++ b/integrations/providers/usai/catalog.json
@@ -1,0 +1,235 @@
+{
+  "schemaVersion": "usai-model-catalog/v1",
+  "generatedBy": "build-catalog.mjs (generated — do not hand-edit)",
+  "sources": {
+    "bootstrappedFrom": "integrations/isolation/acq-kits/usai-provider/files/home/usai-config/opencode.jsonc"
+  },
+  "gateway": {
+    "host": "api.gsa.usai.gov",
+    "baseUrl": "https://api.gsa.usai.gov/api/v1",
+    "api": "openai-completions",
+    "apiKeyEnv": "USAI_API_KEY"
+  },
+  "vendors": [
+    {
+      "key": "anthropic",
+      "label": "Anthropic",
+      "order": 1,
+      "usaiBackend": "amazon-bedrock"
+    },
+    {
+      "key": "openai",
+      "label": "OpenAI",
+      "order": 2,
+      "usaiBackend": "azure"
+    },
+    {
+      "key": "google",
+      "label": "Google",
+      "order": 3,
+      "usaiBackend": "google-vertex"
+    },
+    {
+      "key": "meta",
+      "label": "Meta",
+      "order": 4,
+      "usaiBackend": "amazon-bedrock"
+    },
+    {
+      "key": "cohere",
+      "label": "Cohere",
+      "order": 5,
+      "usaiBackend": "cohere"
+    }
+  ],
+  "models": [
+    {
+      "id": "claude_4_8_opus",
+      "vendor": "anthropic",
+      "name": "Claude 4.8 Opus",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 128000,
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cacheRead": 0.5,
+        "cacheWrite": 6.25
+      }
+    },
+    {
+      "id": "claude_4_7_opus",
+      "vendor": "anthropic",
+      "name": "Claude 4.7 Opus",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 128000,
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cacheRead": 0.5,
+        "cacheWrite": 6.25
+      }
+    },
+    {
+      "id": "claude_4_6_sonnet",
+      "vendor": "anthropic",
+      "name": "Claude 4.6 Sonnet",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 64000,
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cacheRead": 0.3,
+        "cacheWrite": 3.75
+      }
+    },
+    {
+      "id": "claude_4_5_haiku",
+      "vendor": "anthropic",
+      "name": "Claude 4.5 Haiku",
+      "contextWindow": 200000,
+      "maxOutputTokens": 64000,
+      "cost": {
+        "input": 1,
+        "output": 5,
+        "cacheRead": 0.1,
+        "cacheWrite": 1.25
+      }
+    },
+    {
+      "id": "claude_4_5_opus",
+      "vendor": "anthropic",
+      "name": "Claude 4.5 Opus",
+      "contextWindow": 200000,
+      "maxOutputTokens": 64000,
+      "cost": {
+        "input": 5,
+        "output": 25,
+        "cacheRead": 0.5,
+        "cacheWrite": 6.25
+      }
+    },
+    {
+      "id": "claude_4_5_sonnet",
+      "vendor": "anthropic",
+      "name": "Claude 4.5 Sonnet",
+      "contextWindow": 200000,
+      "maxOutputTokens": 64000,
+      "cost": {
+        "input": 3,
+        "output": 15,
+        "cacheRead": 0.3,
+        "cacheWrite": 3.75
+      }
+    },
+    {
+      "id": "gpt-5.5-latest-guardrails-defaultv2",
+      "vendor": "openai",
+      "name": "GPT 5.5 Latest Guardrails Defaultv2",
+      "contextWindow": 1050000,
+      "maxOutputTokens": 128000,
+      "cost": {
+        "input": 5,
+        "output": 30,
+        "cacheRead": 0.5
+      },
+      "costAbove200kContext": {
+        "input": 10,
+        "output": 45,
+        "cacheRead": 1
+      }
+    },
+    {
+      "id": "gpt-5.4-latest-guardrails-defaultv2",
+      "vendor": "openai",
+      "name": "GPT-5.4 Latest — Guardrails Default v2",
+      "contextWindow": 1050000,
+      "maxOutputTokens": 128000,
+      "cost": {
+        "input": 2.5,
+        "output": 15,
+        "cacheRead": 0.25
+      },
+      "costAbove200kContext": {
+        "input": 5,
+        "output": 22.5,
+        "cacheRead": 0.5
+      }
+    },
+    {
+      "id": "gpt-5.2-latest-guardrails-defaultv2",
+      "vendor": "openai",
+      "name": "GPT-5.2 Latest — Guardrails Default v2",
+      "contextWindow": 400000,
+      "maxOutputTokens": 128000,
+      "cost": {
+        "input": 1.75,
+        "output": 14,
+        "cacheRead": 0.125
+      }
+    },
+    {
+      "id": "gemini-2.5-flash",
+      "vendor": "google",
+      "name": "Gemini 2.5 Flash",
+      "contextWindow": 1048576,
+      "maxOutputTokens": 65536,
+      "cost": {
+        "input": 0.3,
+        "output": 2.5,
+        "cacheRead": 0.075,
+        "cacheWrite": 0.383
+      }
+    },
+    {
+      "id": "gemini-2.5-flash-lite",
+      "vendor": "google",
+      "name": "Gemini 2.5 Flash Lite",
+      "contextWindow": 1048576,
+      "maxOutputTokens": 65536,
+      "cost": {
+        "input": 0.1,
+        "output": 0.4,
+        "cacheRead": 0.01
+      }
+    },
+    {
+      "id": "gemini-2.5-pro",
+      "vendor": "google",
+      "name": "Gemini 2.5 Pro",
+      "contextWindow": 1048576,
+      "maxOutputTokens": 65536,
+      "cost": {
+        "input": 1.25,
+        "output": 10,
+        "cacheRead": 0.125
+      },
+      "costAbove200kContext": {
+        "input": 2.5,
+        "output": 15,
+        "cacheRead": 0.25
+      }
+    },
+    {
+      "id": "llama_4_maverick",
+      "vendor": "meta",
+      "name": "Llama 4 Maverick",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 16384,
+      "cost": {
+        "input": 0.24,
+        "output": 0.97
+      }
+    },
+    {
+      "id": "cohere_english_v3",
+      "vendor": "cohere",
+      "name": "Cohere English v3",
+      "contextWindow": 128000,
+      "maxOutputTokens": 4000,
+      "cost": {
+        "input": 0.0375,
+        "output": 0.15
+      }
+    }
+  ]
+}

--- a/integrations/providers/usai/catalog.schema.json
+++ b/integrations/providers/usai/catalog.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "usai-model-catalog/v1",
+  "title": "USAi Model Catalog",
+  "description": "Harness-neutral catalog of USAi gateway models. Generated from live feeds by build-catalog.mjs; consumed by per-harness emitters. Do not hand-edit the generated catalog.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "gateway", "vendors", "models"],
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "const": "usai-model-catalog/v1",
+      "description": "Schema identifier and version for this catalog document."
+    },
+    "generatedBy": {
+      "type": "string",
+      "description": "Path/marker signaling this document is derived. Do not hand-edit."
+    },
+    "sources": {
+      "type": "object",
+      "description": "Provenance: free-form record of where fields were derived from (e.g. modelsList, enrichment, bootstrappedFrom).",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "gateway": {
+      "type": "object",
+      "description": "USAi gateway connection metadata.",
+      "additionalProperties": false,
+      "required": ["host", "baseUrl", "api", "apiKeyEnv"],
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Gateway hostname."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Full base URL for the OpenAI-compatible completions API."
+        },
+        "api": {
+          "type": "string",
+          "const": "openai-completions",
+          "description": "API surface. USAi speaks the OpenAI completions protocol."
+        },
+        "apiKeyEnv": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]*$",
+          "description": "NAME of the environment variable holding the API key. Never a secret value."
+        }
+      }
+    },
+    "vendors": {
+      "type": "array",
+      "description": "Model vendors (Anthropic, OpenAI, Google, ...), for grouping and display order.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key", "label", "order", "usaiBackend"],
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Stable vendor key referenced by models[].vendor."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable vendor label."
+          },
+          "order": {
+            "type": "integer",
+            "description": "Display/sort order for the vendor group."
+          },
+          "usaiBackend": {
+            "type": "string",
+            "description": "USAi backend identifier for this vendor."
+          }
+        }
+      }
+    },
+    "models": {
+      "type": "array",
+      "description": "Model definitions available through the USAi gateway.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "vendor", "name"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Model identifier as used by the gateway (e.g. claude_4_8_opus)."
+          },
+          "vendor": {
+            "type": "string",
+            "description": "Vendor key referencing vendors[].key."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable display name."
+          },
+          "contextWindow": {
+            "type": "integer",
+            "description": "Maximum input context window in tokens (opencode limit.context)."
+          },
+          "maxOutputTokens": {
+            "type": "integer",
+            "description": "Maximum output tokens per response (opencode limit.output)."
+          },
+          "cost": {
+            "$ref": "#/$defs/cost",
+            "description": "Base per-token pricing."
+          },
+          "costAbove200kContext": {
+            "$ref": "#/$defs/cost",
+            "description": "Tiered pricing applied above 200k context (opencode cost.context_over_200k)."
+          },
+          "reasoning": {
+            "type": "boolean",
+            "description": "Whether the model supports reasoning/extended thinking. Not populated yet."
+          },
+          "inputModalities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Supported input modalities (e.g. text, image). Not populated yet."
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "cost": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Per-million-token pricing. All fields optional.",
+      "properties": {
+        "input": {
+          "type": "number",
+          "description": "Cost per input token (opencode cost.input)."
+        },
+        "output": {
+          "type": "number",
+          "description": "Cost per output token (opencode cost.output)."
+        },
+        "cacheRead": {
+          "type": "number",
+          "description": "Cost per cached-read token (opencode cost.cache_read)."
+        },
+        "cacheWrite": {
+          "type": "number",
+          "description": "Cost per cache-write token (opencode cost.cache_write)."
+        }
+      }
+    }
+  }
+}

--- a/integrations/providers/usai/emitters/opencode.mjs
+++ b/integrations/providers/usai/emitters/opencode.mjs
@@ -1,0 +1,153 @@
+// =============================================================================
+// opencode.mjs — the RENDER half of the USAi catalog pipeline (opencode target).
+//
+// Data flow:
+//   live feeds -> build-catalog.mjs -> catalog.json -> emitters/opencode.mjs
+//
+// This module is a PURE function: given the parsed catalog.json object it
+// returns the EXACT text of the region between (and including) the
+// `// BEGIN GENERATED USAI MODELS` and `// END GENERATED USAI MODELS` marker
+// comment lines as it appears in the shipped provider config:
+//   integrations/isolation/acq-kits/usai-provider/files/home/usai-config/opencode.jsonc
+//
+// The byte-exact round-trip test (tests/emitters.test.mjs) asserts that this
+// emitter reproduces the shipped block verbatim, which is the guarantee that
+// catalog.json losslessly represents the shipped config.
+//
+// Neutral (catalog) -> OpenCode translation:
+//   models are a MAP keyed by id (not an array);
+//   contextWindow    -> limit.context
+//   maxOutputTokens  -> limit.output
+//   cost.cacheRead   -> cost.cache_read
+//   cost.cacheWrite  -> cost.cache_write
+//   costAbove200kContext -> a compact one-line `context_over_200k` object nested
+//                           inside cost.
+//   vendor group comments (`// Anthropic Models`, ...) emitted in vendor order;
+//   model order within each vendor preserved as in catalog.json.
+//
+// No fetch, no fs — the caller passes the parsed catalog; the test does the
+// file reads.
+// =============================================================================
+
+const BEGIN_MARKER = "// BEGIN GENERATED USAI MODELS"
+const END_MARKER = "// END GENERATED USAI MODELS"
+
+// Indentation constants matching the shipped opencode.jsonc. The model MAP lives
+// under provider.usai.models, which is nested 4 levels deep (8 spaces) in the
+// file; nested objects add 2 spaces per level.
+const INDENT_MODEL = "        " // 8 spaces — model key + marker/comment lines
+const INDENT_2 = "          " // 10 spaces — model body keys (name, limit, cost)
+const INDENT_3 = "            " // 12 spaces — nested limit/cost entries
+
+// Vendor-group comment label. The shipped file uses "<Label> Models".
+function vendorComment(label) {
+  return `${INDENT_MODEL}// ${label} Models`
+}
+
+// Render one cost tier object (base cost) as multi-line JSON entries, in the
+// canonical key order the file uses: input, output, cache_read, cache_write,
+// then the compact context_over_200k line last (when present).
+function renderCost(model) {
+  const lines = []
+  const cost = model.cost || {}
+  const parts = []
+  if ("input" in cost) parts.push([`"input"`, cost.input])
+  if ("output" in cost) parts.push([`"output"`, cost.output])
+  if ("cacheRead" in cost) parts.push([`"cache_read"`, cost.cacheRead])
+  if ("cacheWrite" in cost) parts.push([`"cache_write"`, cost.cacheWrite])
+
+  // context_over_200k is rendered as a compact one-line object, always LAST.
+  const above = model.costAbove200kContext
+  let aboveLine = null
+  if (above && typeof above === "object") {
+    const inner = []
+    if ("input" in above) inner.push(`"input":${above.input}`)
+    if ("output" in above) inner.push(`"output":${above.output}`)
+    if ("cacheRead" in above) inner.push(`"cache_read":${above.cacheRead}`)
+    if ("cacheWrite" in above) inner.push(`"cache_write":${above.cacheWrite}`)
+    aboveLine = `"context_over_200k": {${inner.join(",")}}`
+  }
+
+  const totalEntries = parts.length + (aboveLine ? 1 : 0)
+  let emitted = 0
+  for (const [key, value] of parts) {
+    emitted++
+    const trailing = emitted < totalEntries ? "," : ""
+    lines.push(`${INDENT_3}${key}: ${value}${trailing}`)
+  }
+  if (aboveLine) {
+    // context_over_200k is last, so it never carries a trailing comma.
+    lines.push(`${INDENT_3}${aboveLine}`)
+  }
+  return lines
+}
+
+// Render one model object body (name, limit, cost). `trailingComma` controls
+// whether the closing brace of the model gets a trailing comma (all but the
+// last model in the whole block do).
+function renderModel(model, trailingComma) {
+  const lines = []
+  lines.push(`${INDENT_MODEL}"${model.id}": {`)
+  lines.push(`${INDENT_2}"name": "${model.name}",`)
+  lines.push(`${INDENT_2}"limit": {`)
+  lines.push(`${INDENT_3}"context": ${model.contextWindow},`)
+  lines.push(`${INDENT_3}"output": ${model.maxOutputTokens}`)
+  lines.push(`${INDENT_2}},`)
+  lines.push(`${INDENT_2}"cost": {`)
+  lines.push(...renderCost(model))
+  lines.push(`${INDENT_2}}`)
+  lines.push(`${INDENT_MODEL}}${trailingComma ? "," : ""}`)
+  return lines
+}
+
+/**
+ * Emit the OpenCode GENERATED USAI MODELS block (inclusive of the BEGIN/END
+ * marker comment lines) from a parsed catalog.json object.
+ *
+ * @param {object} catalog parsed catalog.json (schema usai-model-catalog/v1)
+ * @returns {string} the exact block text, matching the shipped opencode.jsonc
+ */
+export function emitOpenCodeBlockFromCatalog(catalog) {
+  if (!catalog || typeof catalog !== "object") {
+    throw new TypeError("emitOpenCodeBlockFromCatalog: catalog must be an object")
+  }
+  const vendors = Array.isArray(catalog.vendors) ? catalog.vendors : []
+  const models = Array.isArray(catalog.models) ? catalog.models : []
+
+  // Vendors in declared display order.
+  const orderedVendors = [...vendors].sort((a, b) => (a.order ?? 99) - (b.order ?? 99))
+
+  // Group models by vendor, preserving catalog.json order within each vendor.
+  const byVendor = new Map()
+  for (const v of orderedVendors) byVendor.set(v.key, [])
+  for (const m of models) {
+    if (!byVendor.has(m.vendor)) byVendor.set(m.vendor, [])
+    byVendor.get(m.vendor).push(m)
+  }
+
+  // Only vendors that actually have models get a group comment/section.
+  const vendorSections = orderedVendors
+    .map((v) => ({ vendor: v, models: byVendor.get(v.key) || [] }))
+    .filter((s) => s.models.length > 0)
+
+  const totalModels = vendorSections.reduce((n, s) => n + s.models.length, 0)
+
+  const lines = [`${INDENT_MODEL}${BEGIN_MARKER}`]
+
+  let modelIndex = 0
+  vendorSections.forEach((section, sectionIdx) => {
+    // A blank line precedes every vendor group EXCEPT the first.
+    if (sectionIdx > 0) lines.push("")
+    lines.push(vendorComment(section.vendor.label))
+    for (const model of section.models) {
+      modelIndex++
+      const isLast = modelIndex === totalModels
+      lines.push(...renderModel(model, !isLast))
+    }
+  })
+
+  lines.push(`${INDENT_MODEL}${END_MARKER}`)
+  return lines.join("\n")
+}
+
+export default emitOpenCodeBlockFromCatalog

--- a/integrations/providers/usai/emitters/prime-agent.mjs
+++ b/integrations/providers/usai/emitters/prime-agent.mjs
@@ -1,0 +1,94 @@
+// =============================================================================
+// prime-agent.mjs — the RENDER half of the USAi catalog pipeline (prime-agent).
+//
+// Data flow:
+//   live feeds -> build-catalog.mjs -> catalog.json -> emitters/prime-agent.mjs
+//
+// This module is a PURE function: given the parsed catalog.json object it
+// returns the EXACT text of a prime-agent models.json — a serialized JSON string
+// ready to write to disk (2-space indent, trailing newline, no comments — it is
+// a .json file). Issue #362 wires this output into the prime-agent kit's
+// models.json on the kit branch; returning a ready-to-write string keeps that
+// wiring a single `writeFileSync(path, emitPrimeAgentModelsFromCatalog(catalog))`.
+//
+// Neutral (catalog) -> prime-agent translation:
+//   gateway.baseUrl   -> providers.usai.baseUrl
+//   gateway.api       -> providers.usai.api
+//   gateway.apiKeyEnv -> providers.usai.apiKey (the NAME of an env var, never a
+//                        value; e.g. "USAI_API_KEY")
+//   authHeader: true  (constant — prime-agent auths via an Authorization header)
+//   models are an ARRAY of objects (each carries its own `id`), NOT a map;
+//   catalog order (vendor-grouped) is preserved as-is.
+//   Per model:
+//     id            -> id
+//     name          -> name
+//     contextWindow -> contextWindow   (flat; no OpenCode `limit` object)
+//     maxOutputTokens -> maxTokens     (renamed)
+//     cost.{input,output,cacheRead,cacheWrite} -> cost.{...} camelCase, verbatim
+//                       (no snake_case translation; absent keys omitted)
+//
+// INTENTIONAL LOSS: the tiered `costAbove200kContext` field is DROPPED. The
+// prime-agent models.json shape has no equivalent field, so the >200k-context
+// pricing tier carried by gpt-5.5 / gpt-5.4 / gemini-2.5-pro cannot be
+// represented here and is deliberately not emitted (see renderCost below).
+//
+// No fetch, no fs — the caller passes the parsed catalog and serializes/writes.
+// =============================================================================
+
+// Copy only the recognized camelCase cost keys, preserving their values and the
+// canonical input/output/cacheRead/cacheWrite order. Absent keys are omitted.
+//
+// NOTE: `costAbove200kContext` is intentionally NOT read here — prime-agent has
+// no tiered-pricing field, so that data is dropped (documented loss).
+function renderCost(cost) {
+  const out = {}
+  if (!cost || typeof cost !== "object") return out
+  if ("input" in cost) out.input = cost.input
+  if ("output" in cost) out.output = cost.output
+  if ("cacheRead" in cost) out.cacheRead = cost.cacheRead
+  if ("cacheWrite" in cost) out.cacheWrite = cost.cacheWrite
+  return out
+}
+
+// Map one catalog model to a prime-agent model object.
+function renderModel(model) {
+  return {
+    id: model.id,
+    name: model.name,
+    contextWindow: model.contextWindow,
+    maxTokens: model.maxOutputTokens, // catalog.maxOutputTokens -> prime-agent maxTokens
+    cost: renderCost(model.cost),
+    // costAbove200kContext is intentionally dropped — no prime-agent equivalent.
+  }
+}
+
+/**
+ * Emit a prime-agent models.json (serialized) from a parsed catalog.json object.
+ *
+ * @param {object} catalog parsed catalog.json (schema usai-model-catalog/v1)
+ * @returns {string} pretty-printed JSON (2-space indent) with a trailing newline,
+ *                    ready to write directly as models.json
+ */
+export function emitPrimeAgentModelsFromCatalog(catalog) {
+  if (!catalog || typeof catalog !== "object") {
+    throw new TypeError("emitPrimeAgentModelsFromCatalog: catalog must be an object")
+  }
+  const gateway = catalog.gateway && typeof catalog.gateway === "object" ? catalog.gateway : {}
+  const models = Array.isArray(catalog.models) ? catalog.models : []
+
+  const doc = {
+    providers: {
+      usai: {
+        baseUrl: gateway.baseUrl,
+        api: gateway.api,
+        apiKey: gateway.apiKeyEnv, // env-var NAME (e.g. "USAI_API_KEY"), never a value
+        authHeader: true,
+        models: models.map(renderModel), // ARRAY, catalog order preserved
+      },
+    },
+  }
+
+  return `${JSON.stringify(doc, null, 2)}\n`
+}
+
+export default emitPrimeAgentModelsFromCatalog

--- a/integrations/providers/usai/package.json
+++ b/integrations/providers/usai/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Harness-neutral USAi model catalog + emitters"
+  "description": "Harness-neutral USAi model catalog + emitters",
+  "scripts": {
+    "test": "node --test 'tests/**/*.test.mjs'"
+  }
 }

--- a/integrations/providers/usai/package.json
+++ b/integrations/providers/usai/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@gsa-tts/usai-catalog",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Harness-neutral USAi model catalog + emitters"
+}

--- a/integrations/providers/usai/scripts/build-catalog.mjs
+++ b/integrations/providers/usai/scripts/build-catalog.mjs
@@ -1,0 +1,769 @@
+#!/usr/bin/env node
+
+// =============================================================================
+// build-catalog.mjs — the FETCH + SHAPE half of the USAi catalog pipeline.
+//
+// Data flow:
+//   live feeds -> build-catalog.mjs -> catalog.json -> per-harness emitters
+//
+// This script derives `integrations/providers/usai/catalog.json` (schema
+// `usai-model-catalog/v1`). It DOES NOT render any harness config — the RENDER
+// half (the opencode.jsonc emitter) lives in a later issue and consumes this
+// catalog. The byte-exact round-trip test against the shipped opencode.jsonc is
+// the safety gate; therefore the FIRST committed catalog.json is BOOTSTRAPPED
+// from that shipped file's `// BEGIN GENERATED USAI MODELS` block so it exactly
+// represents today's models. Live-feed mode (fetch USAi + models.dev) is
+// provided for future regeneration.
+//
+// Modes:
+//   (default, no flags)     bootstrap catalog.json from the shipped opencode.jsonc
+//                           GENERATED block (offline, deterministic).
+//   --models-url <path|url> read the USAi model list from a local path or URL.
+//   --no-enrichment         do not fetch/read models.dev; use only the models
+//                           list (limits/costs come from the fixture/list only).
+//   --models-dev <path|url> read models.dev enrichment from a local path or URL.
+//   --bootstrap             force bootstrap-from-opencode.jsonc mode (default
+//                           when neither --models-url nor live fetch is used).
+//   --opencode-jsonc <path> override the bootstrap source path.
+//   --out <path>            override the output catalog.json path.
+//   --check                 do not write; fail if catalog.json is out of date.
+//
+// CI / round-trip callers use the offline paths (--bootstrap, or --models-url
+// against committed fixtures with --no-enrichment) so no network is required.
+// =============================================================================
+
+import { readFile, writeFile } from "node:fs/promises"
+import path from "node:path"
+import process from "node:process"
+import { fileURLToPath } from "node:url"
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const USAI_DIR = path.resolve(HERE, "..")
+const REPO_ROOT = path.resolve(USAI_DIR, "../../..")
+
+const DEFAULT_OUT = path.join(USAI_DIR, "catalog.json")
+const DEFAULT_SCHEMA = path.join(USAI_DIR, "catalog.schema.json")
+const DEFAULT_OPENCODE_JSONC = path.join(
+  REPO_ROOT,
+  "integrations/isolation/acq-kits/usai-provider/files/home/usai-config/opencode.jsonc",
+)
+// Path recorded in catalog.sources.bootstrappedFrom — repo-relative, stable.
+const OPENCODE_JSONC_REL =
+  "integrations/isolation/acq-kits/usai-provider/files/home/usai-config/opencode.jsonc"
+
+const GENERATED_START = "// BEGIN GENERATED USAI MODELS"
+const GENERATED_END = "// END GENERATED USAI MODELS"
+
+const SCHEMA_VERSION = "usai-model-catalog/v1"
+const GENERATED_MARKER = "build-catalog.mjs (generated — do not hand-edit)"
+
+const USAI_MODELS_URL = "https://api.gsa.usai.gov/api/v1/models"
+const MODELS_DEV_URL = "https://models.dev/api.json"
+
+// Network hardening (mirrors the monolith sync-usai-models.mjs): bound time and
+// size, and shape-validate before trusting third-party content.
+const FETCH_TIMEOUT_MS = 15000
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024 // 10 MiB
+
+const FALLBACK_LIMITS = { context: 128000, output: 8192 }
+
+// Vendor grouping + USAi backend routing. Order here is the canonical vendor
+// display order for the catalog (Anthropic, OpenAI, Google, Meta, Cohere).
+// usaiBackend records the backend USAi routes each vendor through — the same
+// backend the monolith sources pricing from (Anthropic->Bedrock, OpenAI->Azure,
+// Gemini->Vertex, Meta->Bedrock, Cohere->Cohere).
+const VENDOR_CONFIG = {
+  anthropic: { label: "Anthropic", order: 1, usaiBackend: "amazon-bedrock" },
+  openai: { label: "OpenAI", order: 2, usaiBackend: "azure" },
+  google: { label: "Google", order: 3, usaiBackend: "google-vertex" },
+  meta: { label: "Meta", order: 4, usaiBackend: "amazon-bedrock" },
+  cohere: { label: "Cohere", order: 5, usaiBackend: "cohere" },
+  other: { label: "Other", order: 99, usaiBackend: "" },
+}
+
+// models.dev provider search order per vendor (primary backend, then fallbacks)
+// — same routing the monolith uses so enrichment reads the backend USAi serves.
+const VENDOR_PROVIDER_MAP = {
+  anthropic: { primary: "amazon-bedrock", fallback: ["anthropic"] },
+  openai: { primary: "azure", fallback: ["openai"] },
+  google: { primary: "google-vertex", fallback: ["google"] },
+  meta: { primary: "amazon-bedrock", fallback: ["meta", "llama"] },
+  cohere: { primary: "cohere", fallback: [] },
+  other: { primary: null, fallback: [] },
+}
+
+// Display-name overrides carried over from the monolith for complex IDs.
+const DISPLAY_NAME_OVERRIDES = {
+  "gpt-5.4-latest-guardrails-defaultv2": "GPT-5.4 Latest — Guardrails Default v2",
+  "gpt-5.2-latest-guardrails-defaultv2": "GPT-5.2 Latest — Guardrails Default v2",
+  cohere_english_v3: "Cohere English v3",
+}
+
+// -----------------------------------------------------------------------------
+// Vendor classification (owned_by + id prefix), from the monolith.
+// -----------------------------------------------------------------------------
+function normalizeText(value) {
+  return String(value ?? "").toLowerCase()
+}
+
+function classifyVendor(id, ownedBy) {
+  const owned = normalizeText(ownedBy)
+  if (owned.includes("anthropic") || /^claude/i.test(id)) return "anthropic"
+  if (owned.includes("open ai") || owned.includes("openai") || /^gpt/i.test(id)) return "openai"
+  if (owned.includes("google") || /^gemini/i.test(id)) return "google"
+  if (owned.includes("meta") || /^llama/i.test(id)) return "meta"
+  if (owned.includes("cohere") || /^cohere/i.test(id)) return "cohere"
+  return "other"
+}
+
+function generateDisplayName(id) {
+  if (DISPLAY_NAME_OVERRIDES[id]) return DISPLAY_NAME_OVERRIDES[id]
+  return id
+    .replace(/[_-]+/g, " ")
+    .replace(/(\d)\s+(\d)/g, "$1.$2")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .replace(/\bGpt\b/g, "GPT")
+    .replace(/\bLlama\b/g, "Llama")
+}
+
+// -----------------------------------------------------------------------------
+// Fuzzy models.dev matching (structural re-implementation of the monolith).
+// -----------------------------------------------------------------------------
+function normalizeModelId(id) {
+  const withoutProvider = id.includes("/") ? id.split("/").pop() : id
+  return withoutProvider
+    .toLowerCase()
+    .replace(/[_-]+/g, "-")
+    .replace(/(\d)\.(\d)/g, "$1-$2")
+    .replace(/guardrails.*$/i, "")
+    .replace(/latest.*$/i, "")
+    .replace(/-+$/, "")
+}
+
+function extractModelTokens(id) {
+  const normalized = normalizeModelId(id)
+  const parts = normalized.split("-")
+  let family = ""
+  let variant = ""
+  const versionParts = []
+  for (const part of parts) {
+    if (/^(claude|gpt|gemini|llama\d*|cohere|command)$/i.test(part)) {
+      family = /^llama/i.test(part) ? "llama" : /^command$/i.test(part) ? "cohere" : part
+    } else if (/^(opus|sonnet|haiku|pro|flash|mini|nano|maverick)$/i.test(part)) {
+      variant = part
+    } else if (/^\d+$/.test(part)) {
+      versionParts.push(Number.parseInt(part, 10))
+    }
+  }
+  if (!family) {
+    if (/claude/i.test(normalized)) family = "claude"
+    else if (/gpt/i.test(normalized)) family = "gpt"
+    else if (/gemini/i.test(normalized)) family = "gemini"
+    else if (/llama/i.test(normalized)) family = "llama"
+    else if (/cohere|command/i.test(normalized)) family = "cohere"
+  }
+  return { family, version: versionParts, variant }
+}
+
+function findModelsDevMatch(usaiId, catalog) {
+  const usaiTokens = extractModelTokens(usaiId)
+  const usaiNorm = normalizeModelId(usaiId)
+  const usaiHasLite = /lite/.test(usaiNorm)
+  let bestMatch = null
+  let bestScore = -Infinity
+  for (const [catalogId, data] of Object.entries(catalog)) {
+    const catalogTokens = extractModelTokens(catalogId)
+    const catalogNorm = normalizeModelId(catalogId)
+    if (usaiTokens.family !== catalogTokens.family) continue
+    let score = 10
+    if (usaiTokens.variant && usaiTokens.variant === catalogTokens.variant) score += 50
+    const catalogHasLite = /lite/.test(catalogNorm)
+    if (usaiHasLite !== catalogHasLite) score -= 40
+    const versionMatch = usaiTokens.version.every((v, i) => catalogTokens.version[i] === v)
+    if (versionMatch && usaiTokens.version.length > 0) {
+      score += 30
+      if (catalogTokens.version.length === usaiTokens.version.length) score += 3
+    }
+    for (const suffix of ["tts", "image", "audio", "vision", "embed", "embedding", "search", "realtime"]) {
+      const re = new RegExp(`(^|[.\\-/])${suffix}([.\\-]|$)`)
+      if (re.test(catalogNorm) && !re.test(usaiNorm)) score -= 60
+    }
+    for (const v of ["pro", "codex", "mini", "nano", "max"]) {
+      const re = new RegExp(`(^|[.\\-/])${v}([.\\-]|$)`)
+      if (re.test(catalogNorm) && !re.test(usaiNorm)) score -= 20
+    }
+    if (/^(eu|au)\./.test(catalogId)) score -= 15
+    else if (/^(us|global)\./.test(catalogId)) score += 2
+    else if (/^[a-z]{2}\./.test(catalogId)) score += 1
+    else score += 3
+    if (normalizeModelId(catalogId).startsWith(normalizeModelId(usaiId).slice(0, 10))) score += 5
+    if (score > bestScore) {
+      bestScore = score
+      bestMatch = { id: catalogId, data }
+    }
+  }
+  return bestMatch && bestScore > 0 ? bestMatch : null
+}
+
+function providerModelMaps(vendor, catalog) {
+  const mapping = VENDOR_PROVIDER_MAP[vendor] || VENDOR_PROVIDER_MAP.other
+  const providerIds = [mapping.primary, ...mapping.fallback].filter(Boolean)
+  const maps = []
+  for (const id of providerIds) {
+    const models = catalog[id]?.models
+    if (models && typeof models === "object") maps.push({ providerId: id, models })
+  }
+  return maps
+}
+
+// -----------------------------------------------------------------------------
+// Cost normalization. The CATALOG schema uses camelCase cost keys
+// (input/output/cacheRead/cacheWrite) and a `costAbove200kContext` object with
+// the same keys. models.dev uses snake_case (cache_read/cache_write) and nests
+// tiered pricing under `context_over_200k`. We translate to the catalog shape.
+// -----------------------------------------------------------------------------
+const COST_MAP = [
+  ["input", "input"],
+  ["output", "output"],
+  ["cacheRead", "cache_read"],
+  ["cacheWrite", "cache_write"],
+]
+
+function normalizeCostFromModelsDev(cost) {
+  if (!cost || typeof cost !== "object") return { cost: null, costAbove200kContext: null }
+  const out = {}
+  for (const [camel, snake] of COST_MAP) {
+    if (typeof cost[snake] === "number") out[camel] = cost[snake]
+  }
+  let above = null
+  const over = cost.context_over_200k
+  if (over && typeof over === "object") {
+    const o = {}
+    for (const [camel, snake] of COST_MAP) {
+      if (typeof over[snake] === "number") o[camel] = over[snake]
+    }
+    if (typeof o.input === "number" && typeof o.output === "number") above = o
+  }
+  return {
+    cost: Object.keys(out).length > 0 ? out : null,
+    costAbove200kContext: above,
+  }
+}
+
+function normalizeLimit(value, fallback) {
+  return Number.isInteger(value) && value > 0 ? value : fallback
+}
+
+// -----------------------------------------------------------------------------
+// Bounded fetch + shape validation (mirrors the monolith hardening).
+// -----------------------------------------------------------------------------
+async function readBodyCapped(response, ref) {
+  if (!response.body || typeof response.body.getReader !== "function") {
+    const text = await response.text()
+    if (Buffer.byteLength(text, "utf8") > MAX_RESPONSE_BYTES) {
+      throw new Error(`response from ${ref} exceeded ${MAX_RESPONSE_BYTES} bytes`)
+    }
+    return text
+  }
+  const reader = response.body.getReader()
+  const chunks = []
+  let total = 0
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    total += value.byteLength
+    if (total > MAX_RESPONSE_BYTES) {
+      await reader.cancel().catch(() => {})
+      throw new Error(`response from ${ref} exceeded ${MAX_RESPONSE_BYTES} bytes`)
+    }
+    chunks.push(value)
+  }
+  return Buffer.concat(chunks.map((c) => Buffer.from(c))).toString("utf8")
+}
+
+async function fetchJsonBounded(url, options = {}) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), options.timeoutMs ?? FETCH_TIMEOUT_MS)
+  let response
+  try {
+    response = await fetch(url, { ...options, signal: controller.signal })
+  } catch (err) {
+    if (err.name === "AbortError") throw new Error(`request to ${url} timed out after ${FETCH_TIMEOUT_MS}ms`)
+    throw err
+  } finally {
+    clearTimeout(timer)
+  }
+  if (!response.ok) {
+    const body = await response.text().catch(() => "(no body)")
+    throw new Error(`request to ${url} failed: ${response.status} ${response.statusText} - ${body.slice(0, 200)}`)
+  }
+  const declaredLength = Number(response.headers.get("content-length") || "0")
+  if (declaredLength > MAX_RESPONSE_BYTES) {
+    throw new Error(`response from ${url} too large: ${declaredLength} bytes > ${MAX_RESPONSE_BYTES}`)
+  }
+  const text = await readBodyCapped(response, url)
+  try {
+    return JSON.parse(text)
+  } catch (err) {
+    throw new Error(`response from ${url} was not valid JSON: ${err.message}`)
+  }
+}
+
+// A source ref is a local file path unless it looks like an http(s) URL.
+function isUrl(ref) {
+  return /^https?:\/\//i.test(ref)
+}
+
+async function loadJsonSource(ref, options = {}) {
+  if (isUrl(ref)) return fetchJsonBounded(ref, options)
+  const abs = path.isAbsolute(ref) ? ref : path.resolve(process.cwd(), ref)
+  const text = await readFile(abs, "utf8")
+  if (Buffer.byteLength(text, "utf8") > MAX_RESPONSE_BYTES) {
+    throw new Error(`file ${abs} exceeded ${MAX_RESPONSE_BYTES} bytes`)
+  }
+  try {
+    return JSON.parse(text)
+  } catch (err) {
+    throw new Error(`file ${abs} was not valid JSON: ${err.message}`)
+  }
+}
+
+// Extract the USAi model list from any accepted shape (array / {data} / {models}).
+function extractUsaiList(payload) {
+  const list = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.data)
+      ? payload.data
+      : Array.isArray(payload?.models)
+        ? payload.models
+        : null
+  if (!list) throw new Error("USAi payload invalid: expected an array or { data | models: [] }")
+  if (list.length === 0) throw new Error("USAi payload invalid: model list is empty")
+  const hasUsableId = list.some((m) => m && typeof m === "object" && (m.id || m.model_id || m.name))
+  if (!hasUsableId) throw new Error("USAi payload invalid: no entries have an id/model_id/name field")
+  return list
+}
+
+// -----------------------------------------------------------------------------
+// Bootstrap: parse the shipped opencode.jsonc GENERATED block into catalog
+// models, translating opencode cost keys -> catalog cost keys. This preserves
+// model ORDER and vendor grouping exactly as the block declares them.
+// -----------------------------------------------------------------------------
+function extractGeneratedBlock(jsoncText) {
+  const start = jsoncText.indexOf(GENERATED_START)
+  const end = jsoncText.indexOf(GENERATED_END)
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error("GENERATED USAI MODELS markers not found in opencode.jsonc")
+  }
+  return jsoncText.slice(start + GENERATED_START.length, end)
+}
+
+// Parse the block body — a sequence of `// Vendor Comment` lines and
+// `"id": { ...json... }` objects — into ordered { id, vendor, name, json }.
+// We rely on brace-balancing to slice each model object, then JSON.parse it
+// (the model objects are strict JSON; comments only appear between objects).
+function parseBootstrapModels(blockBody) {
+  const entries = []
+  let i = 0
+  const n = blockBody.length
+  while (i < n) {
+    // Skip to the next quoted key that begins a model object: `"<id>": {`
+    const keyMatch = /"([^"]+)"\s*:\s*\{/g
+    keyMatch.lastIndex = i
+    const m = keyMatch.exec(blockBody)
+    if (!m) break
+    const id = m[1]
+    // Find the balanced closing brace of the object starting at m.index + key.
+    const objStart = blockBody.indexOf("{", m.index)
+    let depth = 0
+    let j = objStart
+    let inStr = false
+    for (; j < n; j++) {
+      const ch = blockBody[j]
+      if (inStr) {
+        if (ch === "\\") j++
+        else if (ch === '"') inStr = false
+        continue
+      }
+      if (ch === '"') inStr = true
+      else if (ch === "{") depth++
+      else if (ch === "}") {
+        depth--
+        if (depth === 0) {
+          j++
+          break
+        }
+      }
+    }
+    const objText = blockBody.slice(objStart, j)
+    let obj
+    try {
+      obj = JSON.parse(objText)
+    } catch (err) {
+      throw new Error(`bootstrap: could not parse model "${id}": ${err.message}`)
+    }
+    entries.push({ id, obj })
+    i = j
+  }
+  if (entries.length === 0) throw new Error("bootstrap: no models parsed from GENERATED block")
+  return entries
+}
+
+function bootstrapModelsFromBlock(entries) {
+  const models = []
+  const vendorsSeen = new Set()
+  for (const { id, obj } of entries) {
+    const vendor = classifyVendor(id, "")
+    vendorsSeen.add(vendor)
+    const model = { id, vendor, name: obj.name ?? generateDisplayName(id) }
+    const limit = obj.limit || {}
+    if (Number.isInteger(limit.context)) model.contextWindow = limit.context
+    if (Number.isInteger(limit.output)) model.maxOutputTokens = limit.output
+    const cost = obj.cost || {}
+    const baseCost = {}
+    for (const [camel, snake] of COST_MAP) {
+      if (typeof cost[snake] === "number") baseCost[camel] = cost[snake]
+    }
+    if (Object.keys(baseCost).length > 0) model.cost = baseCost
+    const over = cost.context_over_200k
+    if (over && typeof over === "object") {
+      const above = {}
+      for (const [camel, snake] of COST_MAP) {
+        if (typeof over[snake] === "number") above[camel] = over[snake]
+      }
+      if (Object.keys(above).length > 0) model.costAbove200kContext = above
+    }
+    models.push(model)
+  }
+  return { models, vendorsSeen }
+}
+
+// Build the ordered vendors[] array. Bootstrap preserves the order the vendors
+// first appear in the block; live-feed mode uses VENDOR_CONFIG.order.
+function buildVendors(vendorKeysInOrder) {
+  return vendorKeysInOrder.map((key, idx) => {
+    const cfg = VENDOR_CONFIG[key] || VENDOR_CONFIG.other
+    return {
+      key,
+      label: cfg.label,
+      order: idx + 1,
+      usaiBackend: cfg.usaiBackend,
+    }
+  })
+}
+
+// -----------------------------------------------------------------------------
+// Live-feed shaping: parse USAi list, classify, optionally enrich from models.dev.
+// -----------------------------------------------------------------------------
+function shapeFromFeeds(usaiList, modelsDevCatalog) {
+  // Chat models only (exclude embeddings), preserve incoming list order but
+  // group by vendor display order for a stable catalog.
+  const parsed = usaiList
+    .map((raw) => {
+      const id = raw.id || raw.model_id || raw.name
+      if (!id) return null
+      const vendor = classifyVendor(id, raw.owned_by)
+      const haystack = `${id} ${raw.name ?? ""}`.toLowerCase()
+      const isEmbedding = /embedding|embed/.test(haystack)
+      return { id, vendor, name: raw.name || generateDisplayName(id), isEmbedding, raw }
+    })
+    .filter(Boolean)
+    .filter((m) => !m.isEmbedding)
+
+  parsed.sort((a, b) => {
+    const oa = VENDOR_CONFIG[a.vendor]?.order ?? 99
+    const ob = VENDOR_CONFIG[b.vendor]?.order ?? 99
+    if (oa !== ob) return oa - ob
+    return a.id.localeCompare(b.id)
+  })
+
+  const vendorOrder = []
+  const models = []
+  for (const p of parsed) {
+    if (!vendorOrder.includes(p.vendor)) vendorOrder.push(p.vendor)
+    const model = { id: p.id, vendor: p.vendor, name: p.name }
+    let context = Number.isInteger(p.raw.context_window) ? p.raw.context_window : null
+    let output = Number.isInteger(p.raw.max_output_tokens) ? p.raw.max_output_tokens : null
+    let baseCost = null
+    let above = null
+    if (modelsDevCatalog) {
+      for (const { models: providerModels } of providerModelMaps(p.vendor, modelsDevCatalog)) {
+        const match = findModelsDevMatch(p.id, providerModels)
+        if (match?.data) {
+          if (match.data.limit) {
+            context = context || match.data.limit.context || null
+            output = output || match.data.limit.output || null
+          }
+          const norm = normalizeCostFromModelsDev(match.data.cost)
+          baseCost = norm.cost
+          above = norm.costAbove200kContext
+          break
+        }
+      }
+    }
+    model.contextWindow = normalizeLimit(context, FALLBACK_LIMITS.context)
+    model.maxOutputTokens = normalizeLimit(output, FALLBACK_LIMITS.output)
+    if (baseCost) model.cost = baseCost
+    if (above) model.costAbove200kContext = above
+    models.push(model)
+  }
+  return { models, vendorOrder }
+}
+
+// -----------------------------------------------------------------------------
+// Minimal structural validator against catalog.schema.json. ajv is NOT a repo
+// dependency (checked package.json + node_modules), so we hand-roll a check of
+// the constraints that matter for this catalog rather than add a dependency.
+// -----------------------------------------------------------------------------
+function assert(cond, msg, errors) {
+  if (!cond) errors.push(msg)
+}
+
+function validateCost(cost, where, errors) {
+  if (cost === undefined) return
+  assert(cost && typeof cost === "object" && !Array.isArray(cost), `${where}: cost must be an object`, errors)
+  if (!cost || typeof cost !== "object") return
+  const allowed = new Set(["input", "output", "cacheRead", "cacheWrite"])
+  for (const [k, v] of Object.entries(cost)) {
+    assert(allowed.has(k), `${where}: cost has disallowed key "${k}"`, errors)
+    assert(typeof v === "number", `${where}: cost.${k} must be a number`, errors)
+  }
+}
+
+function validateCatalog(catalog, schema) {
+  const errors = []
+  assert(catalog && typeof catalog === "object" && !Array.isArray(catalog), "catalog must be an object", errors)
+  if (errors.length) return errors
+
+  const topAllowed = new Set(Object.keys(schema.properties))
+  for (const k of Object.keys(catalog)) {
+    assert(topAllowed.has(k), `top-level: disallowed key "${k}"`, errors)
+  }
+  for (const req of schema.required) {
+    assert(req in catalog, `top-level: missing required key "${req}"`, errors)
+  }
+
+  assert(catalog.schemaVersion === SCHEMA_VERSION, `schemaVersion must be "${SCHEMA_VERSION}"`, errors)
+
+  // gateway
+  const gw = catalog.gateway
+  if (gw && typeof gw === "object") {
+    const gwAllowed = new Set(["host", "baseUrl", "api", "apiKeyEnv"])
+    for (const k of Object.keys(gw)) assert(gwAllowed.has(k), `gateway: disallowed key "${k}"`, errors)
+    for (const r of ["host", "baseUrl", "api", "apiKeyEnv"]) assert(r in gw, `gateway: missing "${r}"`, errors)
+    assert(gw.api === "openai-completions", `gateway.api must be "openai-completions"`, errors)
+    assert(/^[A-Z][A-Z0-9_]*$/.test(String(gw.apiKeyEnv)), `gateway.apiKeyEnv must be an UPPER_SNAKE env var name`, errors)
+    assert(typeof gw.baseUrl === "string" && /^\w+:\/\//.test(gw.baseUrl), `gateway.baseUrl must be a URI`, errors)
+  } else {
+    assert(false, "gateway must be an object", errors)
+  }
+
+  // vendors
+  assert(Array.isArray(catalog.vendors), "vendors must be an array", errors)
+  if (Array.isArray(catalog.vendors)) {
+    const vendorAllowed = new Set(["key", "label", "order", "usaiBackend"])
+    for (const [idx, v] of catalog.vendors.entries()) {
+      for (const k of Object.keys(v)) assert(vendorAllowed.has(k), `vendors[${idx}]: disallowed key "${k}"`, errors)
+      for (const r of ["key", "label", "order", "usaiBackend"]) assert(r in v, `vendors[${idx}]: missing "${r}"`, errors)
+      assert(typeof v.key === "string", `vendors[${idx}].key must be string`, errors)
+      assert(Number.isInteger(v.order), `vendors[${idx}].order must be integer`, errors)
+    }
+  }
+
+  // models
+  assert(Array.isArray(catalog.models), "models must be an array", errors)
+  if (Array.isArray(catalog.models)) {
+    const modelAllowed = new Set([
+      "id", "vendor", "name", "contextWindow", "maxOutputTokens",
+      "cost", "costAbove200kContext", "reasoning", "inputModalities",
+    ])
+    const vendorKeys = new Set((catalog.vendors || []).map((v) => v.key))
+    for (const [idx, m] of catalog.models.entries()) {
+      for (const k of Object.keys(m)) assert(modelAllowed.has(k), `models[${idx}]: disallowed key "${k}"`, errors)
+      for (const r of ["id", "vendor", "name"]) assert(r in m, `models[${idx}]: missing "${r}"`, errors)
+      assert(typeof m.id === "string", `models[${idx}].id must be string`, errors)
+      assert(typeof m.name === "string", `models[${idx}].name must be string`, errors)
+      assert(vendorKeys.has(m.vendor), `models[${idx}].vendor "${m.vendor}" not in vendors[]`, errors)
+      if ("contextWindow" in m) assert(Number.isInteger(m.contextWindow), `models[${idx}].contextWindow must be integer`, errors)
+      if ("maxOutputTokens" in m) assert(Number.isInteger(m.maxOutputTokens), `models[${idx}].maxOutputTokens must be integer`, errors)
+      validateCost(m.cost, `models[${idx}]`, errors)
+      validateCost(m.costAbove200kContext, `models[${idx}]`, errors)
+    }
+  }
+  return errors
+}
+
+// -----------------------------------------------------------------------------
+// Deterministic serialization: keys in a fixed order, 2-space indent, trailing
+// newline. Order is stable so the committed catalog.json is reproducible.
+// -----------------------------------------------------------------------------
+const KEY_ORDER = {
+  root: ["schemaVersion", "generatedBy", "sources", "gateway", "vendors", "models"],
+  gateway: ["host", "baseUrl", "api", "apiKeyEnv"],
+  vendor: ["key", "label", "order", "usaiBackend"],
+  model: ["id", "vendor", "name", "contextWindow", "maxOutputTokens", "cost", "costAbove200kContext", "reasoning", "inputModalities"],
+  cost: ["input", "output", "cacheRead", "cacheWrite"],
+}
+
+function orderObject(obj, order) {
+  const out = {}
+  for (const k of order) if (k in obj) out[k] = obj[k]
+  // Preserve any keys not in the explicit order (defensive; none expected).
+  for (const k of Object.keys(obj)) if (!(k in out)) out[k] = obj[k]
+  return out
+}
+
+function orderCatalog(catalog) {
+  const out = orderObject(catalog, KEY_ORDER.root)
+  if (out.gateway) out.gateway = orderObject(out.gateway, KEY_ORDER.gateway)
+  if (Array.isArray(out.vendors)) out.vendors = out.vendors.map((v) => orderObject(v, KEY_ORDER.vendor))
+  if (Array.isArray(out.models)) {
+    out.models = out.models.map((m) => {
+      const om = orderObject(m, KEY_ORDER.model)
+      if (om.cost) om.cost = orderObject(om.cost, KEY_ORDER.cost)
+      if (om.costAbove200kContext) om.costAbove200kContext = orderObject(om.costAbove200kContext, KEY_ORDER.cost)
+      return om
+    })
+  }
+  return out
+}
+
+function serialize(catalog) {
+  return JSON.stringify(orderCatalog(catalog), null, 2) + "\n"
+}
+
+// -----------------------------------------------------------------------------
+// gateway metadata — derived from the shipped provider config (static).
+// -----------------------------------------------------------------------------
+function buildGateway() {
+  return {
+    host: "api.gsa.usai.gov",
+    baseUrl: "https://api.gsa.usai.gov/api/v1",
+    api: "openai-completions",
+    apiKeyEnv: "USAI_API_KEY",
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Arg parsing
+// -----------------------------------------------------------------------------
+function parseArgs(argv) {
+  const args = { flags: new Set(), opts: {} }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === "--no-enrichment" || a === "--bootstrap" || a === "--check") {
+      args.flags.add(a)
+    } else if (a === "--models-url" || a === "--models-dev" || a === "--opencode-jsonc" || a === "--out" || a === "--schema") {
+      args.opts[a] = argv[++i]
+    } else if (a.startsWith("--") && a.includes("=")) {
+      const [k, v] = a.split(/=(.*)/s)
+      args.opts[k] = v
+    } else {
+      throw new Error(`unknown argument: ${a}`)
+    }
+  }
+  return args
+}
+
+async function buildCatalog(args) {
+  const schemaPath = args.opts["--schema"] || DEFAULT_SCHEMA
+  const schema = JSON.parse(await readFile(schemaPath, "utf8"))
+
+  const modelsUrl = args.opts["--models-url"]
+  const noEnrichment = args.flags.has("--no-enrichment")
+  const forceBootstrap = args.flags.has("--bootstrap")
+
+  let catalog
+  if (modelsUrl && !forceBootstrap) {
+    // Live-feed / fixture mode.
+    const usaiPayload = await loadJsonSource(modelsUrl)
+    const usaiList = extractUsaiList(usaiPayload)
+    let modelsDevCatalog = null
+    if (!noEnrichment) {
+      const modelsDevRef = args.opts["--models-dev"] || MODELS_DEV_URL
+      const raw = await loadJsonSource(modelsDevRef)
+      if (raw && typeof raw === "object" && !Array.isArray(raw)) modelsDevCatalog = raw
+      else throw new Error("models.dev source has unexpected shape (expected provider-keyed object)")
+    }
+    const { models, vendorOrder } = shapeFromFeeds(usaiList, modelsDevCatalog)
+    catalog = {
+      schemaVersion: SCHEMA_VERSION,
+      generatedBy: GENERATED_MARKER,
+      sources: {
+        modelsList: modelsUrl,
+        enrichment: noEnrichment ? "(none)" : (args.opts["--models-dev"] || MODELS_DEV_URL),
+      },
+      gateway: buildGateway(),
+      vendors: buildVendors(vendorOrder),
+      models,
+    }
+  } else {
+    // Bootstrap from the shipped opencode.jsonc GENERATED block (default).
+    const opencodePath = args.opts["--opencode-jsonc"] || DEFAULT_OPENCODE_JSONC
+    const jsoncText = await readFile(opencodePath, "utf8")
+    const block = extractGeneratedBlock(jsoncText)
+    const entries = parseBootstrapModels(block)
+    const { models } = bootstrapModelsFromBlock(entries)
+    // Preserve vendor first-appearance order from the block.
+    const vendorOrder = []
+    for (const m of models) if (!vendorOrder.includes(m.vendor)) vendorOrder.push(m.vendor)
+    catalog = {
+      schemaVersion: SCHEMA_VERSION,
+      generatedBy: GENERATED_MARKER,
+      sources: {
+        bootstrappedFrom: OPENCODE_JSONC_REL,
+      },
+      gateway: buildGateway(),
+      vendors: buildVendors(vendorOrder),
+      models,
+    }
+  }
+
+  const errors = validateCatalog(catalog, schema)
+  if (errors.length) {
+    throw new Error(`catalog failed schema validation:\n  - ${errors.join("\n  - ")}`)
+  }
+  return catalog
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const outPath = args.opts["--out"] || DEFAULT_OUT
+  const catalog = await buildCatalog(args)
+  const serialized = serialize(catalog)
+
+  if (args.flags.has("--check")) {
+    let existing = null
+    try {
+      existing = await readFile(outPath, "utf8")
+    } catch {
+      throw new Error(`catalog.json missing at ${outPath}; run without --check to generate`)
+    }
+    if (existing !== serialized) {
+      throw new Error("catalog.json is out of date with the current sources")
+    }
+    process.stdout.write(`catalog.json is up to date (${catalog.models.length} models)\n`)
+    return
+  }
+
+  await writeFile(outPath, serialized)
+  process.stdout.write(`Wrote ${outPath} (${catalog.models.length} models, ${catalog.vendors.length} vendors)\n`)
+}
+
+export {
+  buildCatalog,
+  validateCatalog,
+  serialize,
+  parseBootstrapModels,
+  bootstrapModelsFromBlock,
+  shapeFromFeeds,
+  findModelsDevMatch,
+  classifyVendor,
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error.message)
+    process.exit(1)
+  })
+}

--- a/integrations/providers/usai/tests/emitters.test.mjs
+++ b/integrations/providers/usai/tests/emitters.test.mjs
@@ -1,0 +1,84 @@
+// =============================================================================
+// emitters.test.mjs — byte-exact round-trip test for the OpenCode emitter.
+//
+// This is the load-bearing guarantee that catalog.json losslessly represents
+// the shipped usai-provider opencode.jsonc: emitting the OpenCode GENERATED
+// USAI MODELS block from catalog.json must reproduce the shipped block
+// BYTE-FOR-BYTE (including the two marker comment lines, indentation, vendor
+// group comments, snake_case cost keys, the compact one-line context_over_200k,
+// and the last-entry trailing-comma formatting).
+//
+// The test reads the REAL shipped opencode.jsonc via a relative path (NOT a
+// copied fixture) so drift between catalog.json and the shipped config fails CI.
+// =============================================================================
+
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { test } from "node:test"
+
+import { emitOpenCodeBlockFromCatalog } from "../emitters/opencode.mjs"
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const USAI_DIR = path.resolve(HERE, "..")
+const REPO_ROOT = path.resolve(USAI_DIR, "../../..")
+
+const OPENCODE_JSONC = path.join(
+  REPO_ROOT,
+  "integrations/isolation/acq-kits/usai-provider/files/home/usai-config/opencode.jsonc",
+)
+const CATALOG_JSON = path.join(USAI_DIR, "catalog.json")
+
+const BEGIN_MARKER = "// BEGIN GENERATED USAI MODELS"
+const END_MARKER = "// END GENERATED USAI MODELS"
+
+// Extract the region between the BEGIN/END markers INCLUSIVE, preserving the
+// exact source lines (including the markers' own leading indentation).
+function extractShippedBlock(jsoncText) {
+  const lines = jsoncText.split("\n")
+  const beginIdx = lines.findIndex((l) => l.includes(BEGIN_MARKER))
+  const endIdx = lines.findIndex((l) => l.includes(END_MARKER))
+  assert.ok(beginIdx !== -1, "shipped opencode.jsonc: BEGIN marker not found")
+  assert.ok(endIdx !== -1, "shipped opencode.jsonc: END marker not found")
+  assert.ok(endIdx > beginIdx, "shipped opencode.jsonc: END marker before BEGIN")
+  return lines.slice(beginIdx, endIdx + 1).join("\n")
+}
+
+// On mismatch, find the first differing character offset and print a small
+// window around it (expected vs actual) to make debugging fast.
+function firstMismatchReport(expected, actual) {
+  const len = Math.min(expected.length, actual.length)
+  let i = 0
+  for (; i < len; i++) {
+    if (expected[i] !== actual[i]) break
+  }
+  const ctx = 40
+  const from = Math.max(0, i - ctx)
+  const to = i + ctx
+  return [
+    `first mismatch at offset ${i}`,
+    `  expected len=${expected.length} actual len=${actual.length}`,
+    `  expected: ${JSON.stringify(expected.slice(from, to))}`,
+    `  actual:   ${JSON.stringify(actual.slice(from, to))}`,
+  ].join("\n")
+}
+
+test("emitOpenCodeBlockFromCatalog reproduces the shipped block byte-for-byte", () => {
+  const jsoncText = readFileSync(OPENCODE_JSONC, "utf8")
+  const expected = extractShippedBlock(jsoncText)
+
+  const catalog = JSON.parse(readFileSync(CATALOG_JSON, "utf8"))
+  const actual = emitOpenCodeBlockFromCatalog(catalog)
+
+  if (expected !== actual) {
+    // Print a targeted diff before the assertion fails.
+    // eslint-disable-next-line no-console
+    console.error(firstMismatchReport(expected, actual))
+  }
+  assert.strictEqual(
+    actual,
+    expected,
+    "emitted OpenCode block does not match the shipped opencode.jsonc byte-for-byte",
+  )
+})

--- a/integrations/providers/usai/tests/fixtures/models-dev.json
+++ b/integrations/providers/usai/tests/fixtures/models-dev.json
@@ -1,0 +1,125 @@
+{
+  "amazon-bedrock": {
+    "id": "amazon-bedrock",
+    "name": "Amazon Bedrock",
+    "models": {
+      "anthropic.claude-opus-4-8": {
+        "id": "anthropic.claude-opus-4-8",
+        "name": "Claude 4.8 Opus",
+        "limit": { "context": 1000000, "output": 128000 },
+        "cost": { "input": 5, "output": 25, "cache_read": 0.5, "cache_write": 6.25 }
+      },
+      "anthropic.claude-opus-4-7": {
+        "id": "anthropic.claude-opus-4-7",
+        "name": "Claude 4.7 Opus",
+        "limit": { "context": 1000000, "output": 128000 },
+        "cost": { "input": 5, "output": 25, "cache_read": 0.5, "cache_write": 6.25 }
+      },
+      "anthropic.claude-sonnet-4-6": {
+        "id": "anthropic.claude-sonnet-4-6",
+        "name": "Claude 4.6 Sonnet",
+        "limit": { "context": 1000000, "output": 64000 },
+        "cost": { "input": 3, "output": 15, "cache_read": 0.3, "cache_write": 3.75 }
+      },
+      "anthropic.claude-haiku-4-5": {
+        "id": "anthropic.claude-haiku-4-5",
+        "name": "Claude 4.5 Haiku",
+        "limit": { "context": 200000, "output": 64000 },
+        "cost": { "input": 1, "output": 5, "cache_read": 0.1, "cache_write": 1.25 }
+      },
+      "anthropic.claude-opus-4-5": {
+        "id": "anthropic.claude-opus-4-5",
+        "name": "Claude 4.5 Opus",
+        "limit": { "context": 200000, "output": 64000 },
+        "cost": { "input": 5, "output": 25, "cache_read": 0.5, "cache_write": 6.25 }
+      },
+      "anthropic.claude-sonnet-4-5": {
+        "id": "anthropic.claude-sonnet-4-5",
+        "name": "Claude 4.5 Sonnet",
+        "limit": { "context": 200000, "output": 64000 },
+        "cost": { "input": 3, "output": 15, "cache_read": 0.3, "cache_write": 3.75 }
+      },
+      "us.meta.llama4-maverick": {
+        "id": "us.meta.llama4-maverick",
+        "name": "Llama 4 Maverick",
+        "limit": { "context": 1000000, "output": 16384 },
+        "cost": { "input": 0.24, "output": 0.97 }
+      }
+    }
+  },
+  "azure": {
+    "id": "azure",
+    "name": "Azure OpenAI",
+    "models": {
+      "gpt-5.5": {
+        "id": "gpt-5.5",
+        "name": "GPT 5.5",
+        "limit": { "context": 1050000, "output": 128000 },
+        "cost": {
+          "input": 5,
+          "output": 30,
+          "cache_read": 0.5,
+          "context_over_200k": { "input": 10, "output": 45, "cache_read": 1 }
+        }
+      },
+      "gpt-5.4": {
+        "id": "gpt-5.4",
+        "name": "GPT 5.4",
+        "limit": { "context": 1050000, "output": 128000 },
+        "cost": {
+          "input": 2.5,
+          "output": 15,
+          "cache_read": 0.25,
+          "context_over_200k": { "input": 5, "output": 22.5, "cache_read": 0.5 }
+        }
+      },
+      "gpt-5.2": {
+        "id": "gpt-5.2",
+        "name": "GPT 5.2",
+        "limit": { "context": 400000, "output": 128000 },
+        "cost": { "input": 1.75, "output": 14, "cache_read": 0.125 }
+      }
+    }
+  },
+  "google-vertex": {
+    "id": "google-vertex",
+    "name": "Google Vertex",
+    "models": {
+      "gemini-2.5-flash": {
+        "id": "gemini-2.5-flash",
+        "name": "Gemini 2.5 Flash",
+        "limit": { "context": 1048576, "output": 65536 },
+        "cost": { "input": 0.3, "output": 2.5, "cache_read": 0.075, "cache_write": 0.383 }
+      },
+      "gemini-2.5-flash-lite": {
+        "id": "gemini-2.5-flash-lite",
+        "name": "Gemini 2.5 Flash Lite",
+        "limit": { "context": 1048576, "output": 65536 },
+        "cost": { "input": 0.1, "output": 0.4, "cache_read": 0.01 }
+      },
+      "gemini-2.5-pro": {
+        "id": "gemini-2.5-pro",
+        "name": "Gemini 2.5 Pro",
+        "limit": { "context": 1048576, "output": 65536 },
+        "cost": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125,
+          "context_over_200k": { "input": 2.5, "output": 15, "cache_read": 0.25 }
+        }
+      }
+    }
+  },
+  "cohere": {
+    "id": "cohere",
+    "name": "Cohere",
+    "models": {
+      "command-english-v3": {
+        "id": "command-english-v3",
+        "name": "Cohere English v3",
+        "limit": { "context": 128000, "output": 4000 },
+        "cost": { "input": 0.0375, "output": 0.15 }
+      }
+    }
+  }
+}

--- a/integrations/providers/usai/tests/fixtures/models-list.json
+++ b/integrations/providers/usai/tests/fixtures/models-list.json
@@ -1,0 +1,19 @@
+{
+  "object": "list",
+  "data": [
+    { "id": "claude_4_8_opus", "owned_by": "Anthropic" },
+    { "id": "claude_4_7_opus", "owned_by": "Anthropic" },
+    { "id": "claude_4_6_sonnet", "owned_by": "Anthropic" },
+    { "id": "claude_4_5_haiku", "owned_by": "Anthropic" },
+    { "id": "claude_4_5_opus", "owned_by": "Anthropic" },
+    { "id": "claude_4_5_sonnet", "owned_by": "Anthropic" },
+    { "id": "gpt-5.5-latest-guardrails-defaultv2", "owned_by": "OpenAI" },
+    { "id": "gpt-5.4-latest-guardrails-defaultv2", "owned_by": "OpenAI" },
+    { "id": "gpt-5.2-latest-guardrails-defaultv2", "owned_by": "OpenAI" },
+    { "id": "gemini-2.5-flash", "owned_by": "Google" },
+    { "id": "gemini-2.5-flash-lite", "owned_by": "Google" },
+    { "id": "gemini-2.5-pro", "owned_by": "Google" },
+    { "id": "llama_4_maverick", "owned_by": "Meta" },
+    { "id": "cohere_english_v3", "owned_by": "Cohere" }
+  ]
+}

--- a/integrations/providers/usai/tests/prime-agent.test.mjs
+++ b/integrations/providers/usai/tests/prime-agent.test.mjs
@@ -1,0 +1,143 @@
+// =============================================================================
+// prime-agent.test.mjs — shape + no-secret + no-leakage tests for the
+// prime-agent emitter.
+//
+// The prime-agent kit consumes a models.json where providers.usai.models is an
+// ARRAY of objects (each with an `id`), with flat contextWindow/maxTokens and
+// camelCase cost keys. These tests assert the emitter produces THAT shape and
+// specifically does NOT leak the OpenCode shape (limit object, snake_case cost
+// keys, context_over_200k), does NOT embed any real key material, and drops the
+// tiered costAbove200kContext field that prime-agent cannot represent.
+//
+// Reads the REAL shipped catalog.json via a relative path so catalog drift is
+// exercised by these assertions too.
+// =============================================================================
+
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+import { test } from "node:test"
+
+import { emitPrimeAgentModelsFromCatalog } from "../emitters/prime-agent.mjs"
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+const USAI_DIR = path.resolve(HERE, "..")
+const CATALOG_JSON = path.join(USAI_DIR, "catalog.json")
+
+const catalog = JSON.parse(readFileSync(CATALOG_JSON, "utf8"))
+
+// Emitter returns a serialized string; tests parse it back for structural
+// assertions AND scan the raw string for leakage / secrets.
+const serialized = emitPrimeAgentModelsFromCatalog(catalog)
+const doc = JSON.parse(serialized)
+const provider = doc.providers.usai
+
+test("emits a ready-to-write JSON string (2-space indent, trailing newline)", () => {
+  assert.equal(typeof serialized, "string")
+  assert.ok(serialized.endsWith("\n"), "output must end with a trailing newline")
+  // 2-space indent: the first nested key is indented by exactly 2 spaces.
+  assert.match(serialized, /\n {2}"providers": \{/)
+  // Round-trips as valid JSON with no trailing garbage.
+  assert.deepEqual(JSON.parse(serialized), doc)
+})
+
+test("prime-agent ARRAY shape: providers.usai.models is an array; each has an id", () => {
+  assert.ok(Array.isArray(provider.models), "providers.usai.models must be an array")
+  for (const m of provider.models) {
+    assert.equal(typeof m.id, "string")
+    assert.ok(m.id.length > 0, "every model must carry a non-empty id")
+    assert.equal(typeof m.name, "string")
+    assert.equal(typeof m.contextWindow, "number")
+    assert.equal(typeof m.maxTokens, "number")
+    assert.equal(typeof m.cost, "object")
+  }
+})
+
+test("provider-level fields map from catalog.gateway + authHeader constant", () => {
+  assert.equal(provider.baseUrl, catalog.gateway.baseUrl)
+  assert.equal(provider.api, catalog.gateway.api)
+  assert.equal(provider.authHeader, true)
+})
+
+test("model count matches the catalog (14)", () => {
+  assert.equal(provider.models.length, 14)
+  assert.equal(provider.models.length, catalog.models.length)
+})
+
+test("preserves catalog (vendor-grouped) model order", () => {
+  assert.deepEqual(
+    provider.models.map((m) => m.id),
+    catalog.models.map((m) => m.id),
+  )
+})
+
+test("maxTokens maps from catalog.maxOutputTokens", () => {
+  for (let i = 0; i < provider.models.length; i++) {
+    assert.equal(provider.models[i].maxTokens, catalog.models[i].maxOutputTokens)
+  }
+})
+
+test("NO OpenCode-shaped leakage (no limit object, no snake_case cost, no context_over_200k)", () => {
+  // Structural: no model carries a `limit` object; cost uses camelCase only.
+  for (const m of provider.models) {
+    assert.equal(m.limit, undefined, "prime-agent has flat contextWindow, not a limit object")
+    assert.equal(m.cost.cache_read, undefined, "cost must use camelCase cacheRead, not snake_case")
+    assert.equal(m.cost.cache_write, undefined, "cost must use camelCase cacheWrite, not snake_case")
+    assert.equal(m.cost.context_over_200k, undefined, "no OpenCode context_over_200k nesting")
+  }
+  // Textual: none of the OpenCode-shaped tokens appear anywhere in the output.
+  assert.doesNotMatch(serialized, /"limit"/)
+  assert.doesNotMatch(serialized, /cache_read/)
+  assert.doesNotMatch(serialized, /cache_write/)
+  assert.doesNotMatch(serialized, /context_over_200k/)
+})
+
+test("costAbove200kContext is dropped (tiered models carry no such field)", () => {
+  // Sanity: these three DO carry the tiered field in the source catalog.
+  const tieredIds = [
+    "gpt-5.5-latest-guardrails-defaultv2",
+    "gpt-5.4-latest-guardrails-defaultv2",
+    "gemini-2.5-pro",
+  ]
+  for (const id of tieredIds) {
+    const src = catalog.models.find((m) => m.id === id)
+    assert.ok(src && src.costAbove200kContext, `catalog fixture must have tiered pricing for ${id}`)
+    const out = provider.models.find((m) => m.id === id)
+    assert.ok(out, `emitted output must still contain ${id}`)
+    assert.equal(out.costAbove200kContext, undefined, `costAbove200kContext must be dropped for ${id}`)
+  }
+  // And no model anywhere retains the field.
+  for (const m of provider.models) {
+    assert.equal(m.costAbove200kContext, undefined)
+  }
+  assert.doesNotMatch(serialized, /costAbove200kContext/)
+})
+
+test("cacheWrite preserved where the catalog has it (claude models + gemini-flash)", () => {
+  const withCacheWrite = catalog.models.filter((m) => m.cost && "cacheWrite" in m.cost)
+  // Guard the fixture assumption: claude models + gemini-2.5-flash carry it.
+  assert.ok(withCacheWrite.length >= 7, "fixture should have cacheWrite on 6 claude + gemini-flash")
+  for (const src of withCacheWrite) {
+    const out = provider.models.find((m) => m.id === src.id)
+    assert.equal(out.cost.cacheWrite, src.cost.cacheWrite, `cacheWrite preserved for ${src.id}`)
+  }
+  // Spot-check gemini-2.5-flash specifically (the non-claude cacheWrite carrier).
+  const flash = provider.models.find((m) => m.id === "gemini-2.5-flash")
+  assert.equal(flash.cost.cacheWrite, 0.383)
+})
+
+test("apiKey is the env-var NAME, and NO real key material appears anywhere", () => {
+  // apiKey must be the NAME of an env var, exactly as declared in the catalog.
+  assert.equal(provider.apiKey, "USAI_API_KEY")
+  assert.equal(provider.apiKey, catalog.gateway.apiKeyEnv)
+
+  // No value that looks like a real secret leaked into the serialized output:
+  //  - no `api-key-`/`sk-`/`Bearer ` prefixed strings,
+  //  - no long base64-ish/hex blob that would look like a token.
+  assert.doesNotMatch(serialized, /api-key-/i)
+  assert.doesNotMatch(serialized, /\bsk-[A-Za-z0-9]/)
+  assert.doesNotMatch(serialized, /Bearer\s+\S/i)
+  assert.doesNotMatch(serialized, /[A-Za-z0-9+/]{32,}={0,2}/, "no long base64-ish secret blob")
+  assert.doesNotMatch(serialized, /\b[0-9a-f]{32,}\b/i, "no long hex secret blob")
+})


### PR DESCRIPTION
The **MVP core** of the harness-neutral USAi model catalog (epic #357). **Purely additive** under `integrations/providers/usai/` — the shipped `usai-provider` `opencode.jsonc` and every kit are untouched (Phase A: nothing consumes the catalog yet). Built by fan-out subagents, orchestrator-verified; 3/3 consensus.

## What's here (4 issues)
- **#358** — `catalog.schema.json` (`usai-model-catalog/v1`, draft 2020-12, `additionalProperties:false` everywhere; `apiKeyEnv` pattern-constrained to an env-var NAME) + `README.md` + `package.json`.
- **#359** — `build-catalog.mjs`: fetches USAi `/models` + models.dev, vendor-classifies, backend-routes, neutral-shapes → `catalog.json`. Bounded fetch (15s/size-cap/shape-validate). **Offline/CI mode** (`--models-url`/`--models-dev`/`--no-enrichment`) runs against committed fixtures with no network; `--check` fails on drift. Default bootstraps from the shipped `opencode.jsonc` GENERATED block. Hand-rolled validator — **no new npm dep**. `catalog.json` = **14 models** (matches the block; the epic's "15" was an over-estimate), tiered `costAbove200kContext` on gpt-5.5/5.4/gemini-2.5-pro.
- **#360** — `emitters/opencode.mjs` + **byte-exact round-trip test**: regenerates the shipped `BEGIN/END GENERATED USAI MODELS` block from `catalog.json` and asserts it equals the **real** file byte-for-byte. This is the load-bearing guarantee that the catalog losslessly represents production.
- **#361** — `emitters/prime-agent.mjs` (array shape, `maxTokens`, drops tiered pricing) + shape/no-secret tests (`apiKey`=env-var NAME, no key material, no OpenCode leakage). Feeds the prime-agent kit's `models.json` (#362).

## Verification (orchestrator, first-hand)
- `make test-kits` green — **11/11** (byte-exact OpenCode round-trip + 10 prime-agent subtests).
- **Tamper check:** perturbing one price in `catalog.json` flips the round-trip test to FAIL at a precise offset — the guard has teeth.
- `make validate` green; `build-catalog --check` up to date; `jsonschema` VALID. Node 22 stdlib only.

## Not in this PR (tracked)
- **#362** generate+commit the prime-agent kit's `models.json` (lands on the prime-agent kit branch, consuming this emitter).
- **Later:** #363 sync-script cutover (gated on this round-trip test), #364 more emitters, #365 default-model, #366 reasoning/modalities, #367 sbx-kit 2nd round-trip.

Refs #357 #358 #359 #360 #361

AI-assisted (OpenCode).