### PR TITLE
feat(isolation): add cloud.gov acq kit

### DIFF
--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -8,14 +8,13 @@
       "name": "linters",
       "version": "1.0.0",
       "dependencies": {
-        "markdownlint-cli2": "0.22.1"
+        "markdownlint-cli2": "0.23.2"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -28,7 +27,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -37,7 +35,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -50,7 +47,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
       "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -62,7 +58,6 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
       "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
-      "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
       }
@@ -70,26 +65,22 @@
     "node_modules/@types/katex": {
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
-      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
-      "license": "MIT"
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg=="
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "license": "MIT"
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/unist": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-      "license": "MIT"
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
     },
     "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
       "engines": {
         "node": ">=12"
       },
@@ -107,7 +98,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -119,7 +109,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -129,7 +118,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -139,7 +127,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
       "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -149,7 +136,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -158,7 +144,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -175,7 +160,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
       "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
-      "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
       },
@@ -188,7 +172,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -197,7 +180,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
       },
@@ -222,7 +204,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -235,10 +216,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "license": "ISC",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -247,7 +227,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -259,7 +238,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -271,7 +249,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -280,10 +257,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
-      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
-      "license": "MIT",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
         "fast-glob": "^3.3.3",
@@ -300,10 +276,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "license": "MIT",
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.9.tgz",
+      "integrity": "sha512-brTTsvFRt5C1gGHtPst/281UjPD5t9fBqbgoMPlVWy11ZLTPfu7HxK4ZYqO9H7o/yC9rSTCI85EaQ4OoY12qYw==",
       "engines": {
         "node": ">= 4"
       }
@@ -312,7 +287,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
       "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -322,7 +296,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
       "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-      "license": "MIT",
       "dependencies": {
         "is-alphabetical": "^2.0.0",
         "is-decimal": "^2.0.0"
@@ -336,7 +309,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
       "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -346,7 +318,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -355,7 +326,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -367,7 +337,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
       "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -377,7 +346,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -386,7 +354,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
       "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -408,7 +375,6 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -439,7 +405,6 @@
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
       ],
-      "license": "MIT",
       "dependencies": {
         "commander": "^8.3.0"
       },
@@ -494,10 +459,9 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
-      "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
-      "license": "MIT",
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.41.1.tgz",
+      "integrity": "sha512-qHKeU2E1bdyNAT077go2FVTNXvYcktN5IHtF6XyeD1l0PClxzSp2tUApAV14ORI8DGX4H9bNKZEzelZp4qn8IA==",
       "dependencies": {
         "micromark": "4.0.2",
         "micromark-core-commonmark": "2.0.3",
@@ -507,36 +471,35 @@
         "micromark-extension-gfm-table": "2.1.1",
         "micromark-extension-math": "3.1.0",
         "micromark-util-types": "2.0.2",
-        "string-width": "8.1.0"
+        "string-width": "8.2.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/DavidAnson"
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.1.tgz",
-      "integrity": "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==",
-      "license": "MIT",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.2.tgz",
+      "integrity": "sha512-eUhcnkSpzURo/o4htSqc7LPDszgOOTknhU4eY/sPHvMCLxnTCYscv1gw1/js/idmaZPisv9ECVEIORcllqjTUw==",
       "dependencies": {
-        "globby": "16.2.0",
-        "js-yaml": "4.1.1",
+        "globby": "16.2.2",
+        "js-yaml": "5.2.2",
         "jsonc-parser": "3.3.1",
         "jsonpointer": "5.0.1",
-        "markdown-it": "14.1.1",
-        "markdownlint": "0.40.0",
+        "markdown-it": "14.3.0",
+        "markdownlint": "0.41.1",
         "markdownlint-cli2-formatter-default": "0.0.6",
         "micromatch": "4.0.8",
-        "smol-toml": "1.6.1"
+        "smol-toml": "1.7.0"
       },
       "bin": {
         "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/DavidAnson"
@@ -564,7 +527,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -583,7 +545,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -618,7 +579,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "devlop": "^1.0.0",
@@ -642,7 +602,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
       "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
-      "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-factory-space": "^2.0.0",
@@ -661,7 +620,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
       "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
-      "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-sanitize-uri": "^2.0.0",
@@ -677,7 +635,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
-      "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-core-commonmark": "^2.0.0",
@@ -697,7 +654,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
       "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
-      "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-factory-space": "^2.0.0",
@@ -714,7 +670,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
       "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
-      "license": "MIT",
       "dependencies": {
         "@types/katex": "^0.16.0",
         "devlop": "^1.0.0",
@@ -743,7 +698,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -764,7 +718,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-character": "^2.0.0",
@@ -786,7 +739,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -806,7 +758,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
@@ -828,7 +779,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
@@ -850,7 +800,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -870,7 +819,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
       }
@@ -889,7 +837,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -910,7 +857,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-chunked": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -930,7 +876,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
       }
@@ -948,8 +893,7 @@
           "type": "OpenCollective",
           "url": "https://opencollective.com/unified"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
@@ -964,8 +908,7 @@
           "type": "OpenCollective",
           "url": "https://opencollective.com/unified"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/micromark-util-normalize-identifier": {
       "version": "2.0.1",
@@ -981,7 +924,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
       }
@@ -1000,7 +942,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^2.0.0"
       }
@@ -1019,7 +960,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-encode": "^2.0.0",
@@ -1040,7 +980,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-chunked": "^2.0.0",
@@ -1061,8 +1000,7 @@
           "type": "OpenCollective",
           "url": "https://opencollective.com/unified"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/micromark-util-types": {
       "version": "2.0.2",
@@ -1077,14 +1015,12 @@
           "type": "OpenCollective",
           "url": "https://opencollective.com/unified"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -1096,14 +1032,12 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
       "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "character-entities-legacy": "^3.0.0",
@@ -1122,7 +1056,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -1156,14 +1089,12 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -1187,7 +1118,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -1196,7 +1126,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
       "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -1217,13 +1146,12 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
-      "license": "MIT",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dependencies": {
-        "get-east-asian-width": "^1.3.0",
-        "strip-ansi": "^7.1.0"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
         "node": ">=20"
@@ -1236,7 +1164,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
       },
@@ -1251,7 +1178,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -1269,7 +1195,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
       "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
-      "license": "MIT",
       "engines": {
         "node": ">=20"
       },

--- a/.github/linters/package.json
+++ b/.github/linters/package.json
@@ -7,7 +7,7 @@
     "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules'"
   },
   "dependencies": {
-    "markdownlint-cli2": "0.22.1"
+    "markdownlint-cli2": "0.23.2"
   },
   "overrides": {
     "js-yaml": "4.3.2",

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -58,6 +58,7 @@ globs:
 # Ignore files
 ignores:
   - "node_modules"
+  - ".venv"
   - "deleteme"
   - "**/fixtures/**"
 

--- a/integrations/isolation/acq-kits/README.md
+++ b/integrations/isolation/acq-kits/README.md
@@ -20,6 +20,7 @@ not agent behavior. (Behavioral patterns live in `skills/`, `prompts/`, etc.)
 |-----|---------|
 | [`usai-provider/`](usai-provider/) | Configure the agent to use the GSA USAi model provider (OpenCode today), with egress allow-listed. |
 | [`agentic-coding-playbook/`](agentic-coding-playbook/) | Clone the GSA agentic-coding-playbook at startup and link its `AGENTS.md` + skills into each agent's search paths. |
+| [`cloud-gov/`](cloud-gov/) | Install the Cloud Foundry CLI and allow-list cloud.gov platform, app-route, dashboard, and docs domains, with auth supplied through acq secrets. |
 | [`zscaler-ca-certificate/`](zscaler-ca-certificate/) | Trust the public Zscaler Root CA in the sandbox (msb: native `--trust-host-cas`; sbx: file-drop + `update-ca-certificates`). |
 | [`git-ssh-sign/`](git-ssh-sign/) | Sign git commits and tags with the SSH key forwarded from the host agent (vendored from sbx-kits-contrib). |
 | [`openchamber/`](openchamber/) | Run OpenChamber, a browser UI for OpenCode, inside the sandbox alongside the terminal TUI. Opt-in (see its parity note). |

--- a/integrations/isolation/acq-kits/cloud-gov/README.md
+++ b/integrations/isolation/acq-kits/cloud-gov/README.md
@@ -26,9 +26,9 @@ sandbox.
 
 ## Backend Parity
 
-The kit currently declares `sbx` support. sbx consumes the neutral kit fields:
-`caps.network.allow`, file drops, and create-time/startup commands. There is no
-backend shortcut.
+The kit declares `sbx` and `msb` support. Both backends consume the neutral kit
+fields: `caps.network.allow`, file drops, and create-time/startup commands. There
+is no backend shortcut.
 
 The Cloud Foundry token is not a kit field. The user stores it in the acq secret
 store and binds it to `api.fr.cloud.gov`; the active backend maps that to its
@@ -36,9 +36,9 @@ own proxy or secret-substitution mechanism. The kit writes only the injected
 placeholder into CF CLI config so `cf` can send an auth header for the proxy to
 rewrite.
 
-msb support is intentionally not declared yet: this kit relies on
-`**.cloud.gov`, and acq must translate per-kit `**.` wildcard entries to msb
-suffix rules before the same spec can honestly claim msb parity.
+The only backend-specific network nuance is the cloud.gov wildcard. sbx consumes
+`**.cloud.gov` directly. msb support requires acq to translate that per-kit
+wildcard to msb's suffix rule form (`*.cloud.gov`).
 
 ## Usage
 

--- a/integrations/isolation/acq-kits/cloud-gov/README.md
+++ b/integrations/isolation/acq-kits/cloud-gov/README.md
@@ -1,0 +1,142 @@
+# cloud-gov (acq mixin kit, `hybrid/v1`)
+
+A neutral [`acq`](https://github.com/GSA-TTS/agentic-coding-quickstart) **mixin
+kit** for working with [cloud.gov](https://cloud.gov/) from an isolated coding
+sandbox.
+
+> **Neutral (backend-agnostic) kit.** This is the `schemaVersion: "hybrid/v1"`
+> form consumed by `acq`, which abstracts the isolation backend. See
+> [backend parity](#backend-parity) and
+> [`../../docs/decisions/0001-neutral-hybrid-v1-acq-kits.md`](../../docs/decisions/0001-neutral-hybrid-v1-acq-kits.md).
+
+## What It Does
+
+- **Cloud Foundry CLI** - uses an existing `cf` binary when the base image already
+  has one. If `cf` is missing, installs Cloud Foundry CLI v8.19.0 from pinned
+  upstream release tarballs with committed SHA-256 checks.
+- **cloud.gov egress** - allow-lists the `cloud.gov` apex and all `cloud.gov`
+  subdomains, covering the Cloud Foundry API, login/UAA, log-stream hosts,
+  dashboard, public app routes, and user-facing cloud.gov documentation.
+- **Cloud Foundry docs egress** - allow-lists upstream Cloud Foundry CLI and docs
+  hosts so agents can look up command behavior and platform guidance.
+- **Secret-safe authorization** - documents the `acq secret set` binding for a
+  host-side `cf oauth-token`. The sandbox receives only the backend placeholder
+  needed for `cf` to send an auth header; the real token stays in the host-side
+  secret store / backend proxy.
+
+## Backend Parity
+
+The kit currently declares `sbx` support. sbx consumes the neutral kit fields:
+`caps.network.allow`, file drops, and create-time/startup commands. There is no
+backend shortcut.
+
+The Cloud Foundry token is not a kit field. The user stores it in the acq secret
+store and binds it to `api.fr.cloud.gov`; the active backend maps that to its
+own proxy or secret-substitution mechanism. The kit writes only the injected
+placeholder into CF CLI config so `cf` can send an auth header for the proxy to
+rewrite.
+
+msb support is intentionally not declared yet: this kit relies on
+`**.cloud.gov`, and acq must translate per-kit `**.` wildcard entries to msb
+suffix rules before the same spec can honestly claim msb parity.
+
+## Usage
+
+Apply the kit alongside an agent sandbox:
+
+```bash
+acq run --kit <path-to-this-kit> opencode /path/to/project
+```
+
+The kit is a `mixin`, so it composes with the other acq-kits.
+
+## CF CLI Installation Pin
+
+If the base image already has `cf`, the install step exits successfully without
+network package installation. If `cf` is missing, the kit installs Cloud Foundry
+CLI v8.19.0 from the upstream GitHub release tarball for `linux_x86-64` or
+`linux_arm64`, then verifies the archive SHA-256 before installing it. Unsupported
+architectures fail closed.
+
+To update the CLI, change the version and both SHA-256 constants in
+`files/home/cloud-gov-install-cf-cli.sh` together after reviewing the upstream
+release metadata.
+
+## Prerequisites
+
+From a host shell, log in to cloud.gov with the normal human-controlled flow:
+
+```bash
+cf login -a https://api.fr.cloud.gov --sso
+```
+
+Then store the short-lived Cloud Foundry OAuth token string in acq. `cf
+oauth-token` returns the full authorization value, including the `bearer` prefix;
+this command passes that value over stdin to the host-side secret store. Do not
+paste it into chat or write it to a file:
+
+```bash
+cf oauth-token | acq secret set -g cloud-gov --host api.fr.cloud.gov --env CF_OAUTH_TOKEN
+```
+
+For a sandbox-specific token, scope the secret to that sandbox:
+
+```bash
+cf oauth-token | acq secret set <sandbox-name> cloud-gov --host api.fr.cloud.gov --env CF_OAUTH_TOKEN
+```
+
+The `CF_OAUTH_TOKEN` name is a placeholder binding for backend proxy/secret
+substitution. At startup the kit targets `https://api.fr.cloud.gov` and, when
+that placeholder is present, writes it into `~/.cf/config.json` so the stock CF
+CLI can send `Authorization: Bearer ...`. That file contains only the backend
+placeholder, not the real OAuth token.
+
+## Network Allow-List
+
+The kit allow-lists:
+
+| Host | Purpose |
+|------|---------|
+| `cloud.gov`, `**.cloud.gov` | cloud.gov apex and all cloud.gov subdomains, including API, login/UAA, dashboard, docs, and public app routes. This is intentionally broad for cloud.gov work; custom domains outside `cloud.gov` stay project-specific. |
+| `docs.cloudfoundry.org`, `cli.cloudfoundry.org` | Cloud Foundry documentation |
+| `github.com`, `objects.githubusercontent.com` | Pinned Cloud Foundry CLI release tarball download |
+
+## Using `cf`
+
+Inside the sandbox, target cloud.gov normally:
+
+```bash
+cf api https://api.fr.cloud.gov
+cf target
+cf apps
+```
+
+If the CLI requires an interactive login or reports that no user is logged in,
+refresh the host-side secret with `cf oauth-token | acq secret set ...` and
+restart or recreate the sandbox so the placeholder reaches CF CLI config. Do not
+paste the token into chat or commit it to the workspace.
+
+## Troubleshooting
+
+Failure-mode notes are in [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md).
+
+## Design Decisions
+
+- [`docs/decisions/cloud-gov-cli-and-auth.md`](docs/decisions/cloud-gov-cli-and-auth.md)
+  - why this kit installs `cf`, uses broad `cloud.gov` egress, and relies on acq
+  placeholder-based auth.
+
+## Verifying
+
+Run the bundled check:
+
+```bash
+./scripts/verify
+```
+
+By default it runs offline checks only: repository kit validation and shell
+syntax for the install script. Set `RUN_ACQ=1` to create a throwaway sandbox and
+verify that `cf` is installed, cloud.gov/docs endpoints are reachable, the
+injected placeholder reaches the CF API, and an authenticated `cf orgs` command
+works. `RUN_ACQ=1` requires a global `cloud-gov` acq secret. Set `KEEP=1` with
+`RUN_ACQ=1` to keep the sandbox for inspection.

--- a/integrations/isolation/acq-kits/cloud-gov/TROUBLESHOOTING.md
+++ b/integrations/isolation/acq-kits/cloud-gov/TROUBLESHOOTING.md
@@ -1,0 +1,84 @@
+# Troubleshooting - cloud-gov kit
+
+These are failure modes specific to the cloud-gov acq mixin kit.
+
+## `cf` Is Not Installed
+
+**Symptoms:** `cf version` fails inside the sandbox.
+
+**Causes and fixes:**
+
+- **Install egress blocked.** Check the sandbox policy log and confirm the CF CLI
+  package hosts in `spec.yaml` are allowed.
+- **Unsupported architecture.** The install script supports upstream Linux
+  x86_64/amd64 and arm64/aarch64 tarballs. For another architecture, install the
+  CF CLI in the base image or extend `files/home/cloud-gov-install-cf-cli.sh`
+  with a pinned artifact and SHA-256.
+- **Release artifact changed.** The install script verifies the downloaded
+  tarball SHA-256. A mismatch fails closed; review the upstream release metadata
+  before changing the pinned version or hash.
+
+## `cf api https://api.fr.cloud.gov` Fails
+
+**Symptoms:** `cf api` times out or cannot resolve/reach the API host.
+
+**Causes and fixes:**
+
+- **Kit not applied.** Recreate the sandbox with this kit applied.
+- **Egress blocked by org policy.** Check `acq policy log <sandbox>` or the
+  active backend's policy log for `api.fr.cloud.gov`.
+- **TLS trust issue.** If your network uses TLS inspection, compose this kit with
+  `zscaler-ca-certificate` or the local equivalent CA-trust kit.
+
+## CF Authentication Fails
+
+**Symptoms:** cloud.gov is reachable, but `cf` reports unauthorized, forbidden,
+or no current user.
+
+**Causes and fixes:**
+
+- **Missing or expired host-side token.** From a host shell where you are logged
+  in to cloud.gov, refresh the acq secret:
+
+  ```bash
+  cf oauth-token | acq secret set -g cloud-gov --host api.fr.cloud.gov --env CF_OAUTH_TOKEN
+  ```
+
+- **Wrong scope.** If the sandbox has a sandbox-scoped `cloud-gov` secret, update
+  that scoped secret instead of the global one:
+
+  ```bash
+  cf oauth-token | acq secret set <sandbox-name> cloud-gov --host api.fr.cloud.gov --env CF_OAUTH_TOKEN
+  ```
+
+- **Client-side token cache mismatch.** The kit writes only the injected
+  placeholder to `~/.cf/config.json`, never the real token. If the CF CLI needs
+  an interactive login before making requests, complete authentication from the
+  host, refresh the acq secret, and restart or recreate the sandbox so the
+  placeholder is written into CF CLI config. Do not paste the token into chat or
+  commit it to the workspace.
+
+## A cloud.gov App Route Is Blocked
+
+**Symptoms:** `curl https://<app>.app.cloud.gov` or a browser/API request to a
+cloud.gov app route fails because egress is denied.
+
+**Causes and fixes:**
+
+- **Route outside cloud.gov.** The kit allow-lists `cloud.gov` and
+  `**.cloud.gov`. If your app uses a custom domain or an internal route outside
+  `cloud.gov`, add a separate project-specific network allow-list entry rather
+  than broadening this shared kit.
+- **Wildcard not supported by the active backend.** Confirm the generated backend
+  policy from `acq`; if needed, add the specific app host as a per-sandbox allow.
+
+## Docs Are Not Reachable
+
+**Symptoms:** Requests to cloud.gov or Cloud Foundry docs fail.
+
+**Causes and fixes:**
+
+- Confirm the requested host is one of `cloud.gov`, `www.cloud.gov`,
+  `docs.cloud.gov`, `docs.cloudfoundry.org`, or `cli.cloudfoundry.org`.
+- If docs pull assets from another host and the backend blocks them, add the
+  specific observed host after review instead of adding a broad wildcard.

--- a/integrations/isolation/acq-kits/cloud-gov/docs/decisions/cloud-gov-cli-and-auth.md
+++ b/integrations/isolation/acq-kits/cloud-gov/docs/decisions/cloud-gov-cli-and-auth.md
@@ -16,7 +16,7 @@ an authenticated request.
 
 ## Decision
 
-Create a neutral `cloud-gov` acq mixin kit, initially registered for sbx, that:
+Create a neutral `cloud-gov` acq mixin kit for sbx and msb that:
 
 1. Installs `cf` at create time from pinned Cloud Foundry CLI release tarballs
    with committed SHA-256 values.
@@ -51,6 +51,9 @@ active backend's secret/proxy mechanism.
   should treat that as an accepted blast-radius tradeoff for this shared kit, not
   as a generic default for other kits. Custom domains and internal routes outside
   `cloud.gov` should be added per project rather than broadening this shared kit.
+- msb support depends on acq translating the neutral per-kit `**.cloud.gov` entry
+  into msb's suffix rule form (`*.cloud.gov`). Without that adapter behavior,
+  exact cloud.gov hosts may work but the all-subdomains contract is not met.
 - Live verification with `RUN_ACQ=1` requires a configured `cloud-gov` secret and
   must exercise both raw authenticated CF API access and an authenticated `cf`
   command. Offline verification remains useful for schema/shell checks, but it is

--- a/integrations/isolation/acq-kits/cloud-gov/docs/decisions/cloud-gov-cli-and-auth.md
+++ b/integrations/isolation/acq-kits/cloud-gov/docs/decisions/cloud-gov-cli-and-auth.md
@@ -1,0 +1,62 @@
+# Decision: install CF CLI and use acq secret placeholder auth
+
+**Status:** accepted
+
+## Context
+
+cloud.gov operations use the Cloud Foundry CLI (`cf`) against the cloud.gov
+Cloud Foundry API. A sandbox used for this work needs the CLI, egress to the
+cloud.gov platform and application-route domains, and access to cloud.gov and
+Cloud Foundry documentation.
+
+Authentication is sensitive. A token from `cf oauth-token` must not be committed,
+printed in chat, or written into agent-readable workspace files. At the same
+time, the stock CF CLI expects an auth token in its own config before it will send
+an authenticated request.
+
+## Decision
+
+Create a neutral `cloud-gov` acq mixin kit, initially registered for sbx, that:
+
+1. Installs `cf` at create time from pinned Cloud Foundry CLI release tarballs
+   with committed SHA-256 values.
+2. Allow-lists `cloud.gov`, all `cloud.gov` subdomains, and Cloud Foundry docs
+   domains.
+3. Uses acq's custom secret binding for a host-side token captured with
+   `cf oauth-token`:
+
+   ```sh
+   cf oauth-token | acq secret set -g cloud-gov --host api.fr.cloud.gov --env CF_OAUTH_TOKEN
+   ```
+
+4. Writes only the injected backend placeholder to `~/.cf/config.json` at
+   startup, so `cf` sends an auth header that the backend proxy can rewrite on the
+   way to `api.fr.cloud.gov`.
+
+The kit does not store the real Cloud Foundry OAuth token in `spec.yaml`, files,
+or repository docs. The token remains in the host-side acq secret store and the
+active backend's secret/proxy mechanism.
+
+## Consequences
+
+- Agents can use normal `cf` commands after the user supplies a host-side token.
+- The real token remains outside the sandbox; the sandbox may contain only a
+  backend-generated placeholder.
+- The install currently supports Linux x86_64/amd64 and arm64/aarch64 release
+  tarballs. Other architectures should either preinstall `cf` or add a pinned,
+  integrity-checked install path before being supported.
+- `**.cloud.gov` is intentionally broad because this kit is specifically for
+  cloud.gov work and the requested working surface includes all cloud.gov
+  subdomains. This widens egress to tenant app routes under `cloud.gov`; reviewers
+  should treat that as an accepted blast-radius tradeoff for this shared kit, not
+  as a generic default for other kits. Custom domains and internal routes outside
+  `cloud.gov` should be added per project rather than broadening this shared kit.
+- Live verification with `RUN_ACQ=1` requires a configured `cloud-gov` secret and
+  must exercise both raw authenticated CF API access and an authenticated `cf`
+  command. Offline verification remains useful for schema/shell checks, but it is
+  not evidence that cloud.gov auth wiring works.
+
+## Links
+
+- `../../README.md` - operator usage and troubleshooting entry points.
+- `../../spec.yaml` - authoritative kit behavior.

--- a/integrations/isolation/acq-kits/cloud-gov/files/home/cloud-gov-configure-cf-auth.sh
+++ b/integrations/isolation/acq-kits/cloud-gov/files/home/cloud-gov-configure-cf-auth.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+set -eu
+
+# Configure the CF CLI to use cloud.gov. If acq injected a backend placeholder in
+# CF_OAUTH_TOKEN, write that placeholder into CF CLI config so the CLI sends an
+# Authorization header; the backend proxy swaps the placeholder on the wire.
+
+log() { printf '%s\n' "cloud-gov: $*" >&2; }
+
+json_escape() {
+  # CF_OAUTH_TOKEN should be a generated placeholder, but escape defensively
+  # before embedding it in JSON. Newlines are not valid in this single-value path.
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+mkdir -p "$HOME/.cf"
+
+if command -v cf >/dev/null 2>&1; then
+  cf api https://api.fr.cloud.gov >/dev/null 2>&1 || log "warning: cf api target failed; check egress/TLS"
+fi
+
+if [ -n "${CF_OAUTH_TOKEN:-}" ]; then
+  case "$CF_OAUTH_TOKEN" in
+    *eyJ*.*.*)
+      log "CF_OAUTH_TOKEN looks like real JWT token material; refusing to write it"
+      exit 1
+      ;;
+  esac
+  escaped_token="$(json_escape "$CF_OAUTH_TOKEN")"
+  cat >"$HOME/.cf/config.json" <<EOF
+{
+  "ConfigVersion": 3,
+  "Target": "https://api.fr.cloud.gov",
+  "AuthorizationEndpoint": "https://login.fr.cloud.gov",
+  "UaaEndpoint": "https://uaa.fr.cloud.gov",
+  "AccessToken": "${escaped_token}",
+  "RefreshToken": ""
+}
+EOF
+  chmod 0600 "$HOME/.cf/config.json"
+  log "configured cf for cloud.gov using injected token placeholder"
+else
+  log "no CF_OAUTH_TOKEN placeholder present; cf is targeted but unauthenticated"
+fi

--- a/integrations/isolation/acq-kits/cloud-gov/files/home/cloud-gov-install-cf-cli.sh
+++ b/integrations/isolation/acq-kits/cloud-gov/files/home/cloud-gov-install-cf-cli.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env sh
+set -eu
+
+# Install the Cloud Foundry CLI from a pinned upstream release tarball. The exact
+# version and SHA-256 values are committed in this script so the install is
+# reproducible and fails closed on upstream drift.
+
+CF_CLI_VERSION="8.19.0"
+CF_CLI_SHA256_X86_64="98268ab3134bb3a1c97ffce797b4e6d35590a82e006cd098ad7a29f0a5cae7d8"
+CF_CLI_SHA256_ARM64="454c29a44a51c8edc9696678403e2e40808357a397033af5a018e6ca8ee32117"
+
+log() { printf '%s\n' "cloud-gov: $*" >&2; }
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | cut -d' ' -f1
+  else
+    return 1
+  fi
+}
+
+if command -v cf >/dev/null 2>&1; then
+  log "cf CLI already installed: $(cf version 2>/dev/null || printf 'version unavailable')"
+  exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  log "curl is required to fetch the pinned CF CLI release; refusing install"
+  exit 1
+fi
+if ! command -v tar >/dev/null 2>&1; then
+  log "tar is required to unpack the pinned CF CLI release; refusing install"
+  exit 1
+fi
+if ! command -v gzip >/dev/null 2>&1; then
+  log "gzip is required to unpack the pinned CF CLI release; refusing install"
+  exit 1
+fi
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+  log "sha256sum or shasum is required to verify the pinned CF CLI release; refusing install"
+  exit 1
+fi
+
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64)
+    asset="cf8-cli_${CF_CLI_VERSION}_linux_x86-64.tgz"
+    want_sha="$CF_CLI_SHA256_X86_64"
+    ;;
+  aarch64|arm64)
+    asset="cf8-cli_${CF_CLI_VERSION}_linux_arm64.tgz"
+    want_sha="$CF_CLI_SHA256_ARM64"
+    ;;
+  *)
+    log "unsupported architecture for pinned CF CLI release: $arch"
+    exit 1
+    ;;
+esac
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT INT TERM
+url="https://github.com/cloudfoundry/cli/releases/download/v${CF_CLI_VERSION}/${asset}"
+curl -fsSL "$url" -o "$work/cf-cli.tgz"
+got_sha="$(sha256_of "$work/cf-cli.tgz" || true)"
+if [ -z "$got_sha" ] || [ "$got_sha" != "$want_sha" ]; then
+  log "CF CLI release SHA-256 mismatch (got ${got_sha:-none}, want $want_sha); refusing install"
+  exit 1
+fi
+
+tar -xzf "$work/cf-cli.tgz" -C "$work"
+if [ -x "$work/cf8" ]; then
+  install -m 0755 "$work/cf8" /usr/local/bin/cf8
+elif [ -x "$work/cf" ]; then
+  install -m 0755 "$work/cf" /usr/local/bin/cf8
+else
+  log "pinned CF CLI archive did not contain cf8 or cf executable"
+  exit 1
+fi
+ln -sf /usr/local/bin/cf8 /usr/local/bin/cf
+
+if command -v cf >/dev/null 2>&1; then
+  log "installed $(cf version 2>/dev/null || printf 'cf CLI')"
+else
+  log "cf CLI install completed but cf is not on PATH"
+  exit 1
+fi

--- a/integrations/isolation/acq-kits/cloud-gov/scripts/verify
+++ b/integrations/isolation/acq-kits/cloud-gov/scripts/verify
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# verify - host-side validation for the cloud-gov acq mixin kit.
+#
+# By default this runs offline checks only. Set RUN_ACQ=1 to create a throwaway
+# sandbox and verify the CF CLI plus cloud.gov/docs network reachability.
+
+set -uo pipefail
+
+KIT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$KIT_DIR/../../../.." && pwd)"
+SBX_NAME="cloud-gov-verify-$$"
+WORK="$(mktemp -d "$KIT_DIR/verify-workspace.XXXXXX")"
+CREATE_LOG="$WORK/create.log"
+KEEP="${KEEP:-0}"
+RUN_ACQ="${RUN_ACQ:-0}"
+
+pass=0
+fail=0
+ok() { printf '  \033[32mPASS\033[0m %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; fail=$((fail + 1)); }
+skip() { printf '  \033[33mSKIP\033[0m %s\n' "$1"; }
+info() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+
+cleanup() {
+  if [ "$KEEP" = "1" ]; then
+    printf '\nKEEP=1 set; leaving sandbox %s and %s in place.\n' "$SBX_NAME" "$WORK" >&2
+    return
+  fi
+  acq rm "$SBX_NAME" >/dev/null 2>&1 || true
+  rm -rf "$WORK" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+in_acq() { acq exec "$SBX_NAME" -- sh -c "$1" </dev/null 2>/dev/null || true; }
+
+info "0. Offline preconditions"
+[ -f "$KIT_DIR/spec.yaml" ] && ok "kit spec.yaml present" || { bad "spec.yaml missing"; exit 1; }
+[ -f "$KIT_DIR/files/home/cloud-gov-install-cf-cli.sh" ] && ok "install script present" || bad "install script missing"
+
+if command -v bash >/dev/null 2>&1; then
+  if bash -n "$KIT_DIR/files/home/cloud-gov-install-cf-cli.sh"; then
+    ok "install script parses"
+  else
+    bad "install script has a shell syntax error"
+  fi
+else
+  skip "bash not on PATH - skipped shell parse check"
+fi
+
+info "1. Validate the neutral kit spec"
+VALIDATOR="$REPO_ROOT/integrations/isolation/acq-kits/validate-kits.py"
+if ! command -v python3 >/dev/null 2>&1; then
+  skip "validate-kits.py not run (python3 not on PATH)"
+elif [ ! -f "$VALIDATOR" ]; then
+  skip "validate-kits.py not found at $VALIDATOR"
+elif ! python3 -c 'import jsonschema, yaml' >/dev/null 2>&1; then
+  skip "validate-kits.py needs jsonschema + pyyaml"
+else
+  if val_out="$(python3 "$VALIDATOR" --root "$REPO_ROOT" 2>&1)"; then
+    ok "acq-kits validate-kits.py passes"
+  else
+    bad "validate-kits.py failed:"
+    printf '%s\n' "$val_out" | sed 's/^/    | /' >&2
+  fi
+fi
+
+if [ "$RUN_ACQ" != "1" ]; then
+  info "2. Live sandbox check"
+  skip "RUN_ACQ=1 not set - skipped live cloud.gov sandbox verification"
+  printf '\nSummary\n  %d passed, %d failed\n' "$pass" "$fail"
+  [ "$fail" -eq 0 ]
+  exit $?
+fi
+
+info "2. Live sandbox preconditions"
+if ! command -v acq >/dev/null 2>&1; then
+  bad "acq not on PATH"
+  exit 1
+fi
+ok "acq on PATH"
+
+if acq secret has -g cloud-gov >/dev/null 2>&1; then
+  ok "global cloud-gov secret is set"
+else
+  bad "RUN_ACQ=1 requires a global cloud-gov secret for authenticated verification"
+  printf '  Set it from a host shell with: cf oauth-token | acq secret set -g cloud-gov --host api.fr.cloud.gov --env CF_OAUTH_TOKEN\n' >&2
+  exit 1
+fi
+
+info "3. Create sandbox with the kit"
+printf '  creating %s (workspace %s)...\n' "$SBX_NAME" "$WORK"
+if acq create --name "$SBX_NAME" --kit "$KIT_DIR" opencode "$WORK" >"$CREATE_LOG" 2>&1; then
+  ok "sandbox created with cloud-gov kit"
+else
+  bad "acq create failed"
+  sed 's/^/  | /' "$CREATE_LOG" >&2
+  exit 1
+fi
+
+info "4. CF CLI installed"
+cf_version="$(in_acq 'cf version')"
+printf '  %s\n' "${cf_version:-<no output>}"
+case "$cf_version" in
+  *"cf version"*) ok "cf CLI reports a version" ;;
+  *) bad "cf CLI did not report a version" ;;
+esac
+
+info "5. cloud.gov API and docs reachable"
+for url in \
+  https://api.fr.cloud.gov/v3/info \
+  https://cloud.gov/ \
+  https://docs.cloud.gov/ \
+  https://docs.cloudfoundry.org/ \
+  https://cli.cloudfoundry.org/; do
+  status="$(in_acq "curl -sS -o /dev/null -w '%{http_code}' '$url'")"
+  printf '  %s -> %s\n' "$url" "${status:-<none>}"
+  case "$status" in
+    2*|3*|401|403) ok "$url reachable" ;;
+    *) bad "$url not reachable (status ${status:-none})" ;;
+  esac
+done
+
+info "6. Authenticated CF API wiring"
+auth_status="$(in_acq "curl -sS -o /dev/null -w '%{http_code}' -H \"Authorization: \$CF_OAUTH_TOKEN\" https://api.fr.cloud.gov/v3/organizations")"
+printf '  authenticated /v3/organizations -> %s\n' "${auth_status:-<none>}"
+case "$auth_status" in
+  2*|3*) ok "authenticated CF API probe succeeded" ;;
+  401|403) bad "authenticated CF API probe rejected credentials (status $auth_status)" ;;
+  *) bad "authenticated CF API probe failed (status ${auth_status:-none})" ;;
+esac
+
+cf_auth="$(in_acq 'cf orgs >/dev/null 2>&1 && printf ok || printf fail')"
+case "$cf_auth" in
+  ok) ok "cf CLI authenticated command succeeds" ;;
+  *) bad "cf CLI authenticated command failed" ;;
+esac
+
+info "Summary"
+printf '  %d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ] && printf '  \033[32mAll checks passed.\033[0m\n' || printf '  \033[31mSome checks failed - see notes above.\033[0m\n'
+
+[ "$fail" -eq 0 ]

--- a/integrations/isolation/acq-kits/cloud-gov/spec.yaml
+++ b/integrations/isolation/acq-kits/cloud-gov/spec.yaml
@@ -82,7 +82,3 @@ agentContext: |
   Do not ask the user to paste the token into chat or write it to the workspace.
   Use normal `cf` commands; real token material remains outside agent-readable
   files.
-
-# No backend shortcuts: sbx consumes the neutral files, create-time install, and
-# allow-list. msb support is not declared until acq translates per-kit `**.`
-# wildcard entries to msb suffix rules.

--- a/integrations/isolation/acq-kits/cloud-gov/spec.yaml
+++ b/integrations/isolation/acq-kits/cloud-gov/spec.yaml
@@ -1,0 +1,88 @@
+# spec.yaml - cloud-gov (a neutral acq mixin kit, hybrid/v1)
+#
+# Configures a sandbox for cloud.gov work:
+#   - install/verify the Cloud Foundry CLI (`cf`) at create time;
+#   - allow-list cloud.gov control-plane, app-route, and documentation domains;
+#   - document the acq secret binding needed for CF OAuth token injection without
+#     placing the token in environment variables or files readable by the agent.
+#
+# AUTH MODEL: the kit does NOT store or expose a Cloud Foundry token. Users set a
+# custom acq secret from `cf oauth-token` and bind it to api.fr.cloud.gov. acq's
+# active backend injects a placeholder in CF_OAUTH_TOKEN and swaps it on the
+# egress path for requests to the CF API host; the raw token stays in the
+# host-side secret store / backend proxy.
+schemaVersion: "hybrid/v1"
+kind: mixin
+name: cloud-gov
+displayName: cloud.gov Cloud Foundry CLI
+description: >
+  Installs the Cloud Foundry CLI and allow-lists cloud.gov control-plane,
+  application-route, and documentation domains so agents can inspect and operate
+  cloud.gov applications through proxied egress. Cloud Foundry authorization is
+  supplied through acq's custom secret mechanism, using a token captured from
+  `cf oauth-token`, so credentials are not stored in the kit or exposed in the
+  sandbox environment.
+
+caps:
+  network:
+    allow:
+      # cloud.gov apex and every cloud.gov subdomain, including API, login/UAA,
+      # dashboard, docs, and public application routes. Keep wildcard hosts
+      # quoted: leading-* YAML scalars can otherwise be parsed as aliases by
+      # downstream translators.
+      - cloud.gov:443
+      - "**.cloud.gov:443"
+      # Upstream Cloud Foundry documentation.
+      - docs.cloudfoundry.org:443
+      - cli.cloudfoundry.org:443
+      # Pinned CF CLI release tarballs used by cloud-gov-install-cf-cli.sh.
+      - github.com:443
+      - objects.githubusercontent.com:443
+
+files:
+  - path: /home/agent/cloud-gov-install-cf-cli.sh
+    mode: "0755"
+    source: files/home/cloud-gov-install-cf-cli.sh
+    description: Install or verify the Cloud Foundry CLI at sandbox create time
+  - path: /home/agent/cloud-gov-configure-cf-auth.sh
+    mode: "0755"
+    source: files/home/cloud-gov-configure-cf-auth.sh
+    description: Target cloud.gov and configure cf with the injected token placeholder
+
+commands:
+  - phase: install
+    user: "0"
+    description: Install the Cloud Foundry CLI if it is missing
+    command:
+      - sh
+      - /home/agent/cloud-gov-install-cf-cli.sh
+  - phase: startup
+    user: "1000"
+    description: Target cloud.gov and configure cf auth from the injected placeholder
+    command:
+      - sh
+      - /home/agent/cloud-gov-configure-cf-auth.sh
+
+agentContext: |
+  ## cloud.gov
+
+  This sandbox has the Cloud Foundry CLI (`cf`) available for cloud.gov work and
+  egress allow-listed for the cloud.gov API, login/UAA, log streaming, common app
+  route domains, and cloud.gov / Cloud Foundry documentation domains.
+
+  Authorization is handled through acq's secret injection path. The sandbox may
+  contain a backend placeholder in `CF_OAUTH_TOKEN` and `~/.cf/config.json`, but
+  not the real token. The user should set the secret from a host shell where they
+  are already logged in to cloud.gov:
+
+  ```
+  cf oauth-token | acq secret set -g cloud-gov --host api.fr.cloud.gov --env CF_OAUTH_TOKEN
+  ```
+
+  Do not ask the user to paste the token into chat or write it to the workspace.
+  Use normal `cf` commands; real token material remains outside agent-readable
+  files.
+
+# No backend shortcuts: sbx consumes the neutral files, create-time install, and
+# allow-list. msb support is not declared until acq translates per-kit `**.`
+# wildcard entries to msb suffix rules.

--- a/integrations/isolation/acq-kits/kits.yaml
+++ b/integrations/isolation/acq-kits/kits.yaml
@@ -27,6 +27,18 @@ kits:
       the PLAYBOOK_SHA integrity gate. No backend shortcut. The GitHub token
       (while the playbook repo is private) is injected per-backend by acq.
 
+  cloud-gov:
+    backends: [sbx]
+    parity: |
+      sbx consumes the neutral files, create-time install, and allow-list directly:
+      the kit installs or verifies the Cloud Foundry CLI and allows egress to the
+      cloud.gov apex/subdomain surface, Cloud Foundry docs, and pinned CF CLI
+      release hosts. Cloud Foundry authorization is supplied through acq's custom
+      secret binding for api.fr.cloud.gov, seeded from a host-side `cf oauth-token`;
+      the token is not stored in the kit or exposed as a readable credential file.
+      msb support is pending acq translation of per-kit `**.` wildcard entries to
+      msb suffix rules.
+
   zscaler-ca-certificate:
     backends: [sbx, msb]
     parity: |

--- a/integrations/isolation/acq-kits/kits.yaml
+++ b/integrations/isolation/acq-kits/kits.yaml
@@ -28,16 +28,15 @@ kits:
       (while the playbook repo is private) is injected per-backend by acq.
 
   cloud-gov:
-    backends: [sbx]
+    backends: [sbx, msb]
     parity: |
-      sbx consumes the neutral files, create-time install, and allow-list directly:
-      the kit installs or verifies the Cloud Foundry CLI and allows egress to the
-      cloud.gov apex/subdomain surface, Cloud Foundry docs, and pinned CF CLI
-      release hosts. Cloud Foundry authorization is supplied through acq's custom
-      secret binding for api.fr.cloud.gov, seeded from a host-side `cf oauth-token`;
-      the token is not stored in the kit or exposed as a readable credential file.
-      msb support is pending acq translation of per-kit `**.` wildcard entries to
-      msb suffix rules.
+      Both backends consume the neutral files, create-time install, startup auth
+      configuration, and cloud.gov/docs allow-list. sbx consumes `**.cloud.gov`
+      directly; msb support requires acq to translate per-kit `**.` wildcard
+      entries to msb suffix rules. Cloud Foundry authorization is supplied through
+      acq's custom secret binding for api.fr.cloud.gov, seeded from a host-side
+      `cf oauth-token`; the token is not stored in the kit or exposed as a
+      readable credential file.
 
   zscaler-ca-certificate:
     backends: [sbx, msb]


### PR DESCRIPTION
## Summary

Adds a new cloud.gov acq mixin kit for working with Cloud Foundry on cloud.gov.

The kit:
- installs Cloud Foundry CLI v8.19.0 from pinned upstream release tarballs with committed SHA-256 checks;
- allow-lists the cloud.gov apex and all cloud.gov subdomains, plus Cloud Foundry docs and pinned CF CLI release hosts;
- configures CF CLI auth using an acq-injected placeholder from a host-side `cf oauth-token`, without storing the real token in the kit or workspace;
- documents troubleshooting, verification, and the design decision.

## Context

This supports cloud.gov application work from isolated acq sandboxes while keeping Cloud Foundry authorization in acq's secret mechanism.

`msb` support is now unblocked by merged quickstart PR `GSA-TTS/agentic-coding-quickstart#451`, which translates per-kit `**.cloud.gov` into msb's suffix rule form. I verified the cloud-gov kit spec against quickstart `origin/main`: `**.cloud.gov:443` emits `allow@*.cloud.gov` for msb.

## Verification

- `PATH="$PWD/.venv/bin:$PATH" make validate` - passed
- `PATH="$PWD/.venv/bin:$PATH" make validate-kits` - passed
- `PATH="$PWD/.venv/bin:$PATH" integrations/isolation/acq-kits/cloud-gov/scripts/verify` - passed offline checks: 4 passed, 0 failed; live sandbox check skipped because `RUN_ACQ=1` was not set
- `python3 scripts/scan_unsafe_shell.py integrations/isolation/acq-kits/cloud-gov` - passed, 0 errors / 0 warnings
- `bash -n` on all new shell scripts - passed
- `npx --prefix .github/linters markdownlint-cli2 "**/*.md" "#node_modules" "#.github/linters/node_modules" "#templates" "#CHANGELOG.md"` - passed
- Direct msb adapter check using quickstart `origin/main` emitted `allow@*.cloud.gov` and not `allow@**.cloud.gov`
- Adversarial sub-agent review run three times; blocking findings addressed or scoped, final focused confirmation found no remaining blocking issue for the auth-header path

## Security Impact

- Adds egress to `cloud.gov`, `**.cloud.gov`, `docs.cloudfoundry.org`, `cli.cloudfoundry.org`, `github.com`, and `objects.githubusercontent.com` for this kit.
- `**.cloud.gov` is intentionally broad because the requested working surface is all cloud.gov subdomains; custom domains outside cloud.gov remain project-specific.
- CF CLI install is pinned by version and SHA-256 for Linux x86_64 and arm64 tarballs.
- The real Cloud Foundry token is not committed, logged, or written to the workspace. Runtime config writes only the backend placeholder and rejects JWT-looking values.

## Rollback

Revert this PR to remove the cloud-gov kit, registry entry, and Markdown Lint toolchain update.

## AI Assistance

This PR was generated with assistance from OpenCode, an AI coding agent. Human review is required before merge.
