### PR TITLE
chore(deps): bump ruff to 0.16.3 across pyproject and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: gitleaks
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 7c55798a78262d14b2074abf623d8a992ebb70d4  # v0.16.2
+    rev: 65dbdb59d2f2d9c3bdc343c566821ad3319ddaa3  # v0.16.3
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 dev = [
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
-    "ruff==0.16.2",
+    "ruff==0.16.3",
     "pre-commit==4.6.2",
     "pip-audit==2.10.1",
 ]


### PR DESCRIPTION
## Context
Dependabot opened two PRs that each bump only one side of the ruff version pin:
- #376 bumped `ruff` in `pyproject.toml` to 0.16.3
- #377 bumped the `ruff-pre-commit` hook rev to v0.16.3

Neither passes CI alone because the `test_ruff_pins_match` lockstep guard (#339) requires the `pyproject.toml` `ruff==` pin and the `.pre-commit-config.yaml` ruff-pre-commit `rev` to match. Each single-sided bump produces version drift and fails `Python Lint & Test` + `Python 3.12 Compatibility`.

## Plan
This PR combines both halves so both pins land at 0.16.3 simultaneously:
- `pyproject.toml`: `ruff==0.16.3`
- `.pre-commit-config.yaml`: ruff-pre-commit `rev` 65dbdb5 `# v0.16.3`

Supersedes #376 and #377, which can be closed once this merges.

## Verification
- `test_ruff_pin_lockstep.py::test_ruff_pins_match` now sees matching versions (0.16.3 == 0.16.3). Full CI suite runs on this PR.

## Rollback
Revert this commit to return both pins to 0.16.2.

## Security Impact
None. Dev-tooling version bump only; no runtime code, auth, or data-handling changes.

Co-authored-by: OpenCode Agent <agent@gsa.gov>