### PR TITLE
fix(ci): bump js-yaml to 4.3.2 to clear a high-severity CPU-DoS advisory

### DIFF
--- a/.github/linters/package-lock.json
+++ b/.github/linters/package-lock.json
@@ -395,9 +395,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",

--- a/.github/linters/package.json
+++ b/.github/linters/package.json
@@ -10,7 +10,7 @@
     "markdownlint-cli2": "0.22.1"
   },
   "overrides": {
-    "js-yaml": "4.3.1",
+    "js-yaml": "4.3.2",
     "markdown-it": "14.2.0",
     "linkify-it": "5.0.2"
   }


### PR DESCRIPTION
## Summary

CI's `npm audit --audit-level=high` step in `.github/linters/` started failing on a newly-disclosed high-severity `js-yaml` advisory (GHSA-2883-xcg3-v3hh / CVE-2026-84375, published 2026-09-08), blocking every open PR regardless of content — same defect as the sibling `agentic-coding-quickstart` and `agentic-coding-playbook` repos, which share the identical `.github/linters/package.json` setup.

## Root cause

`js-yaml 4.0.0–4.3.1` doesn't count empty merge-source mappings toward `maxTotalMergeKeys`, so a crafted YAML document with repeated empty-mapping merges can consume disproportionate CPU without tripping the configured limit. `js-yaml` is a transitive dependency of `markdownlint-cli2` (via `markdown-it`'s YAML front-matter parsing), pinned here via an `overrides` entry — that pin was `4.3.1`, one patch short of the fix.

## Fix

Bumped the override to `4.3.2` (the patched version per the advisory), regenerated the lockfile via `npm install` (not hand-edited). Deliberately not `npm audit fix --force`, which would also force an unrelated breaking `markdownlint-cli2` upgrade (0.22.1 → 0.23.2).

## Verification

- `npm install` now reports **0 vulnerabilities** (was 2 high).
- Ran `markdownlint-cli2` against this repo's own docs at the same tool version (0.22.1, unchanged) — 0 errors, no behavioral change.

## Note

Companion fixes: GSA-TTS/agentic-coding-quickstart#454, GSA-TTS/agentic-coding-playbook#290.

Co-authored-by: OpenCode Agent <agent@gsa.gov>