### PR TITLE
chore(deps): bump ruff to 0.16.4 in pyproject.toml and pre-commit lockstep

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: gitleaks
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 65dbdb59d2f2d9c3bdc343c566821ad3319ddaa3  # v0.16.3
+    rev: aab412d509121cb5f7533134b7e67f9fab59c682  # v0.16.4
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 dev = [
     "pytest==9.1.1",
     "pytest-cov==7.1.0",
-    "ruff==0.16.3",
+    "ruff==0.16.4",
     "pre-commit==4.6.2",
     "pip-audit==2.10.1",
 ]


### PR DESCRIPTION
## Summary

Dependabot opened two separate PRs for the same `ruff` 0.16.3→0.16.4 bump — GSA-TTS/agentic-coding-patterns#400 (`pyproject.toml` dev-dependency) and GSA-TTS/agentic-coding-patterns#401 (`.pre-commit-config.yaml`'s `ruff-pre-commit` hook rev) — because Dependabot files one PR per manifest. Neither can merge alone: `test_ruff_pin_lockstep.py` (tracking GSA-TTS/agentic-coding-patterns#339) asserts the two pins stay in sync, so each PR fails CI on its own with the two pins pointing at opposite versions.

This PR bumps both together.

## Changes

- `pyproject.toml`: `ruff==0.16.3` → `0.16.4`
- `.pre-commit-config.yaml`: `ruff-pre-commit` `rev:` → the verified `v0.16.4` commit SHA (`aab412d509121cb5f7533134b7e67f9fab59c682`), confirmed via the GitHub API against the real tag ref and release metadata (published, non-draft, non-prerelease) — not assumed or reused from the existing v0.16.3 pin.

## Verification

- `python3 -m pytest scripts/tests/test_ruff_pin_lockstep.py` — passes
- `python3 -m pytest scripts/tests/` — 401/401 passing
- `ruff check scripts/` and `ruff format --check scripts/` (CI's actual lint scope, per `.github/workflows/ci.yml`) — both clean under 0.16.4

## Deliberately excluded

Running `ruff format`/`ruff check` under 0.16.4 against the FULL repo (not just `scripts/`) surfaces pre-existing reformatting/lint drift in 2 files outside CI's lint scope (`.agents/skills/frontend/tools/readability_score.py`, a `secure-code-review` test fixture). Confirmed these findings are pre-existing and reproduce identically under 0.16.3 too — not introduced by this bump. Left untouched to keep this PR a clean dependency bump rather than bundling an unrelated cleanup.

Closes GSA-TTS/agentic-coding-patterns#400
Closes GSA-TTS/agentic-coding-patterns#401

Co-authored-by: OpenCode Agent <agent@gsa.gov>