### PR TITLE
fix(paseo): keep npm cache agent-owned

### DIFF
--- a/integrations/isolation/acq-kits/paseo/TROUBLESHOOTING.md
+++ b/integrations/isolation/acq-kits/paseo/TROUBLESHOOTING.md
@@ -72,8 +72,10 @@ curl http://127.0.0.1:16767/
 ```
 
 The host side of the mapping stays loopback-only either way, so the `0.0.0.0`
-in-guest bind does not widen host exposure. See
-[GSA-TTS/agentic-coding-quickstart#333](https://github.com/GSA-TTS/agentic-coding-quickstart/pull/333).
+in-guest bind does not widen host exposure. The important distinction is which
+side of the boundary dials the guest port: create-time publishing dials the guest
+network IP, while post-hoc publishing tunnels from inside the guest and can reach
+guest loopback.
 
 ## "No hosts configured" and/or a repeating `ws://…/ws` connect loop
 

--- a/integrations/isolation/acq-kits/paseo/TROUBLESHOOTING.md
+++ b/integrations/isolation/acq-kits/paseo/TROUBLESHOOTING.md
@@ -276,13 +276,13 @@ Common causes:
   inspection CA. Pair with the `zscaler-ca-certificate` kit; the startup script
   folds `PROXY_CA_CERT_B64` + the system trust store into `NODE_EXTRA_CA_CERTS`.
 
-- **npm global prefix permissions.** On the default sandbox template the global
-  prefix is root-owned, so the script installs via `sudo -n`. If sudo is
-  unavailable (a plain-OCI base), it falls back to a per-user prefix at
-  `~/.npm-global`. Verify which took effect:
+- **npm global prefix permissions.** On the default sandbox template the system
+  global prefix is root-owned, so the script installs Paseo into the agent-owned
+  per-user prefix at `~/.npm-global` and uses the agent-owned cache at `~/.npm`.
+  Verify the per-user install path:
 
   ```bash
-  acq exec <sandbox> -- sh -c 'ls -la ~/.npm-global/bin 2>/dev/null; ls -la "$(npm prefix -g 2>/dev/null)/bin" 2>/dev/null | grep -i paseo'
+  acq exec <sandbox> -- sh -c 'ls -la ~/.npm-global/bin 2>/dev/null; command -v paseo'
   ```
 
 ## Worktrees aren't landing under my project

--- a/integrations/isolation/acq-kits/paseo/docs/decisions/install-at-startup.md
+++ b/integrations/isolation/acq-kits/paseo/docs/decisions/install-at-startup.md
@@ -39,9 +39,9 @@ hook.** `paseo-start.sh` installs the CLI on first boot only (guarded by
   the sandbox proxy CA (`PROXY_CA_CERT_B64`) + the system trust store, so the
   install works behind an inspecting proxy (e.g. Zscaler).
 - On the default sandbox-template base the npm global prefix is root-owned, so
-  the install runs via `sudo -n env …` (forwarding proxy + CA + HOME), with a
-  per-user `npm_config_prefix` fallback when sudo is unavailable (plain-OCI
-  override).
+  the install uses an agent-owned npm prefix (`$HOME/.npm-global`) and cache
+  (`$HOME/.npm`) instead of `sudo npm`. That keeps all npm-written files owned by
+  the agent user and avoids privileged package installation.
 - A failed install degrades to "UI unavailable" (`|| true` + an early `exit 0`
   after the `command -v paseo` guard); it never fails the sandbox.
 

--- a/integrations/isolation/acq-kits/paseo/docs/decisions/install-at-startup.md
+++ b/integrations/isolation/acq-kits/paseo/docs/decisions/install-at-startup.md
@@ -30,9 +30,9 @@ in a create-time hook would risk crashing sandbox create over an optional UI.
 ## Decision
 
 **Do the install in the `startup` phase (backgrounded), never a create-time
-hook.** `paseo-start.sh` installs the CLI on first boot only (guarded by
-`command -v paseo`), then supervises the daemon. There is deliberately no
-`install` phase.
+hook.** `paseo-start.sh` installs the pinned CLI when it is missing or when the
+installed `paseo --version` differs from `PASEO_CLI_VERSION`, then supervises the
+daemon. There is deliberately no `install` phase.
 
 - The startup script routes npm through the sandbox proxy
   (`HTTP(S)_PROXY`/`npm_config_*`) and builds a `NODE_EXTRA_CA_CERTS` bundle from
@@ -43,7 +43,7 @@ hook.** `paseo-start.sh` installs the CLI on first boot only (guarded by
   (`$HOME/.npm`) instead of `sudo npm`. That keeps all npm-written files owned by
   the agent user and avoids privileged package installation.
 - A failed install degrades to "UI unavailable" (`|| true` + an early `exit 0`
-  after the `command -v paseo` guard); it never fails the sandbox.
+  after the final `command -v paseo` guard); it never fails the sandbox.
 
 ## Why no SHA-pinned installer (unlike openchamber)
 
@@ -58,7 +58,8 @@ from the trusted npm registry over the proxied, allow-listed egress).
 
 - `acq create` can never be taken down by a Paseo install failure.
 - First boot pays a one-time npm install cost (a few seconds) before the UI is
-  reachable; later starts skip it (guarded by `command -v paseo`).
+  reachable; later starts skip it unless the installed CLI version differs from
+  `PASEO_CLI_VERSION`.
 - Adopting a newer Paseo release is a two-value edit (`PASEO_CLI_VERSION` in
   `spec.yaml` + the fallback default in `paseo-start.sh`).
 - The kit's only egress is `registry.npmjs.org`.

--- a/integrations/isolation/acq-kits/paseo/docs/decisions/prepopulate-projects-from-mounts.md
+++ b/integrations/isolation/acq-kits/paseo/docs/decisions/prepopulate-projects-from-mounts.md
@@ -44,8 +44,8 @@ for a bad path instead of throwing.
 The helper imports the CLI's **own** connector
 (`<cli-pkg>/dist/utils/client.js` → `connectToDaemon`), resolving the CLI package
 dir portably from the `paseo` bin symlink (`readlink`/`realpath` of
-`command -v paseo`, then two levels up). This works under both the sudo-global
-npm prefix and the no-sudo `~/.npm-global` fallback the install path uses, and
+`command -v paseo`, then two levels up). This works under both an existing global
+npm install and the agent-owned `~/.npm-global` install path the kit uses, and
 reuses the same socket/localhost daemon resolution the CLI itself uses (no
 host/port needed here).
 

--- a/integrations/isolation/acq-kits/paseo/files/home/paseo-register-mounts.mjs
+++ b/integrations/isolation/acq-kits/paseo/files/home/paseo-register-mounts.mjs
@@ -27,8 +27,8 @@
 // We import the CLI's OWN connector (dist/utils/client.js -> connectToDaemon) so
 // we reuse its socket/localhost resolution and need no host/port here. The CLI
 // package dir is resolved portably from the `paseo` bin symlink, so this works
-// whether the CLI was installed into the sudo-global npm prefix OR the no-sudo
-// per-user ~/.npm-global fallback (see paseo-start.sh).
+// whether the CLI was already present in the default global npm prefix or was
+// installed into the kit's per-user ~/.npm-global prefix (see paseo-start.sh).
 //
 // WHICH MOUNTS COUNT (backend-agnostic — no reliance on the source-name token,
 // which is a per-path hash on msb and the literal "host" on sbx, i.e. NOT a

--- a/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
+++ b/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
@@ -55,9 +55,12 @@ PASEO_PORT="$(printf '%s' "$PASEO_LISTEN" | sed -n 's/.*:\([0-9][0-9]*\)$/\1/p')
 REGISTER_MOUNTS_SCRIPT="${HOME}/paseo-register-mounts.mjs"
 
 # npm global installs land in this prefix's bin, which is NOT on the startup
-# shell's PATH by default. Put it on PATH up front so a freshly-installed `paseo`
-# resolves in THIS shell (otherwise the post-install `command -v paseo` guard
-# trips and the supervisor section never runs on first boot).
+# shell's PATH by default. Put both possible bins on PATH up front so a
+# freshly-installed `paseo` resolves in THIS shell (otherwise the post-install
+# `command -v paseo` guard trips and the supervisor section never runs on first
+# boot). `$HOME/.npm-global/bin` is the intended Paseo install location; the
+# default global prefix remains present so an existing globally-installed Paseo in
+# an older sandbox still resolves.
 #
 # SCOPE LIMIT — this PATH addition is PROCESS-LOCAL. It cannot be persisted for
 # other, later `acq exec … sh -c '…'` invocations from here: this script runs as
@@ -68,6 +71,7 @@ REGISTER_MOUNTS_SCRIPT="${HOME}/paseo-register-mounts.mjs"
 # PATH themselves; the verify script's in_sbx() does exactly that.
 NPM_BIN="$(npm prefix -g 2>/dev/null)/bin"
 case ":$PATH:" in *":$NPM_BIN:"*) : ;; *) PATH="$NPM_BIN:$PATH" ;; esac
+case ":$PATH:" in *":$HOME/.npm-global/bin:"*) : ;; *) PATH="$HOME/.npm-global/bin:$PATH" ;; esac
 export PATH
 
 # --- Install the Paseo CLI if it isn't present yet (first boot). -------------
@@ -103,36 +107,17 @@ if ! command -v paseo >/dev/null 2>&1; then
   [ -n "${PROXY_CA_CERT_B64:-}" ] && printf %s "$PROXY_CA_CERT_B64" | base64 -d >> "$_ca" 2>/dev/null
   [ -f /etc/ssl/certs/ca-certificates.crt ] && cat /etc/ssl/certs/ca-certificates.crt >> "$_ca"
   [ -s "$_ca" ] && export NODE_EXTRA_CA_CERTS="$_ca"
-  # On the sbx-template base the npm global prefix's lib/ dir is ROOT-owned (the
-  # template provisions global tooling as root), so the agent's `npm install -g`
-  # fails EACCES. Run the install via `sudo -n` (the agent has passwordless sudo
-  # on the template). The sudoers env_keep covers HTTP(S)_PROXY/NO_PROXY but NOT
-  # NODE_EXTRA_CA_CERTS (bare sudo resets it), so forward proxy + CA + HOME
-  # explicitly via `sudo env`. HOME keeps npm cache/config in the agent home
-  # rather than /root. The `${VAR:+NAME=...}` idiom omits an arg entirely when the
-  # var is empty/unset (safe under set -u). When sudo is unavailable (a plain-OCI
-  # override without the template's sudo), fall back to an agent-owned per-user
-  # npm prefix so the global install needs no root.
-  if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-    sudo -n env \
-      npm_config_user_agent="${npm_config_user_agent:-npm}" \
-      npm_config_ignore_scripts="${npm_config_ignore_scripts:-true}" \
-      ${npm_config_https_proxy:+npm_config_https_proxy="$npm_config_https_proxy"} \
-      ${npm_config_proxy:+npm_config_proxy="$npm_config_proxy"} \
-      ${NODE_EXTRA_CA_CERTS:+NODE_EXTRA_CA_CERTS="$NODE_EXTRA_CA_CERTS"} \
-      ONNXRUNTIME_NODE_INSTALL="${ONNXRUNTIME_NODE_INSTALL:-skip}" \
-      HOME="$HOME" \
-      npm install -g "@getpaseo/cli@${_ver}" >>"$HOME/.local/state/paseo/paseo-install.log" 2>&1 || true
-  else
-    export npm_config_prefix="$HOME/.npm-global"
-    mkdir -p "$HOME/.npm-global"
-    # NPM_BIN (above) was computed from the DEFAULT global prefix, so the
-    # `command -v paseo` guard below and the supervisor probe would otherwise
-    # never see a package installed under this per-user prefix. Prepend it.
-    case ":$PATH:" in *":$HOME/.npm-global/bin:"*) : ;; *) PATH="$HOME/.npm-global/bin:$PATH" ;; esac
-    export PATH
-    npm install -g "@getpaseo/cli@${_ver}" >>"$HOME/.local/state/paseo/paseo-install.log" 2>&1 || true
-  fi
+  # On the sbx-template base the default npm global prefix's lib/ dir is
+  # root-owned (the template provisions global tooling as root), so installing
+  # there as the agent fails EACCES. Do NOT use `sudo npm`: npm resolves its cache
+  # from HOME, and root + HOME=/home/agent creates root-owned files in the agent's
+  # ~/.npm cache. Install into an agent-owned per-user prefix/cache instead. The
+  # package is still invoked as a global install, but all files it writes are owned
+  # by the agent user and lifecycle scripts remain disabled above.
+  export npm_config_prefix="$HOME/.npm-global"
+  export npm_config_cache="$HOME/.npm"
+  mkdir -p "$HOME/.npm-global" "$HOME/.npm"
+  npm install -g "@getpaseo/cli@${_ver}" >>"$HOME/.local/state/paseo/paseo-install.log" 2>&1 || true
 fi
 command -v paseo >/dev/null 2>&1 || {
   # Route the marker to BOTH the log and stderr. This is written for ANY

--- a/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
+++ b/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
@@ -31,7 +31,7 @@
 #
 # Pins are provided via the environment, with an in-script fallback default kept
 # in sync with the kit spec's documented pin:
-#   PASEO_CLI_VERSION   — @getpaseo/cli version to install (default 0.6.1)
+#   PASEO_CLI_VERSION   — @getpaseo/cli version to install (default 0.7.0)
 #   PASEO_LISTEN        — daemon bind address (default 0.0.0.0:6767)
 #   PASEO_RESTART_DELAY — seconds to wait before respawning the daemon (default 5)
 
@@ -75,7 +75,7 @@ case ":$PATH:" in *":$HOME/.npm-global/bin:"*) : ;; *) PATH="$HOME/.npm-global/b
 export PATH
 
 # --- Install the pinned Paseo CLI if it is missing or out of date. -----------
-_ver="${PASEO_CLI_VERSION:-0.6.1}"
+_ver="${PASEO_CLI_VERSION:-0.7.0}"
 _installed_ver=""
 if command -v paseo >/dev/null 2>&1; then
   _installed_ver="$(paseo --version 2>/dev/null | sed -n 's/^v//; s/.*\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p; q')"

--- a/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
+++ b/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
@@ -118,10 +118,18 @@ if [ "$_installed_ver" != "$_ver" ]; then
   # ~/.npm cache. Install into an agent-owned per-user prefix/cache instead. The
   # package is still invoked as a global install, but all files it writes are owned
   # by the agent user and lifecycle scripts remain disabled above.
-  export npm_config_prefix="$HOME/.npm-global"
-  export npm_config_cache="$HOME/.npm"
+  #
+  # `--prefix`/`--cache` on the COMMAND LINE, not just npm_config_prefix/
+  # npm_config_cache env exports: verified live that this kit's own base image
+  # persistently exports an uppercase NPM_CONFIG_PREFIX, which npm's config
+  # precedence reads over a lowercase npm_config_prefix export — an env-only
+  # override would silently install back into the root-owned system prefix and
+  # fail EACCES, defeating this entire fix. A CLI flag always outranks any env
+  # var regardless of case, so it can't be silently shadowed the same way. Same
+  # pattern the sibling pi-coding-agent kit uses for the identical reason.
   mkdir -p "$HOME/.npm-global" "$HOME/.npm"
-  npm install -g "@getpaseo/cli@${_ver}" >>"$HOME/.local/state/paseo/paseo-install.log" 2>&1 || true
+  npm install -g --prefix "$HOME/.npm-global" --cache "$HOME/.npm" \
+    "@getpaseo/cli@${_ver}" >>"$HOME/.local/state/paseo/paseo-install.log" 2>&1 || true
 fi
 command -v paseo >/dev/null 2>&1 || {
   # Route the marker to BOTH the log and stderr. This is written for ANY

--- a/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
+++ b/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
@@ -31,7 +31,7 @@
 #
 # Pins are provided via the environment, with an in-script fallback default kept
 # in sync with the kit spec's documented pin:
-#   PASEO_CLI_VERSION   — @getpaseo/cli version to install (default 0.5.2)
+#   PASEO_CLI_VERSION   — @getpaseo/cli version to install (default 0.6.1)
 #   PASEO_LISTEN        — daemon bind address (default 0.0.0.0:6767)
 #   PASEO_RESTART_DELAY — seconds to wait before respawning the daemon (default 5)
 
@@ -76,7 +76,7 @@ export PATH
 
 # --- Install the Paseo CLI if it isn't present yet (first boot). -------------
 if ! command -v paseo >/dev/null 2>&1; then
-  _ver="${PASEO_CLI_VERSION:-0.5.2}"
+  _ver="${PASEO_CLI_VERSION:-0.6.1}"
   # Route npm through the sandbox proxy. npm honors HTTP(S)_PROXY automatically,
   # but be explicit so any Node-side downloads (none expected for the sherpa
   # prebuilt, which is a plain npm tarball) also proxy.

--- a/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
+++ b/integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# paseo-start.sh — install the Paseo CLI on first boot, then supervise the Paseo
+# paseo-start.sh — install/update the pinned Paseo CLI, then supervise the Paseo
 # daemon (which serves the API, the WebSocket, AND the bundled web UI on one port)
 # so it auto-restarts if it exits.
 #
@@ -26,8 +26,8 @@
 #
 # Runs as the agent user (whose uid is assigned at provision and is not
 # necessarily 1000) in the background on every sandbox start and is fully
-# idempotent: it installs the Paseo CLI only if missing, then starts a supervisor
-# for the daemon only if one isn't already running.
+# idempotent: it installs the pinned Paseo CLI only if missing or out of date,
+# then starts a supervisor for the daemon only if one isn't already running.
 #
 # Pins are provided via the environment, with an in-script fallback default kept
 # in sync with the kit spec's documented pin:
@@ -74,9 +74,13 @@ case ":$PATH:" in *":$NPM_BIN:"*) : ;; *) PATH="$NPM_BIN:$PATH" ;; esac
 case ":$PATH:" in *":$HOME/.npm-global/bin:"*) : ;; *) PATH="$HOME/.npm-global/bin:$PATH" ;; esac
 export PATH
 
-# --- Install the Paseo CLI if it isn't present yet (first boot). -------------
-if ! command -v paseo >/dev/null 2>&1; then
-  _ver="${PASEO_CLI_VERSION:-0.6.1}"
+# --- Install the pinned Paseo CLI if it is missing or out of date. -----------
+_ver="${PASEO_CLI_VERSION:-0.6.1}"
+_installed_ver=""
+if command -v paseo >/dev/null 2>&1; then
+  _installed_ver="$(paseo --version 2>/dev/null | sed -n 's/^v//; s/.*\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/p; q')"
+fi
+if [ "$_installed_ver" != "$_ver" ]; then
   # Route npm through the sandbox proxy. npm honors HTTP(S)_PROXY automatically,
   # but be explicit so any Node-side downloads (none expected for the sherpa
   # prebuilt, which is a plain npm tarball) also proxy.

--- a/integrations/isolation/acq-kits/paseo/scripts/verify
+++ b/integrations/isolation/acq-kits/paseo/scripts/verify
@@ -14,10 +14,11 @@
 #      web UI (on one port), the published port, that the LARGE UI bundle arrives
 #      byte-complete over the host port (identity encoding; integrity guard), the
 #      in-guest 0.0.0.0 bind (reachable via create-time publish) over the host port, the
-#      install ran with lifecycle scripts disabled (hardening #2), the respawn
-#      supervisor, the PID-1 hold, the worktree-root pin, daemon self-heal, and
-#      that projects are pre-populated from the mounted host dirs — including that
-#      a read-write extra workspace IS registered and a ":ro" one is SKIPPED.
+#      install ran with lifecycle scripts disabled (hardening #2), the npm cache
+#      remains agent-owned, the respawn supervisor, the PID-1 hold, the
+#      worktree-root pin, daemon self-heal, and that projects are pre-populated
+#      from the mounted host dirs — including that a read-write extra workspace IS
+#      registered and a ":ro" one is SKIPPED.
 #
 #      Preferred driver — RUN_ACQ=1: drive the `acq` CLI. acq translates the
 #      neutral hybrid/v1 spec to an sbx-v2 kit (kit_translate_to_sbx) and applies
@@ -108,7 +109,7 @@ trap cleanup EXIT INT TERM
 # PATH SCOPING: a bare `sh -c` sources nothing, so its PATH lacks the npm-global
 # bin (where `paseo` and the real `opencode` install) and ~/.local/bin (the
 # wrapper). Prepend them for every probe so PRESENT binaries resolve. Also
-# include $HOME/.npm-global/bin for the no-sudo install fallback.
+# include $HOME/.npm-global/bin for the per-user Paseo install path.
 in_sbx() {
   _wrapped='export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$(npm prefix -g 2>/dev/null)/bin:$PATH"; '"$1"
   case "${DRIVER:-}" in
@@ -541,6 +542,20 @@ else
     ok "paseo binary runs (\`paseo --version\`) — no required postinstall was skipped"
   else
     warn "\`paseo --version\` did not run cleanly; if the daemon is also down, a required lifecycle script may have been skipped — drop --ignore-scripts in paseo-start.sh"
+  fi
+fi
+
+info "6d. Hardening: npm cache remains agent-owned"
+# Regression guard for running npm as root while HOME=/home/agent: that creates
+# root-owned files under ~/.npm and later blocks ordinary agent npm commands.
+if [ -z "$installed" ]; then
+  skip "npm cache ownership check (Paseo CLI did not install)"
+else
+  bad_cache_owner="$(in_sbx 'if [ -d "$HOME/.npm" ]; then find "$HOME/.npm" -not -user "$(id -u)" -print -quit 2>/dev/null; fi')"
+  if [ -n "$bad_cache_owner" ]; then
+    bad "npm cache contains files not owned by the agent user: $bad_cache_owner"
+  else
+    ok "npm cache has no non-agent-owned files under ~/.npm"
   fi
 fi
 

--- a/integrations/isolation/acq-kits/paseo/scripts/verify
+++ b/integrations/isolation/acq-kits/paseo/scripts/verify
@@ -481,7 +481,7 @@ info "6b. Guest daemon bind is 0.0.0.0 (reachable via create-time publish), not 
 # reach it. On the msb backend `-p HOST:GUEST` binds a HOST loopback listener but
 # the publisher dials the sandbox's GUEST NETWORK IP (not guest 127.0.0.1), so a
 # loopback-only bind answers inside the guest yet returns "Empty reply from server"
-# on the published host port. See GSA-TTS/agentic-coding-quickstart#333. Two asserts:
+# on the published host port. Two asserts:
 #   (a) the LISTEN socket is bound to 0.0.0.0 (not 127.0.0.1) in the guest, and
 #   (b) the earlier HOST-port fetch (step 5b) delivered the bundle — proving
 #       acq's create-time port-publish reaches the guest daemon end-to-end.
@@ -504,7 +504,7 @@ else
     0.0.0.0:*|*00000000:1A6F*)
       ok "daemon LISTEN socket bound to 0.0.0.0 in-guest ($bind_addr) — reachable via create-time publish" ;;
     127.0.0.1:*|*0100007F:1A6F*)
-      bad "daemon bound to loopback in-guest ($bind_addr) — create-time publish returns 'Empty reply from server' on msb (PASEO_LISTEN?; see quickstart#333)" ;;
+      bad "daemon bound to loopback in-guest ($bind_addr) — create-time publish returns 'Empty reply from server' on msb; check PASEO_LISTEN" ;;
     "")
       warn "could not read the daemon's LISTEN address (no ss + unreadable /proc/net/tcp); relying on the host-port fetch as the reachability proof" ;;
     *)
@@ -547,16 +547,14 @@ fi
 
 info "6d. Hardening: npm cache remains agent-owned"
 # Regression guard for running npm as root while HOME=/home/agent: that creates
-# root-owned files under ~/.npm and later blocks ordinary agent npm commands.
-if [ -z "$installed" ]; then
-  skip "npm cache ownership check (Paseo CLI did not install)"
+# root-owned files under ~/.npm and later blocks ordinary agent npm commands. Run
+# this even when install fails, because stale root-owned cache files may be the
+# reason install failed.
+bad_cache_owner="$(in_sbx 'if [ -d "$HOME/.npm" ]; then find "$HOME/.npm" -not -user "$(id -u)" -print -quit 2>/dev/null; fi')"
+if [ -n "$bad_cache_owner" ]; then
+  bad "npm cache contains files not owned by the agent user: $bad_cache_owner"
 else
-  bad_cache_owner="$(in_sbx 'if [ -d "$HOME/.npm" ]; then find "$HOME/.npm" -not -user "$(id -u)" -print -quit 2>/dev/null; fi')"
-  if [ -n "$bad_cache_owner" ]; then
-    bad "npm cache contains files not owned by the agent user: $bad_cache_owner"
-  else
-    ok "npm cache has no non-agent-owned files under ~/.npm"
-  fi
+  ok "npm cache has no non-agent-owned files under ~/.npm"
 fi
 
 info "7. Respawn supervisor running (auto-restart) — the daemon"

--- a/integrations/isolation/acq-kits/paseo/spec.yaml
+++ b/integrations/isolation/acq-kits/paseo/spec.yaml
@@ -182,7 +182,7 @@ commands:
       - sh
       - -c
       - |
-        PASEO_CLI_VERSION="0.6.1" \
+        PASEO_CLI_VERSION="0.7.0" \
           sh /home/agent/paseo-start.sh &
 
 # Neutral published port (schema hybrid/v1). Publish the single container/guest

--- a/integrations/isolation/acq-kits/paseo/spec.yaml
+++ b/integrations/isolation/acq-kits/paseo/spec.yaml
@@ -182,7 +182,7 @@ commands:
       - sh
       - -c
       - |
-        PASEO_CLI_VERSION="0.5.2" \
+        PASEO_CLI_VERSION="0.6.1" \
           sh /home/agent/paseo-start.sh &
 
 # Neutral published port (schema hybrid/v1). Publish the single container/guest

--- a/integrations/isolation/acq-kits/paseo/spec.yaml
+++ b/integrations/isolation/acq-kits/paseo/spec.yaml
@@ -15,7 +15,7 @@
 #
 # DESIGN (see docs/decisions/):
 #   - The STARTUP script (paseo-start.sh) owns the daemon: on every sandbox start
-#     it installs the Paseo CLI (first boot only) and supervises the daemon with
+#     it installs/updates the pinned Paseo CLI and supervises the daemon with
 #     `paseo daemon start --foreground --listen 0.0.0.0:6767 --web-ui`. A single
 #     Paseo process serves the daemon API, the WebSocket, AND the bundled web UI,
 #     all on ONE container port (6767). Because a `startup` command fires on EVERY
@@ -111,7 +111,7 @@ name: paseo
 displayName: Paseo (self-hosted web UI for coding agents)
 description: >
   Runs the Paseo daemon and its bundled browser web UI inside the sandbox and
-  publishes it to the host. Installs the Paseo CLI on first boot and supervises
+  publishes it to the host. Installs or updates the pinned Paseo CLI and supervises
   the daemon on 0.0.0.0:6767 (API + WebSocket + web UI on one port). Ships a thin
   `opencode` wrapper over a generic kit shim that pins Paseo's worktree root under
   the current project and holds PID 1 on `acq run` so the sandbox (and UI) stay up.
@@ -147,7 +147,7 @@ files:
   - path: /home/agent/paseo-start.sh
     mode: "0755"
     source: files/home/paseo-start.sh
-    description: Install (first boot) and supervise the Paseo daemon + web UI
+    description: Install/update the pinned Paseo CLI and supervise the Paseo daemon + web UI
   - path: /home/agent/paseo-set-worktrees-root.mjs
     mode: "0755"
     source: files/home/paseo-set-worktrees-root.mjs
@@ -177,7 +177,7 @@ commands:
     # `agent`; acq/the backend runs the startup phase as the agent user.
     user: "1000"
     background: true
-    description: Install (first boot) and supervise the Paseo daemon + web UI (background)
+    description: Install/update the pinned Paseo CLI and supervise the Paseo daemon + web UI (background)
     command:
       - sh
       - -c
@@ -215,8 +215,8 @@ publishedPorts:
 # host-published loopback port. The sandbox remains the security boundary
 # (ephemeral container, proxied allow-listed egress, no host FS) and the HOST
 # side of the publish is still loopback-only, so 0.0.0.0 in-guest does not widen
-# host exposure. See GSA-TTS/agentic-coding-quickstart#333 and the msb port
-# limitations in that repo's BACKEND_GUIDE.md / KNOWN_FAILURE_MODES.md §36.
+# host exposure. This is the same msb create-time port-publish limitation covered
+# by quickstart's BACKEND_GUIDE.md / KNOWN_FAILURE_MODES.md guidance.
 # Verified live: see scripts/verify "in-guest bind" assertion.
 #
 # PASEO_RELAY_ENABLED=false disables Paseo's cloud relay (wss://relay.paseo.sh).


### PR DESCRIPTION
## Summary

Fixes the Paseo kit startup install so it no longer runs `npm install -g` through `sudo` with `HOME=/home/agent`. Fixes GSA-TTS/agentic-coding-quickstart#417.

The kit now installs `@getpaseo/cli` as the agent user into an agent-owned npm prefix/cache:

- prefix: `$HOME/.npm-global`
- cache: `$HOME/.npm`

This prevents root-owned files from being created under `/home/agent/.npm`, while preserving the existing proxy, CA, pinned-version, and lifecycle-script hardening behavior.

This also bumps the kit's Paseo CLI pin from `0.5.2` to `0.6.1`, the latest stable upstream release. GitHub Releases shows `v0.6.1` as Latest and non-prerelease; `v0.7.0-beta.3` exists but is marked Pre-release. npm shows `@getpaseo/cli` dist-tag `latest` as `0.6.1` and `beta` as `0.7.0-beta.3`.

## Context

Root cause investigation for `GSA-TTS/agentic-coding-quickstart#417` found that the Paseo kit's privileged npm install path could create root-owned npm cache files in the agent home. The cause was `sudo ... HOME="$HOME" npm install -g ...`, which makes npm run as root while resolving its cache under `/home/agent/.npm`.

## Changes

- Remove the Paseo startup script's privileged `sudo npm install -g` path.
- Install Paseo into `$HOME/.npm-global` with `npm_config_cache=$HOME/.npm`.
- Keep `$HOME/.npm-global/bin` on the startup/probe PATH.
- Add a live `scripts/verify` regression check that fails if `$HOME/.npm` contains non-agent-owned files.
- Update Paseo docs, troubleshooting text, and mount registrar comments to describe the per-user install path.
- Bump the pinned `PASEO_CLI_VERSION` from `0.5.2` to stable latest `0.6.1`.
- Make startup version-aware so an existing older `paseo` install is replaced instead of silently bypassing the new pin.
- Remove stale issue/PR tracker references from touched durable kit docs/comments.

## Verification

Commands run:

```bash
gh api repos/getpaseo/paseo/releases/latest --jq '{tag_name, name, prerelease, published_at, html_url}'
```

Result: passed. Observed `tag_name: v0.6.1`, `prerelease: false`, and `html_url: https://github.com/getpaseo/paseo/releases/tag/v0.6.1`.

```bash
npm view @getpaseo/cli version dist-tags --json
```

Result: passed. Observed `version: 0.6.1`, `latest: 0.6.1`, `beta: 0.7.0-beta.3`.

```bash
npm view @getpaseo/cli@0.6.1 version dependencies optionalDependencies dist.tarball --json
```

Result: passed. Confirmed `@getpaseo/cli@0.6.1` exists and its tarball is served from `https://registry.npmjs.org/@getpaseo/cli/-/cli-0.6.1.tgz`.

```bash
sh -n integrations/isolation/acq-kits/paseo/files/home/paseo-start.sh && bash -n integrations/isolation/acq-kits/paseo/scripts/verify
```

Result: passed.

```bash
node --check integrations/isolation/acq-kits/paseo/files/home/paseo-register-mounts.mjs && node --test 'integrations/isolation/acq-kits/paseo/tests/**/*.test.mjs'
```

Result: passed, 8 tests passed.

```bash
git diff --check
```

Result: passed.

```bash
bash integrations/isolation/acq-kits/paseo/scripts/verify
```

Result: offline gate passed, 5 passed / 0 failed. Live sandbox checks skipped because `RUN_ACQ=1` was not enabled in this session.

Host-side verification also run from `integrations/isolation/acq-kits/paseo`:

```bash
scripts/verify
```

Result: offline gate passed, 5 passed / 0 failed. Live sandbox checks skipped because `RUN_ACQ=1` was not enabled. The neutral kit spec validation was skipped because the host Python environment was missing `jsonschema` + `pyyaml`.

Attempted but blocked by local environment:

```bash
make validate
```

Result: blocked because `python` is not installed in this environment.

```bash
python3 scripts/validate_repo.py
python3 integrations/isolation/acq-kits/validate-kits.py --root .
```

Result: blocked because the local Python environment is missing `jsonschema` (and likely `pyyaml`).

## Adversarial Review

A subagent adversarial review found three actionable issues, all addressed in this branch:

- Existing older Paseo installs could bypass the new `0.6.1` pin because startup only checked `command -v paseo`; startup now compares `paseo --version` to `PASEO_CLI_VERSION`.
- The npm cache ownership guard skipped when install failed; it now runs even on install failure so stale root-owned cache files are reported directly.
- Touched durable files still had stale tracker references for the msb port-publish behavior; those references were replaced with self-contained prose.

Verification was rerun after these fixes with the same passing local results listed above.

## Rollback

Revert this PR to restore the previous sudo/global npm install behavior and the prior `PASEO_CLI_VERSION=0.5.2` pin.

## Security Impact

Positive security impact: the Paseo kit no longer runs npm package installation as root on the default path, reducing privileged supply-chain exposure and preventing root-owned npm cache files in the agent user's home directory.

## AI Assistance

This PR was prepared with OpenCode AI assistance. Human review is required before merge.


