### PR TITLE
chore(kits): bump openchamber to v1.20.0 and paseo to 0.5.2

### DIFF
--- a/docs/repository-ecosystem.md
+++ b/docs/repository-ecosystem.md
@@ -217,8 +217,8 @@ workflows where an agent can reference one repo while editing another.
 - **Playbook** defines standards that may be referenced from other repos
 
 For command syntax and examples, see the quickstart guide's
-[Quick Start](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/QUICKSTART.md)
-and its [Multiple Workspaces](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/QUICKSTART_SBX.md#multiple-workspaces)
+[Quick Start](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/howto/acq.md#quick-start)
+and its [Multiple Workspaces](https://github.com/GSA-TTS/agentic-coding-quickstart/blob/main/docs/howto/sbx.md#multiple-workspaces)
 section.
 
 ### Security Best Practice

--- a/integrations/isolation/acq-kits/openchamber/files/home/openchamber-start.sh
+++ b/integrations/isolation/acq-kits/openchamber/files/home/openchamber-start.sh
@@ -98,8 +98,8 @@ if ! command -v openchamber >/dev/null 2>&1; then
   # and the fetch path may be MITM-inspected, so a tag alone is not enough. On
   # mismatch, skip install (UI unavailable) rather than pipe unverified bytes to
   # bash.
-  _ref="${OPENCHAMBER_REF:-v1.9.10}"
-  _want_sha="${OPENCHAMBER_INSTALL_SHA256:-aa268c96ddc6d7d53fc54d2e5c2312e689493ecef6ba4f69730a93d50cf33287}"
+  _ref="${OPENCHAMBER_REF:-v1.20.0}"
+  _want_sha="${OPENCHAMBER_INSTALL_SHA256:-964df00e6b163fefdc8ae0a10608a764bbb326a3d076d1d2fd9af65dbe4e1b34}"
   _installer="$HOME/.local/state/openchamber/install.sh"
   if curl -fsSL "https://raw.githubusercontent.com/openchamber/openchamber/$_ref/scripts/install.sh" \
        -o "$_installer" 2>/tmp/openchamber-install.log; then

--- a/integrations/isolation/acq-kits/openchamber/spec.yaml
+++ b/integrations/isolation/acq-kits/openchamber/spec.yaml
@@ -159,8 +159,8 @@ commands:
       - sh
       - -c
       - |
-        OPENCHAMBER_REF="v1.9.10" \
-        OPENCHAMBER_INSTALL_SHA256="aa268c96ddc6d7d53fc54d2e5c2312e689493ecef6ba4f69730a93d50cf33287" \
+        OPENCHAMBER_REF="v1.20.0" \
+        OPENCHAMBER_INSTALL_SHA256="964df00e6b163fefdc8ae0a10608a764bbb326a3d076d1d2fd9af65dbe4e1b34" \
           sh /home/agent/openchamber-start.sh &
 
 # Neutral published ports (schema hybrid/v1, added in #276). Publish the two

--- a/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
+++ b/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
@@ -31,7 +31,7 @@
 #
 # Pins are provided via the environment, with an in-script fallback default kept
 # in sync with the kit spec's documented pin:
-#   PASEO_CLI_VERSION   — @getpaseo/cli version to install (default 0.4.0)
+#   PASEO_CLI_VERSION   — @getpaseo/cli version to install (default 0.5.2)
 #   PASEO_LISTEN        — daemon bind address (default 0.0.0.0:6767)
 #   PASEO_RESTART_DELAY — seconds to wait before respawning the daemon (default 5)
 
@@ -72,7 +72,7 @@ export PATH
 
 # --- Install the Paseo CLI if it isn't present yet (first boot). -------------
 if ! command -v paseo >/dev/null 2>&1; then
-  _ver="${PASEO_CLI_VERSION:-0.4.0}"
+  _ver="${PASEO_CLI_VERSION:-0.5.2}"
   # Route npm through the sandbox proxy. npm honors HTTP(S)_PROXY automatically,
   # but be explicit so any Node-side downloads (none expected for the sherpa
   # prebuilt, which is a plain npm tarball) also proxy.

--- a/integrations/isolation/acq-kits/paseo/spec.yaml
+++ b/integrations/isolation/acq-kits/paseo/spec.yaml
@@ -182,7 +182,7 @@ commands:
       - sh
       - -c
       - |
-        PASEO_CLI_VERSION="0.4.0" \
+        PASEO_CLI_VERSION="0.5.2" \
           sh /home/agent/paseo-start.sh &
 
 # Neutral published port (schema hybrid/v1). Publish the single container/guest


### PR DESCRIPTION
## Summary

Updates both acq mixin kits under `integrations/isolation/acq-kits/` to the latest upstream releases.

| Kit | Old | New | Mechanism |
|-----|-----|-----|-----------|
| openchamber | `v1.9.10` | `v1.20.0` | git tag + installer SHA-256 |
| paseo (`@getpaseo/cli`) | `0.4.0` | `0.5.2` | npm package version |

## Changes

- **openchamber** — bumped `OPENCHAMBER_REF` and re-verified `OPENCHAMBER_INSTALL_SHA256` (`964df00e...e1b34`, computed by fetching `install.sh` from the `v1.20.0` tag). Updated in both the authoritative `spec.yaml` and the matching start-script fallback default.
- **paseo** — bumped `PASEO_CLI_VERSION` in both `spec.yaml` and the start-script fallback default (plus its doc comment).

Each kit documents that the spec pin and the script fallback must be bumped together; both were updated in each case.

## Verification

- OpenChamber installer SHA-256 re-computed from the pinned `v1.20.0` tag to update the integrity pin (per the pin-and-verify design).
- Both kits verified on host by the requester.

## Rollback

Revert this commit to restore openchamber `v1.9.10` (SHA `aa268c96...cf33287`) and paseo `0.4.0`.

## Security Impact

No change to attack surface. OpenChamber's install remains SHA-256 integrity-pinned; the pin was re-verified against the new tag rather than loosened.

## AI Attribution

AI-assisted (OpenCode). Human ownership and host verification by the requester.